### PR TITLE
fix: JS syntax error breaking dashboard interactivity

### DIFF
--- a/amux-server.py
+++ b/amux-server.py
@@ -13467,7 +13467,7 @@ async function _voiceStart() {
         }] },
         tools: [{ functionDeclarations: [{
           name: 'send_to_session',
-          description: 'Send a text message or command to the user\\'s active terminal session. Use this when the user asks you to run a command, type something, or send input to their session.',
+          description: 'Send a text message or command to the active terminal session. Use this when the user asks you to run a command, type something, or send input to their session.',
           parameters: { type: 'OBJECT', properties: {
             message: { type: 'STRING', description: 'The text/command to send to the session' }
           }, required: ['message'] }


### PR DESCRIPTION
## Summary
- Fixed a JS syntax error in the voice assistant tool description (`amux-server.py:13470`) where `\\'s` in a single-quoted JS string produced a literal backslash + quote, terminating the string early
- This caused `Unexpected identifier 's'` which prevented **all** JavaScript from loading, making the entire dashboard non-interactive (no tab switching, no buttons, nothing)

## Test plan
- [x] Verified fix with `python3 -c "import ast; ast.parse(...)"`
- [x] Automated Playwright tests confirm all tabs now switch correctly (Sessions, Board, Notifications, Scheduler, Files, Notes)
- [x] Settings panel, + menu, and session cards all functional
- [ ] Manual verification in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)