### PR TITLE
fix: Enter key inserts newline on touch devices instead of sending

### DIFF
--- a/amux-server.py
+++ b/amux-server.py
@@ -13724,7 +13724,7 @@ function slashAcKeydown(e) {
   const el = document.getElementById('slash-ac-list');
   if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); sendPeekCmd(); return; }
   if (!el.classList.contains('open')) {
-    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendPeekCmd(); return; }
+    if (e.key === 'Enter' && !e.shiftKey && !matchMedia('(pointer: coarse)').matches) { e.preventDefault(); sendPeekCmd(); return; }
     if (e.key === 'ArrowUp' && inp.selectionStart === 0) { e.preventDefault(); cmdHistoryUp(inp); return; }
     if (e.key === 'ArrowDown' && _cmdHistoryIdx !== -1) { e.preventDefault(); cmdHistoryDown(inp); return; }
     return;
@@ -13864,7 +13864,7 @@ function cardSlashAcKeydown(name, e) {
   const el = document.getElementById('card-ac-' + name);
   if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); sendFromInput(name); return; }
   if (!el || !el.classList.contains('open')) {
-    if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendFromInput(name); return; }
+    if (e.key === 'Enter' && !e.shiftKey && !matchMedia('(pointer: coarse)').matches) { e.preventDefault(); sendFromInput(name); return; }
     if (e.key === 'ArrowUp' && inp && inp.selectionStart === 0) { e.preventDefault(); cmdHistoryUp(inp); return; }
     if (e.key === 'ArrowDown' && _cmdHistoryIdx !== -1) { e.preventDefault(); if (inp) cmdHistoryDown(inp); return; }
     return;


### PR DESCRIPTION
## Summary

On touch devices (phones, tablets), pressing Enter in the peek and card input boxes now inserts a newline instead of sending. The Send button is used to send. On desktop, Enter still sends as before.

This matches the behavior of most chat apps (Slack, Discord, Telegram, WhatsApp) — Enter sends on desktop where Shift+Enter is easy, Enter inserts a newline on mobile where it isn't.

## Approach

Detection uses `matchMedia('(pointer: coarse)')` rather than a viewport width check. This is the same approach Telegram Web uses and is the recommended way to distinguish touch-primary devices from mouse/trackpad-primary ones. It correctly handles:

- Phones → coarse → Enter = newline
- Tablets → coarse → Enter = newline
- Desktop → fine → Enter sends
- Laptop with touchscreen → fine (primary pointer is trackpad) → Enter sends

The change is two lines — one for the peek input, one for the card input.

## Test plan

- [ ] On phone: Enter inserts newline, Send button sends
- [ ] On desktop: Enter sends, Shift+Enter inserts newline
- [ ] Cmd/Ctrl+Enter still sends on both