### PR TITLE
fix(board): atomic claim TOCTOU race

### DIFF
--- a/amux-server.py
+++ b/amux-server.py
@@ -27533,15 +27533,16 @@ class CCHandler(BaseHTTPRequestHandler):
                 if dict(row)["status"] not in ("todo", "backlog"):
                     return self._json({"error": f"item not available (status: {dict(row)['status']})"}, 409)
                 now = int(time.time())
-                # Atomic claim: only succeeds if still todo/backlog
-                db.execute(
+                # Atomic claim: only succeeds if still todo/backlog AND agent-owned
+                # The owner_type check in the WHERE prevents TOCTOU races where
+                # owner_type changes between the SELECT above and this UPDATE.
+                cur = db.execute(
                     "UPDATE issues SET status='doing', session=?, updated=?"
-                    " WHERE id=? AND status IN ('todo','backlog') AND deleted IS NULL",
+                    " WHERE id=? AND status IN ('todo','backlog') AND owner_type='agent' AND deleted IS NULL",
                     (session_name, now, bid),
                 )
                 db.commit()
-                updated = db.execute("SELECT session FROM issues WHERE id=?", (bid,)).fetchone()
-                if not updated or dict(updated)["session"] != session_name:
+                if cur.rowcount == 0:
                     return self._json({"error": "claim failed — taken by another session"}, 409)
                 _sse_cache["board"]["time"] = 0
                 return self._json(_item_by_id(bid))


### PR DESCRIPTION
## Summary

The `/api/board/<id>/claim` endpoint had a TOCTOU race: it `SELECT`ed the task to check eligibility, then `UPDATE`d to claim it, then re-`SELECT`ed to verify the claim stuck. Between the first `SELECT` and the `UPDATE`, another session could have claimed the task (or its `owner_type` could have flipped from `agent` to `human`).

This collapses the verification into the `UPDATE` itself:

- Adds `owner_type='agent'` to the `WHERE` clause so human-owned tasks can't be claimed via this agent-coordination endpoint
- Uses `cur.rowcount` instead of a separate re-`SELECT` to confirm the `UPDATE` hit — single statement, no race window

If `rowcount` is 0, the task was either taken by another session or is ineligible — returns 409 as before.

## Why this matters

I've been using the claim endpoint from multiple concurrent amux sessions for agent coordination, and hit the race a few times under load. The fix is small and localized to the existing claim handler.

## Test plan

- [x] Existing claim flow still returns the claimed item on success
- [x] Double-claim attempt from two sessions: one succeeds with 200, the other gets 409
- [x] Claiming a task with `owner_type='human'` now returns 409 (new behavior)
- [x] Python syntax check: `python3 -c "import ast; ast.parse(open('amux-server.py').read())"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)