### PR TITLE
feat(board): /api/board/tag-completion endpoint

### DIFF
--- a/amux-server.py
+++ b/amux-server.py
@@ -27514,6 +27514,21 @@ class CCHandler(BaseHTTPRequestHandler):
                         db.commit()
                     return self._json({"ok": True})
 
+            # GET /api/board/tag-completion?tag=X — check if all tasks with a tag are done
+            if method == "GET" and path == "/api/board/tag-completion":
+                tag = qs.get("tag", [""])[0]
+                if not tag:
+                    return self._json({"error": "missing tag parameter"}, 400)
+                rows = db.execute(
+                    "SELECT i.status FROM issues i "
+                    "JOIN issue_tags t ON t.issue_id = i.id "
+                    "WHERE t.tag = ? AND i.deleted IS NULL",
+                    (tag,),
+                ).fetchall()
+                total = len(rows)
+                done = sum(1 for r in rows if r["status"] in ("done", "discarded"))
+                return self._json({"tag": tag, "total": total, "done": done, "complete": total > 0 and done == total})
+
             # POST /api/board/<id>/claim — atomic task claim for multi-agent coordination
             claim_m = re.match(r"^/api/board/([A-Za-z0-9_-]+)/claim$", path)
             if claim_m and method == "POST":


### PR DESCRIPTION
## Summary

Adds a read-only API endpoint that reports how many tasks sharing a tag are done:

\`\`\`
GET /api/board/tag-completion?tag=<tag>
→ {"tag": "<tag>", "total": N, "done": M, "complete": bool}
\`\`\`

\`complete\` is \`true\` when \`total > 0\` and \`done == total\` (where "done" means status is either \`done\` or \`discarded\`). Counts only non-deleted issues.

## Why

I use the board to track agent work that's grouped by tag (e.g. a GitHub issue becomes N subtasks all sharing a \`gh:owner/repo#N\` tag). When an agent finishes a subtask, I want to know cheaply whether *all* siblings are done so I can close the upstream issue. This is one indexed query instead of fetching the whole board and filtering client-side.

Nothing in the endpoint is tied to my specific tag scheme — it works on any tag.

## Test plan

- [x] Missing \`tag\` parameter returns 400
- [x] Unknown tag returns \`{total: 0, done: 0, complete: false}\`
- [x] Tag with mixed statuses returns correct counts
- [x] Tag where all tasks are \`done\` returns \`complete: true\`
- [x] Soft-deleted tasks are excluded from both \`total\` and \`done\`
- [x] Python syntax check passes

## Notes

- Endpoint is \`GET\`, idempotent, safe to cache
- No schema changes
- No impact on existing endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)