### PR TITLE
fix: strip decorative separator lines in peek view for mobile readability

### DIFF
--- a/amux-server.py
+++ b/amux-server.py
@@ -12490,7 +12490,8 @@ function stripAnsi(text) {
     .replace(/\x1b\][^\x07]*\x07/g, '')        // OSC sequences (BEL terminated)
     .replace(/\x1b\][^\x1b]*\x1b\\/g, '')      // OSC sequences (ST terminated)
     .replace(/\x1b[()][A-Z0-9]/g, '')          // Character set selection
-    .replace(/\x1b[\x20-\x2f]*[\x40-\x7e]/g, '');  // Other escape sequences
+    .replace(/\x1b[\x20-\x2f]*[\x40-\x7e]/g, '')   // Other escape sequences
+    .replace(/^─{10,}\n?/gm, '');   // Remove decorative separator lines (mobile readability)
 }
 
 function linkifyOutput(text) {


### PR DESCRIPTION
## Summary

Claude Code renders full-width `───────` separator lines around its input prompt. In the peek view, these wrap badly on narrow screens (mobile) and serve no purpose — users type in amux's input box, not the Claude Code prompt.

This strips lines of 10+ box-drawing characters (U+2500 `─`) and their trailing newline in `stripAnsi()` so they don't render at all in peek.

## Before / After

<!-- TODO: paste screenshots -->

**Before** — separator lines wrap across multiple lines on mobile:

<img src=https://github.com/user-attachments/assets/8a89869c-3008-4e8b-b737-ccc6a17cf770 width=200 alt="before">

**After** — separator lines removed, clean output:

<img src=https://github.com/user-attachments/assets/12a957cd-4e2e-4abe-8296-7fc8de950b4a width=200 alt="after">

## Approach

One regex added to `stripAnsi()`:
```js
.replace(/^─{10,}\n?/gm, '')
```

Only matches lines that are entirely `─` (U+2500, the specific box-drawing character Claude Code uses). Regular dashes, equals signs, markdown separators, etc. are unaffected.

## Test plan

- [ ] Peek a Claude Code session on mobile — no separator lines visible
- [ ] Peek on desktop — same (separators removed everywhere, not just mobile)
- [ ] Other output with dashes/hyphens renders normally