### PR TITLE
fix(spawn): shell-safe flag quoting + default-model settings (replaces #18)

### DIFF
--- a/amux
+++ b/amux
@@ -118,6 +118,81 @@ is_running() {
   tmux has-session -t "$(tmux_name "$1")" 2>/dev/null
 }
 
+# ─── Shell-safe flag quoting ─────────────────────────────────────────────────
+#
+# Common runner: spawn python3, isolate stderr to a temp file, check exit
+# code, surface diagnostic on failure. Used by both quote_flags (one-string
+# form) and quote_argv (multi-arg form) so the stderr-isolation pattern
+# lives in one place. SECURITY: never echoes the input arguments back on
+# failure — they may contain secrets — only the input length and python's
+# stderr.
+_run_py_safe() {
+  local script="$1"
+  shift
+  local result err err_file
+  local rc=0
+  err_file=$(mktemp) || {
+    echo "amux: error: mktemp failed (cannot create temp file for python3 stderr)" >&2
+    return 1
+  }
+  # `|| rc=$?` is critical: under set -e (which the source-guard makes
+  # possible if a sourcing script enables it), a naked `result=$(...); rc=$?`
+  # would abort the function on python3 failure BEFORE rc is captured,
+  # bypassing the error handler.
+  result=$(python3 -c "$script" "$@" 2>"$err_file") || rc=$?
+  if (( rc != 0 )); then
+    err=$(<"$err_file")
+    rm -f "$err_file"
+    local n_args=$#
+    echo "amux: error: python3 helper failed (exit $rc, $n_args input args): $err" >&2
+    return 1
+  fi
+  rm -f "$err_file"
+  printf '%s' "$result"
+}
+
+# Tokenize a stored flag string and re-quote each token shell-safely.
+# Mirror of _shell_quote_flags() in amux-server.py — see that function for
+# full rationale. Required because zsh glob-expands unquoted '[1m]' in
+# model IDs like 'claude-opus-4-6[1m]', failing with 'no matches found'
+# before claude is even invoked.
+#
+# Implementation note: this delegates to python3's shlex rather than using
+# native bash word-splitting. Bash's IFS-based splitting (arr=( $s ),
+# read -ra) ignores embedded quotes in multi-word flag values AND triggers
+# pathname expansion (globbing) on the input. xargs has subtle escape-rule
+# differences from shlex on macOS vs GNU. Using python3 guarantees 100%
+# parity with the server's _shell_quote_flags so the same test fixtures
+# verify both code paths.
+#
+# PERFORMANCE: each invocation spawns a python interpreter (~30-50ms).
+# Acceptable for a once-per-session-spawn helper. Do NOT call this inside
+# loops or hot paths.
+quote_flags() {
+  local s="$1"
+  [[ -z "$s" ]] && return 0
+  _run_py_safe '
+import sys, shlex
+s = sys.argv[1]
+try:
+    print(" ".join(shlex.quote(t) for t in shlex.split(s)))
+except ValueError:
+    print(shlex.quote(s))
+' "$s"
+}
+
+# Quote a list of already-tokenized argv elements (each $1, $2, ... is one
+# argument). Used in cmd_start for inline arguments passed via
+# `amux start NAME -- ...`. printf '%q' uses bash-only $'...' syntax that
+# breaks under dash; shlex.quote uses universal POSIX single-quoting.
+quote_argv() {
+  (( $# == 0 )) && return 0
+  _run_py_safe '
+import sys, shlex
+print(" ".join(shlex.quote(a) for a in sys.argv[1:]))
+' "$@"
+}
+
 # Parse Claude Code flags from args, split into CC_FLAGS array and remaining args
 # Sets: CC_FLAGS_STR (for storage), CC_DIR, CC_EXTRA_ARGS
 parse_claude_flags() {
@@ -231,19 +306,32 @@ cmd_start() {
   esac
   [[ -d "$dir" ]] || die "directory not found: $dir"
 
-  # Build claude command
+  # Build claude command. Each component is shell-quoted before
+  # concatenation so the nested shell tmux invokes (the user's default
+  # shell) sees one literal token per argument — preventing zsh nomatch
+  # on '[1m]' globbing AND nested-shell command injection via $* token
+  # boundary loss. See quote_flags / quote_argv comments for details.
   local cmd="claude"
-  # Apply global defaults
+  # Apply global defaults from defaults.env
   if [[ -n "${CC_DEFAULT_FLAGS:-}" ]]; then
-    cmd="$cmd $CC_DEFAULT_FLAGS"
+    local q
+    q=$(quote_flags "$CC_DEFAULT_FLAGS") || die "failed to quote CC_DEFAULT_FLAGS"
+    [[ -n "$q" ]] && cmd="$cmd $q"
   fi
-  # Apply session flags
+  # Apply session flags from <name>.env
   if [[ -n "${CC_FLAGS:-}" ]]; then
-    cmd="$cmd $CC_FLAGS"
+    local q
+    q=$(quote_flags "$CC_FLAGS") || die "failed to quote CC_FLAGS"
+    [[ -n "$q" ]] && cmd="$cmd $q"
   fi
-  # Apply any extra inline args
+  # Apply any extra inline args from `amux start NAME -- ...`. These are
+  # already tokenized argv (the user's outer shell parsed them), so we
+  # quote each token via quote_argv. Without this, the v1 plan's $*
+  # would lose quoting boundaries when re-evaluated by the nested shell.
   if [[ $# -gt 0 ]]; then
-    cmd="$cmd $*"
+    local q
+    q=$(quote_argv "$@") || die "failed to quote inline arguments"
+    [[ -n "$q" ]] && cmd="$cmd $q"
   fi
 
   # Create tmux session and attach
@@ -683,34 +771,41 @@ EOF
 }
 
 # ── Main dispatch ────────────────────────────────────────────────────────────
+#
+# Source guard: when this script is run normally as `amux ...`, BASH_SOURCE[0]
+# equals $0 and the dispatch block runs. When sourced (e.g. from tests via
+# `source amux`), $0 is the parent shell's $0 and the guard skips dispatch.
+# This lets the test suite source the script to access helper functions
+# without triggering CLI side effects.
+if [[ "${BASH_SOURCE[0]:-$0}" == "${0}" ]]; then
+  ensure_dirs
 
-ensure_dirs
-
-case "${1:-}" in
-  register|reg)     shift; cmd_register "$@" ;;
-  start)            shift; cmd_start "$@" ;;
-  exec|run)         shift; cmd_exec "$@" ;;
-  attach|a)         shift; cmd_attach "$@" ;;
-  peek|p)           shift; cmd_peek "$@" ;;
-  send)             shift; cmd_send "$@" ;;
-  stop|kill)        shift; cmd_stop "$@" ;;
-  rm|remove|del)    shift; cmd_rm "$@" ;;
-  ls|list)          shift; cmd_ls "$@" ;;
-  info)             shift; cmd_info "$@" ;;
-  defaults|config)  shift; cmd_defaults "$@" ;;
-  start-all)        cmd_start_all ;;
-  stop-all)         cmd_stop_all ;;
-  serve|web)        shift; cmd_serve "$@" ;;
-  board|b)           shift; cmd_board "$@" ;;
-  help|--help|-h)   cmd_help ;;
-  version|--version|-v) echo "amux v${CC_VERSION}" ;;
-  "")               cmd_dashboard ;;
-  *)
-    # Try as session name shortcut
-    name=$(resolve_session "$1" 2>/dev/null) && cmd_attach "$name" || {
-      echo "${RED}unknown command:${RESET} $1"
-      echo "Run ${BOLD}amux help${RESET} for usage"
-      exit 1
-    }
-    ;;
-esac
+  case "${1:-}" in
+    register|reg)     shift; cmd_register "$@" ;;
+    start)            shift; cmd_start "$@" ;;
+    exec|run)         shift; cmd_exec "$@" ;;
+    attach|a)         shift; cmd_attach "$@" ;;
+    peek|p)           shift; cmd_peek "$@" ;;
+    send)             shift; cmd_send "$@" ;;
+    stop|kill)        shift; cmd_stop "$@" ;;
+    rm|remove|del)    shift; cmd_rm "$@" ;;
+    ls|list)          shift; cmd_ls "$@" ;;
+    info)             shift; cmd_info "$@" ;;
+    defaults|config)  shift; cmd_defaults "$@" ;;
+    start-all)        cmd_start_all ;;
+    stop-all)         cmd_stop_all ;;
+    serve|web)        shift; cmd_serve "$@" ;;
+    board|b)          shift; cmd_board "$@" ;;
+    help|--help|-h)   cmd_help ;;
+    version|--version|-v) echo "amux v${CC_VERSION}" ;;
+    "")               cmd_dashboard ;;
+    *)
+      # Try as session name shortcut
+      name=$(resolve_session "$1" 2>/dev/null) && cmd_attach "$name" || {
+        echo "${RED}unknown command:${RESET} $1"
+        echo "Run ${BOLD}amux help${RESET} for usage"
+        exit 1
+      }
+      ;;
+  esac
+fi

--- a/amux-server.py
+++ b/amux-server.py
@@ -856,12 +856,58 @@ def parse_env_file(path: Path) -> dict:
     return data
 
 
+def _atomic_write_secure(path: Path, content: str) -> None:
+    """Atomically and durably write content to path with mode 0o600.
+
+    Uses NamedTemporaryFile (which calls mkstemp under the hood, defaulting
+    to mode 0o600) plus flush + fsync + os.replace for a crash-safe atomic
+    write. The result file at `path` never exists with permissions other
+    than 0o600 — even briefly. After this function returns successfully,
+    the data is durably persisted to disk: a system crash cannot leave
+    `path` empty or partially-written.
+
+    Use this for any .env file that may contain secrets or per-user config.
+    """
+    import tempfile
+    dir_path = str(path.parent)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=dir_path,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as tmp:
+        tmp.write(content)
+        # Flush Python's userspace buffer to the OS kernel buffer, then
+        # flush the kernel buffer to disk. Without this, a system crash
+        # after os.replace() could leave the file at `path` with empty
+        # or stale contents — the rename succeeded but the data wasn't
+        # yet persisted. fsync is the canonical durability barrier.
+        tmp.flush()
+        os.fsync(tmp.fileno())
+        tmp_path = tmp.name
+    try:
+        os.replace(tmp_path, str(path))
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except FileNotFoundError:
+            pass
+        raise
+
+
 def _write_env(path: Path, cfg: dict):
-    """Write a cfg dict back to a amux .env file."""
+    """Write a cfg dict back to a amux .env file with secure permissions.
+
+    Uses _atomic_write_secure to ensure the file is created with mode 0o600,
+    preventing world-readable .env files that may contain secrets like
+    ANTHROPIC_API_KEY or per-session credentials.
+    """
     lines = [f'# updated: {__import__("datetime").datetime.now().isoformat()}']
     for k, v in cfg.items():
         lines.append(f'{k}="{v}"')
-    path.write_text("\n".join(lines) + "\n")
+    _atomic_write_secure(path, "\n".join(lines) + "\n")
 
 
 # ═══════════════════════════════════════════
@@ -4653,6 +4699,177 @@ def _ensure_memory(name: str, work_dir: str):
     _write_claude_memory(name, work_dir)
 
 
+# Permissive model-name validator. The negative lookahead (?!-) explicitly
+# rejects values starting with '-' which would be re-parsed as a flag by
+# claude's argv parser even after shell-quoting (application-level argument
+# injection — e.g. '-p', '--api-key', '--dangerously-skip-permissions').
+# All other leading characters are allowed including '.', '/', '[' so local
+# model paths like './model' or '/opt/local-model' work for users who use
+# amux to drive non-Anthropic LLM CLIs. The body character class permits
+# the '[1m]' suffix (1M context variants), slash/at-sign forms used by
+# Bedrock/Vertex/OpenRouter (e.g. anthropic/claude-3-opus, claude-3@latest),
+# and '+' for HuggingFace-style variants. Rejects shell metacharacters
+# (; | $ ` > < & ( ) { } \ space \n).
+#
+# Defense in depth — the spawn-side _shell_quote_flags is the load-bearing
+# fix; this just stops obviously malformed or injection-attempting data from
+# being persisted in the first place.
+_MODEL_ID_RE = re.compile(r'^(?!-)[A-Za-z0-9._:\[\]@/+-]+$')
+_MODEL_ID_MAX_LEN = 255  # bound to prevent DoS via huge JSON payloads
+
+
+def _strip_model_from_flags(flags: str) -> str:
+    """Remove any --model X or --model=X tokens from a flag string.
+
+    Uses shlex tokenization to correctly handle both space-separated
+    (`--model X`) and equals-separated (`--model=X`) forms, plus quoted
+    multi-word values that a naive regex would miss or corrupt.
+
+    Returns the remaining flags as a shell-safe string (each token
+    re-quoted via shlex.quote) so the result can be safely stored
+    back in a .env file.
+
+    Raises ValueError if `flags` cannot be tokenized (e.g. unbalanced
+    quotes in a hand-edited config file). Callers MUST catch this and
+    surface a clear error to the user — silently returning the empty
+    string here would wipe out all the user's other flags during a
+    routine model update, which is a data-loss bug.
+
+    Used by both PATCH endpoints (/api/settings/default-model and
+    /api/sessions/{name}) so the substitution semantics are identical.
+    """
+    if not flags:
+        return ""
+    tokens = shlex.split(flags)  # raises ValueError on malformed input
+    filtered = []
+    i = 0
+    while i < len(tokens):
+        t = tokens[i]
+        if t == "--model" and i + 1 < len(tokens):
+            i += 2  # skip --model and its value
+            continue
+        if t.startswith("--model="):
+            i += 1  # skip the --model=X form
+            continue
+        filtered.append(t)
+        i += 1
+    return " ".join(shlex.quote(t) for t in filtered)
+
+
+def _extract_model_from_flags(flags: str) -> str:
+    """Return the --model value from a flag string, or empty string if none.
+
+    Mirror of _strip_model_from_flags but for extraction. Handles both
+    `--model X` and `--model=X` forms via shlex tokenization. On malformed
+    input (unbalanced quotes etc.) returns empty string — this is a
+    read-only display helper, so silent fallback is appropriate.
+    """
+    if not flags:
+        return ""
+    try:
+        tokens = shlex.split(flags)
+    except ValueError:
+        return ""
+    i = 0
+    while i < len(tokens):
+        t = tokens[i]
+        if t == "--model" and i + 1 < len(tokens):
+            return tokens[i + 1]
+        if t.startswith("--model="):
+            return t[len("--model="):]
+        i += 1
+    return ""
+
+
+def _validate_model_name(value) -> tuple[bool, str, str]:
+    """Validate a model name field from a PATCH body.
+
+    Returns (ok, normalized_value, error_message). Used by both PATCH
+    endpoints (/api/settings/default-model and /api/sessions/{name})
+    so the type/length/regex checks are defined in exactly one place.
+
+    Empty string is permitted at this level — callers decide whether
+    empty means "clear the override" or "missing required field" based
+    on endpoint semantics.
+    """
+    if not isinstance(value, str):
+        return False, "", "model must be a string"
+    normalized = value.strip()
+    if len(normalized) > _MODEL_ID_MAX_LEN:
+        return False, "", f"model name too long (max {_MODEL_ID_MAX_LEN} chars)"
+    if normalized and not _MODEL_ID_RE.match(normalized):
+        return False, "", "invalid model name (allowed: alphanumeric and ._:[]@/+-, no leading hyphen)"
+    return True, normalized, ""
+
+
+def _shell_quote_flags(s: str) -> str:
+    """Tokenize a stored flag string and re-quote each token shell-safely.
+
+    Flag strings come from .env files written by various paths (settings UI,
+    REST API, bash CLI, hand edits) and are concatenated into a shell command
+    in start_session(). Stored values may contain shell metacharacters — most
+    notably '[1m]' in the 1M-context model IDs 'claude-opus-4-6[1m]' and
+    'claude-sonnet-4-6[1m]', which zsh treats as a glob character class and
+    fails with 'no matches found' under nomatch. Round-tripping through shlex
+    enforces the invariant: every flag token reaches /bin/sh as a single
+    literal argument, never interpreted by the shell.
+
+    On malformed input (e.g. unbalanced quote in a hand-edited env file),
+    shlex.split raises ValueError. The fallback wraps the entire raw string
+    as a single shlex.quote()'d literal — the shell still receives one safe
+    token, claude itself rejects the bogus flag with a clear error message,
+    and the spawn doesn't brick. The security invariant (shell never
+    interprets stored data) is preserved on every code path.
+
+    NOTE on shlex.split's `#`-handling: by default shlex.split treats an
+    unquoted `#` as the start of a comment and strips the rest of the
+    token (e.g. `--model opus # my note` becomes `['--model', 'opus']`).
+    This is standard shlex behavior. amux config files don't typically
+    use inline comments, so this is unlikely to surprise users.
+
+    BEHAVIOR CHANGE from pre-fix amux: stored flag values are now treated
+    as literal data, NOT as shell expressions. If a user previously stored
+    `CC_FLAGS="--api-key $MY_API_KEY"` expecting the shell to expand
+    $MY_API_KEY at spawn time, that pattern no longer works — the value
+    will be passed to claude as the literal string `$MY_API_KEY`. This is
+    intentional: stored shell fragments are exactly the kind of injection
+    vector this fix exists to neutralize. Users wanting dynamic secrets
+    should set them in their shell profile (e.g. `~/.zprofile`) so they
+    appear as environment variables in the spawned tmux session, not
+    embedded in stored flag strings.
+
+    SECURITY NOTE: this helper makes the shell-command string injection-safe,
+    but flag VALUES still appear in `ps aux` output because tmux runs them as
+    argv. Do not store secrets (API keys, tokens) in CC_FLAGS or
+    CC_DEFAULT_FLAGS. A future refactor to pass sensitive flags via
+    environment variables would close this gap.
+    """
+    if not s:
+        return ""
+    try:
+        return " ".join(shlex.quote(t) for t in shlex.split(s))
+    except ValueError:
+        # Malformed input — quote the whole raw string so it reaches the
+        # shell as one literal argument. claude will reject it with a
+        # clearer error than aborting spawn would give us.
+        return shlex.quote(s)
+
+
+def _get_default_model() -> str:
+    """Return the default model from defaults.env, or 'sonnet' as fallback.
+
+    Uses _extract_model_from_flags so both --model X and --model=X forms
+    are correctly recognized, and quoted multi-word values aren't truncated.
+    """
+    defaults_file = CC_HOME / "defaults.env"
+    if defaults_file.exists():
+        dcfg = parse_env_file(defaults_file)
+        model = _extract_model_from_flags(dcfg.get("CC_DEFAULT_FLAGS", ""))
+        if model:
+            return model
+    return "sonnet"
+
+
 def start_session(name: str, extra_flags: str = "", _skip_conv_id: bool = False) -> tuple[bool, str]:
     """Start a session headless (no attach). Returns (success, message)."""
     f = CC_SESSIONS / f"{name}.env"
@@ -4706,13 +4923,13 @@ def start_session(name: str, extra_flags: str = "", _skip_conv_id: bool = False)
 
     cmd = "claude"
     if default_flags:
-        cmd += f" {default_flags}"
+        cmd += f" {_shell_quote_flags(default_flags)}"
     if flags:
-        cmd += f" {flags}"
+        cmd += f" {_shell_quote_flags(flags)}"
     if session_flag:
-        cmd += f" {session_flag}"
+        cmd += f" {_shell_quote_flags(session_flag)}"
     if extra_flags:
-        cmd += f" {extra_flags}"
+        cmd += f" {_shell_quote_flags(extra_flags)}"
     # Inject --mcp-config based on CC_MCP setting (chrome or empty)
     mcp_val = cfg.get("CC_MCP", "").strip().lower()
     mcp_dir = CC_HOME  # ~/.amux
@@ -9029,6 +9246,22 @@ DASHBOARD_HTML = r"""<!DOCTYPE html>
         </div>
         <div class="settings-sep"></div>
         <div class="settings-section">
+          <div class="settings-section-label">Default Model</div>
+          <div style="font-size:0.72rem;color:var(--dim);margin-bottom:6px;">Applied to new sessions without an explicit model</div>
+          <select id="settings-default-model" onchange="saveDefaultModel(this.value)"
+            style="width:100%;font-size:0.85rem;padding:5px 8px;border-radius:6px;border:1px solid var(--border);background:var(--card);color:var(--fg);">
+            <option value="sonnet">sonnet</option>
+            <option value="opus">opus</option>
+            <option value="haiku">haiku</option>
+            <option value="claude-opus-4-6">claude-opus-4-6</option>
+            <option value="claude-opus-4-6[1m]">claude-opus-4-6 [1M]</option>
+            <option value="claude-sonnet-4-6">claude-sonnet-4-6</option>
+            <option value="claude-sonnet-4-6[1m]">claude-sonnet-4-6 [1M]</option>
+            <option value="claude-haiku-4-5-20251001">claude-haiku-4-5-20251001</option>
+          </select>
+        </div>
+        <div class="settings-sep"></div>
+        <div class="settings-section">
           <div class="settings-section-label">Appearance</div>
           <div class="settings-row" style="justify-content:space-between;align-items:center;">
             <span style="font-size:0.85rem;" id="theme-label">Dark mode</span>
@@ -10302,12 +10535,14 @@ DASHBOARD_HTML = r"""<!DOCTYPE html>
       <div id="edit-ac-list" class="ac-list"></div>
     </div>
     <select id="edit-select" style="display:none;" onchange="submitEdit()">
-      <option value="">Default (sonnet)</option>
+      <option value="" id="model-default-opt">Default</option>
       <option value="opus">opus</option>
       <option value="sonnet">sonnet</option>
       <option value="haiku">haiku</option>
       <option value="claude-opus-4-6">claude-opus-4-6</option>
+      <option value="claude-opus-4-6[1m]">claude-opus-4-6 [1M]</option>
       <option value="claude-sonnet-4-6">claude-sonnet-4-6</option>
+      <option value="claude-sonnet-4-6[1m]">claude-sonnet-4-6 [1M]</option>
       <option value="claude-haiku-4-5-20251001">claude-haiku-4-5-20251001</option>
     </select>
     <div class="edit-actions">
@@ -12396,6 +12631,12 @@ function closeAddMenu() {
   if (!addMenuOpen) return;
   document.getElementById('add-menu').classList.remove('open');
   addMenuOpen = false;
+}
+
+// ── Set default model label from server config ──
+if (window._AMUX_DEFAULT_MODEL) {
+  const defOpt = document.getElementById('model-default-opt');
+  if (defOpt) defOpt.textContent = 'Default (' + window._AMUX_DEFAULT_MODEL + ')';
 }
 
 // ── Edit modal ──
@@ -21902,6 +22143,7 @@ function toggleSettings() {
   const open = menu.classList.toggle('open');
   if (open) {
     _renderInstanceSwitcher();
+    loadDefaultModel();
     // Apply cloud identity (email) or device name
     _applyIdentityToSettings();
     if (!_cloudEmail) {
@@ -22018,6 +22260,34 @@ document.addEventListener('click', function(e) {
   const wrap = document.querySelector('.settings-wrap');
   if (wrap && !wrap.contains(e.target)) closeSettings();
 });
+
+// ── Default Model ────────────────────────────────────────────────────────────
+function loadDefaultModel() {
+  const sel = document.getElementById('settings-default-model');
+  if (sel && window._AMUX_DEFAULT_MODEL) {
+    if (!Array.from(sel.options).some(o => o.value === window._AMUX_DEFAULT_MODEL)) {
+      const opt = document.createElement('option');
+      opt.value = window._AMUX_DEFAULT_MODEL;
+      opt.textContent = window._AMUX_DEFAULT_MODEL;
+      sel.appendChild(opt);
+    }
+    sel.value = window._AMUX_DEFAULT_MODEL;
+  }
+}
+async function saveDefaultModel(val) {
+  try {
+    const r = await fetch('/api/settings/default-model', {
+      method: 'PATCH', headers: {'Content-Type':'application/json'},
+      body: JSON.stringify({model: val})
+    });
+    if (r.ok) {
+      window._AMUX_DEFAULT_MODEL = val;
+      const defOpt = document.getElementById('model-default-opt');
+      if (defOpt) defOpt.textContent = 'Default (' + val + ')';
+      showToast('Default model: ' + val);
+    }
+  } catch(e) { showToast('Error: ' + e.message); }
+}
 
 // ── API Keys ───────────────────────────────────────────────────────────────────
 async function loadApiKeys() {
@@ -27339,7 +27609,8 @@ class CCHandler(BaseHTTPRequestHandler):
                 f'<script>window._AMUX_S3_ICAL_URL={_json.dumps(_S3_CAL_URL)};'
                 f'window._AMUX_AUTH_TOKEN={_json.dumps(AUTH_TOKEN)};'
                 f'window._AMUX_HOME={_json.dumps(str(Path.home()))};'
-                f'window._GOOGLE_API_KEY={_json.dumps(os.environ.get("GOOGLE_API_KEY",""))};</script></head>',
+                f'window._GOOGLE_API_KEY={_json.dumps(os.environ.get("GOOGLE_API_KEY",""))};'
+                f'window._AMUX_DEFAULT_MODEL={_json.dumps(_get_default_model())};</script></head>',
                 1,
             )
             return self._html(page)
@@ -30304,6 +30575,73 @@ end tell
             db.commit()
             return self._json({"ok": True})
 
+        # ── Default model (reads/writes defaults.env) ──────────────────────────
+        if path == "/api/settings/default-model":
+            defaults_file = CC_HOME / "defaults.env"
+            if method == "GET":
+                return self._json({"model": _get_default_model()})
+            if method == "PATCH":
+                body = self._read_body()
+                if not isinstance(body, dict):
+                    return self._json({"error": "payload must be a JSON object"}, 400)
+                # Empty model = clear the --model override; other flags in
+                # CC_DEFAULT_FLAGS (like --max-tokens, --effort) are preserved.
+                # On a non-empty model, the existing --model X is REPLACED but
+                # all other flags are preserved — without this, picking a new
+                # default model in the UI would silently delete the user's
+                # custom flag config.
+                ok, model, err = _validate_model_name(body.get("model", ""))
+                if not ok:
+                    return self._json({"error": err}, 400)
+                # Read existing defaults.env once. The lines list serves both
+                # for extracting the current CC_DEFAULT_FLAGS value AND for
+                # the line-by-line substitution below. Reading the file twice
+                # would create a TOCTOU window where another writer could
+                # modify the file between reads.
+                lines = []
+                if defaults_file.exists():
+                    lines = defaults_file.read_text(encoding="utf-8").splitlines()
+                existing_flags = ""
+                for line in lines:
+                    if line.startswith("CC_DEFAULT_FLAGS="):
+                        value = line[len("CC_DEFAULT_FLAGS="):]
+                        # Strip outer matching quotes (mirrors parse_env_file).
+                        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+                            value = value[1:-1]
+                        existing_flags = value
+                        break
+                try:
+                    flags_no_model = _strip_model_from_flags(existing_flags)
+                except ValueError as e:
+                    return self._json({
+                        "error": f"existing CC_DEFAULT_FLAGS in defaults.env is malformed ({e}); fix the file manually before updating the model via API"
+                    }, 400)
+                # Build the new flag value: prepend --model if non-empty, else
+                # leave the (possibly empty) other flags as-is.
+                if model:
+                    new_flag_value = (
+                        f"--model {model} {flags_no_model}".strip()
+                        if flags_no_model
+                        else f"--model {model}"
+                    )
+                else:
+                    new_flag_value = flags_no_model
+                new_line = f'CC_DEFAULT_FLAGS="{new_flag_value}"'
+                # Substitute in the lines we already loaded above (single read).
+                found = False
+                for i, line in enumerate(lines):
+                    if line.startswith("CC_DEFAULT_FLAGS="):
+                        lines[i] = new_line
+                        found = True
+                        break
+                if not found:
+                    lines.append(new_line)
+                content = "\n".join(lines) + "\n"
+                # Atomic write with mode 0o600 (no TOCTOU window). Same
+                # secure-write pattern as the shared _write_env helper.
+                _atomic_write_secure(defaults_file, content)
+                return self._json({"ok": True, "model": model})
+
         # ── Settings env (ANTHROPIC_API_KEY etc.) ─────────────────────────────
         if path == "/api/settings/env":
             _allowed_env_keys = {"ANTHROPIC_API_KEY", "OPENAI_API_KEY"}
@@ -31672,6 +32010,8 @@ p{{color:#888;margin:12px 0 28px;font-size:0.9rem;line-height:1.5}}
         if method == "PATCH":
             if action == "config":
                 body = self._read_body()
+                if not isinstance(body, dict):
+                    return self._json({"error": "payload must be a JSON object"}, 400)
                 cfg = parse_env_file(env_file)
 
                 # Rename
@@ -31731,12 +32071,28 @@ p{{color:#888;margin:12px 0 28px;font-size:0.9rem;line-height:1.5}}
 
                 # Change model
                 if "model" in body:
-                    model_val = body["model"].strip()
-                    flags = cfg.get("CC_FLAGS", "")
-                    # Remove existing --model flag
-                    flags = re.sub(r'--model\s+\S+\s*', '', flags).strip()
+                    ok, model_val, err = _validate_model_name(body["model"])
+                    if not ok:
+                        return self._json({"error": err}, 400)
+                    # Strip any existing --model X / --model=X via the shared
+                    # shlex-based helper so quoted multi-word values and the
+                    # equals-form aren't corrupted. On parse failure (malformed
+                    # CC_FLAGS in the session env file), surface a 400 rather
+                    # than silently wiping out the user's other flags.
+                    try:
+                        flags_no_model = _strip_model_from_flags(cfg.get("CC_FLAGS", ""))
+                    except ValueError as e:
+                        return self._json({
+                            "error": f"existing CC_FLAGS for session '{name}' is malformed ({e}); fix the .env file manually before updating the model"
+                        }, 400)
                     if model_val:
-                        flags = f"--model {model_val} {flags}".strip()
+                        flags = (
+                            f"--model {model_val} {flags_no_model}".strip()
+                            if flags_no_model
+                            else f"--model {model_val}"
+                        )
+                    else:
+                        flags = flags_no_model
                     cfg["CC_FLAGS"] = flags
                     _write_env(env_file, cfg)
                     # Also send /model to running session so it takes effect immediately

--- a/tests/test_bash_quoting.py
+++ b/tests/test_bash_quoting.py
@@ -1,0 +1,212 @@
+"""Verify the bash quote_flags / quote_argv helpers produce correct output.
+
+Tests the functions as defined in `amux` (the bash CLI), not a copy. Uses
+plain `source amux` — enabled by the source-guard at the bottom of the
+amux script that skips CLI dispatch when sourced.
+
+The bash functions delegate to python3's shlex, so semantically these
+tests should mirror test_shell_quote_flags.py exactly. The parity test
+imports the REAL python helper via importlib (no copy-pasted logic) so
+drift is impossible.
+"""
+
+import importlib.util
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+AMUX_SCRIPT = REPO_ROOT / "amux"
+SERVER_PATH = REPO_ROOT / "amux-server.py"
+
+
+@pytest.fixture(scope="module")
+def amux_server():
+    """Load amux-server.py via importlib so we can call the real
+    _shell_quote_flags for parity comparisons. The __main__ guard at the
+    bottom of the file prevents the HTTP server from starting on import."""
+    spec = importlib.util.spec_from_file_location("amux_server", SERVER_PATH)
+    assert spec is not None and spec.loader is not None, f"could not load {SERVER_PATH}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["amux_server"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def quote_flags(s: str) -> str:
+    """Invoke quote_flags by sourcing the live amux script in a subshell."""
+    if not AMUX_SCRIPT.exists():
+        pytest.skip(f"amux script not found at {AMUX_SCRIPT}")
+    result = subprocess.run(
+        ["bash", "-c", 'source "$1" && quote_flags "$2"', "_", str(AMUX_SCRIPT), s],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"quote_flags failed (exit {result.returncode}): {result.stderr}"
+        )
+    return result.stdout.rstrip("\n")
+
+
+def quote_argv(*args: str) -> str:
+    """Invoke quote_argv (multi-arg form) from the live amux script."""
+    if not AMUX_SCRIPT.exists():
+        pytest.skip(f"amux script not found at {AMUX_SCRIPT}")
+    result = subprocess.run(
+        ["bash", "-c", 'source "$1"; shift; quote_argv "$@"', "_", str(AMUX_SCRIPT), *args],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"quote_argv failed (exit {result.returncode}): {result.stderr}"
+        )
+    return result.stdout.rstrip("\n")
+
+
+# ── quote_flags: regression case ─────────────────────────────────────────────
+
+def test_one_megacontext_model_bash():
+    assert quote_flags("--model claude-opus-4-6[1m]") == "--model 'claude-opus-4-6[1m]'"
+
+
+def test_one_megacontext_in_full_flag_list_bash():
+    s = "--model claude-opus-4-6[1m] --effort high --dangerously-skip-permissions"
+    expected = "--model 'claude-opus-4-6[1m]' --effort high --dangerously-skip-permissions"
+    assert quote_flags(s) == expected
+
+
+# ── quote_flags: pass-through cases ──────────────────────────────────────────
+
+def test_empty_string_bash():
+    assert quote_flags("") == ""
+
+
+def test_plain_flags_unchanged_bash():
+    s = "--model opus --effort high"
+    assert quote_flags(s) == s
+
+
+# ── quote_flags: globbing and word-splitting hazards ────────────────────────
+
+def test_no_globbing_bash(tmp_path, monkeypatch):
+    """Bash's native word-splitting would expand '*' against the filesystem
+    BEFORE quoting. Verify quote_flags does not."""
+    (tmp_path / "file1").touch()
+    (tmp_path / "file2").touch()
+    (tmp_path / "file3").touch()
+    monkeypatch.chdir(tmp_path)
+    result = quote_flags("--model *")
+    assert result == "--model '*'"
+
+
+def test_multiword_quoted_flag_preserved_bash():
+    """Bash's native word-splitting would break this into 3 tokens. shlex
+    correctly parses the quoted multi-word value as a single token."""
+    s = '--system-prompt "hello world"'
+    result = quote_flags(s)
+    assert shlex.split(result) == ["--system-prompt", "hello world"]
+
+
+# ── quote_flags: metachar safety ────────────────────────────────────────────
+
+def test_semicolon_does_not_execute_bash():
+    result = quote_flags("--model evil;rm")
+    assert shlex.split(result) == ["--model", "evil;rm"]
+
+
+def test_dollar_sign_quoted_bash():
+    result = quote_flags("--model $HOME")
+    assert shlex.split(result) == ["--model", "$HOME"]
+
+
+def test_backtick_quoted_bash():
+    result = quote_flags("--model `whoami`")
+    assert shlex.split(result) == ["--model", "`whoami`"]
+
+
+# ── Source-guard regression ─────────────────────────────────────────────────
+
+def test_source_does_not_run_dispatch():
+    """Sourcing amux must not trigger any CLI dispatch behavior. The
+    source-guard at the bottom of amux is what makes this test possible."""
+    result = subprocess.run(
+        ["bash", "-c", 'source "$1"; echo OK', "_", str(AMUX_SCRIPT)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"source failed: {result.stderr}"
+    assert result.stdout.strip() == "OK", f"unexpected output: {result.stdout!r}"
+
+
+# ── Parity with python helper ────────────────────────────────────────────────
+
+def test_parity_with_python_helper(amux_server):
+    """Outputs of bash quote_flags must match the REAL python
+    _shell_quote_flags for the same input. We import the production
+    helper via importlib (not a copy) so divergence is impossible."""
+    py_quote = amux_server._shell_quote_flags
+    cases = [
+        "--model opus",
+        "--model claude-opus-4-6[1m]",
+        "--model opus --effort high --yolo",
+        "--model evil;rm",
+        "--model $HOME",
+        "--model `whoami`",
+        "--model *",
+        "",
+    ]
+    for s in cases:
+        bash_result = quote_flags(s)
+        py_result = py_quote(s)
+        assert bash_result == py_result, f"parity broken for {s!r}: bash={bash_result!r} py={py_result!r}"
+
+
+# ── quote_argv direct tests (multi-arg form) ────────────────────────────────
+
+def test_quote_argv_empty():
+    assert quote_argv() == ""
+
+
+def test_quote_argv_single_plain():
+    assert quote_argv("--yolo") == "--yolo"
+
+
+def test_quote_argv_two_plain():
+    assert quote_argv("--model", "opus") == "--model opus"
+
+
+def test_quote_argv_bracket_in_value():
+    """The regression case via the multi-arg form."""
+    result = quote_argv("--model", "claude-opus-4-6[1m]")
+    assert result == "--model 'claude-opus-4-6[1m]'"
+
+
+def test_quote_argv_multiword_value():
+    """User passed `--system-prompt "hello world"` to amux start."""
+    result = quote_argv("--system-prompt", "hello world")
+    assert shlex.split(result) == ["--system-prompt", "hello world"]
+
+
+def test_quote_argv_metachar_value():
+    """A semicolon in a value must be quoted, not interpreted."""
+    result = quote_argv("--system-prompt", "wait; echo BOOM")
+    assert shlex.split(result) == ["--system-prompt", "wait; echo BOOM"]
+
+
+def test_quote_argv_dollar_var_in_value():
+    result = quote_argv("--system-prompt", "$HOME mine")
+    assert shlex.split(result) == ["--system-prompt", "$HOME mine"]
+
+
+def test_quote_argv_glob_in_value():
+    """A literal glob char in a value must not expand."""
+    result = quote_argv("--model", "*")
+    assert shlex.split(result) == ["--model", "*"]
+
+
+def test_quote_argv_single_quote_in_value():
+    """shlex.quote handles single quotes via the '\\''-escape pattern."""
+    result = quote_argv("--system-prompt", "it's working")
+    assert shlex.split(result) == ["--system-prompt", "it's working"]

--- a/tests/test_inline_arg_quoting.py
+++ b/tests/test_inline_arg_quoting.py
@@ -1,0 +1,121 @@
+"""Verify shlex.quote-based inline-arg escaping survives nested-shell re-eval.
+
+This is the v3/v4 fix for the bash CLI inline-argument bug. The amux:cmd_start
+function builds a shell command string via:
+
+    q=$(quote_argv "$@")
+    cmd="$cmd $q"
+
+Then passes the string to `tmux new-session ... "$cmd"` which is run by the
+user's default shell (bash, zsh, dash, etc). This test verifies that
+shlex.quote output, when re-evaluated by ANY POSIX shell, yields the
+original argv.
+"""
+
+import shlex
+import shutil
+import subprocess
+
+import pytest
+
+
+def cmd_string_from_argv(argv: list[str]) -> str:
+    """Replicate cmd_start's inline-arg quoting: shlex.quote each token."""
+    parts = ["claude"]
+    parts.extend(shlex.quote(a) for a in argv)
+    return " ".join(parts)
+
+
+def reparse_via_shell(cmd: str, shell: str) -> list[str]:
+    """Pass cmd through a specific shell and recover the argv it parsed.
+
+    We replace `claude` with `printf '%s\\0'` so each argument is
+    null-terminated. Null-separation is required because some test cases
+    (e.g. test_newline_in_value) use literal newlines inside argument
+    values; using newline as the record separator would conflate content
+    and structure."""
+    test_cmd = cmd.replace("claude", "printf '%s\\0'", 1)
+    result = subprocess.run(
+        [shell, "-c", test_cmd],
+        capture_output=True, check=True,  # bytes mode (no text=True)
+    )
+    if not result.stdout:
+        return []
+    # printf '%s\0' produces N nulls for N args, so split gives N+1 entries
+    # with an empty trailing element. Drop it.
+    parts = result.stdout.split(b"\x00")
+    if parts and parts[-1] == b"":
+        parts = parts[:-1]
+    return [p.decode("utf-8") for p in parts]
+
+
+# Discover available POSIX shells on this system. bash and sh are guaranteed.
+# dash and zsh are tested if present so we catch portability regressions.
+_SHELLS = [s for s in ["bash", "sh", "dash", "zsh"] if shutil.which(s)]
+
+
+@pytest.mark.parametrize("shell", _SHELLS)
+def test_quoted_multiword_preserved(shell):
+    """--system-prompt 'hello world' must reach claude as 2 args, not 3."""
+    argv = ["--system-prompt", "hello world"]
+    cmd = cmd_string_from_argv(argv)
+    parsed = reparse_via_shell(cmd, shell)
+    assert parsed == argv, f"shell={shell}: {parsed!r}"
+
+
+@pytest.mark.parametrize("shell", _SHELLS)
+def test_glob_metachar_not_expanded(shell):
+    """--model claude-opus-4-6[1m] must reach claude as the literal string,
+    not trigger zsh's nomatch."""
+    argv = ["--model", "claude-opus-4-6[1m]"]
+    cmd = cmd_string_from_argv(argv)
+    parsed = reparse_via_shell(cmd, shell)
+    assert parsed == argv, f"shell={shell}: {parsed!r}"
+
+
+@pytest.mark.parametrize("shell", _SHELLS)
+def test_semicolon_not_executed(shell):
+    """--system-prompt 'wait; echo BOOM' must NOT spawn an extra command."""
+    argv = ["--system-prompt", "wait; echo BOOM"]
+    cmd = cmd_string_from_argv(argv)
+    parsed = reparse_via_shell(cmd, shell)
+    assert parsed == argv, f"shell={shell}: {parsed!r}"
+
+
+@pytest.mark.parametrize("shell", _SHELLS)
+def test_dollar_var_not_expanded(shell):
+    """--system-prompt '$HOME is mine' must NOT have $HOME expanded."""
+    argv = ["--system-prompt", "$HOME is mine"]
+    cmd = cmd_string_from_argv(argv)
+    parsed = reparse_via_shell(cmd, shell)
+    assert parsed == argv, f"shell={shell}: {parsed!r}"
+
+
+@pytest.mark.parametrize("shell", _SHELLS)
+def test_backtick_not_executed(shell):
+    """--system-prompt 'who is `whoami`' must NOT execute whoami."""
+    argv = ["--system-prompt", "who is `whoami`"]
+    cmd = cmd_string_from_argv(argv)
+    parsed = reparse_via_shell(cmd, shell)
+    assert parsed == argv, f"shell={shell}: {parsed!r}"
+
+
+@pytest.mark.parametrize("shell", _SHELLS)
+def test_single_quote_in_value(shell):
+    """A literal single quote in an arg must round-trip correctly. shlex.quote
+    handles this with the '\\''-escape pattern."""
+    argv = ["--system-prompt", "it's working"]
+    cmd = cmd_string_from_argv(argv)
+    parsed = reparse_via_shell(cmd, shell)
+    assert parsed == argv, f"shell={shell}: {parsed!r}"
+
+
+@pytest.mark.parametrize("shell", _SHELLS)
+def test_newline_in_value(shell):
+    """A newline inside an arg value must be preserved as part of the same
+    argument, not treated as a statement separator. shlex.quote produces
+    literal-newline-inside-single-quotes which all POSIX shells handle."""
+    argv = ["--system-prompt", "first line\nsecond line", "--effort", "high"]
+    cmd = cmd_string_from_argv(argv)
+    parsed = reparse_via_shell(cmd, shell)
+    assert parsed == argv, f"shell={shell}: {parsed!r}"

--- a/tests/test_shell_quote_flags.py
+++ b/tests/test_shell_quote_flags.py
@@ -1,0 +1,358 @@
+"""Unit tests for _shell_quote_flags — the spawn-side flag quoting helper.
+
+This is the load-bearing fix for the spawn-time shell-injection bug where
+zsh interprets '[1m]' in model IDs like 'claude-opus-4-6[1m]' as a glob
+character class and aborts the entire spawn command with 'no matches found'.
+
+We import the helper from amux-server.py via importlib rather than copying
+it. The server's __main__ guard prevents the HTTP server from actually
+starting during import. No drift is possible.
+"""
+
+import importlib.util
+import shlex
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+SERVER_PATH = REPO_ROOT / "amux-server.py"
+
+
+@pytest.fixture(scope="module")
+def amux_server():
+    """Load amux-server.py as a module without running its HTTP server.
+
+    The server file has `if __name__ == "__main__":` at module bottom that
+    contains the actual server startup; importlib sets __name__ to the spec
+    name ('amux_server') so the guard skips startup.
+    """
+    spec = importlib.util.spec_from_file_location("amux_server", SERVER_PATH)
+    assert spec is not None and spec.loader is not None, f"could not load {SERVER_PATH}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["amux_server"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def quote_flags(amux_server):
+    """Return the production _shell_quote_flags function."""
+    return amux_server._shell_quote_flags
+
+
+@pytest.fixture
+def model_id_re(amux_server):
+    """Return the production _MODEL_ID_RE compiled regex."""
+    return amux_server._MODEL_ID_RE
+
+
+# ── The regression case ──────────────────────────────────────────────────────
+
+def test_one_megacontext_model_gets_quoted(quote_flags):
+    """The exact case from PR #18 that broke session spawn."""
+    result = quote_flags("--model claude-opus-4-6[1m]")
+    assert result == "--model 'claude-opus-4-6[1m]'"
+
+
+def test_one_megacontext_in_full_flag_list(quote_flags):
+    """Realistic CC_FLAGS string with [1m] model alongside other flags."""
+    s = "--model claude-opus-4-6[1m] --effort high --dangerously-skip-permissions"
+    result = quote_flags(s)
+    assert result == "--model 'claude-opus-4-6[1m]' --effort high --dangerously-skip-permissions"
+
+
+# ── Pass-through cases ───────────────────────────────────────────────────────
+
+def test_empty_string(quote_flags):
+    assert quote_flags("") == ""
+
+
+def test_plain_flags_unchanged(quote_flags):
+    """Flags with no shell metacharacters round-trip identically."""
+    s = "--model opus --effort high"
+    assert quote_flags(s) == s
+
+
+def test_single_flag(quote_flags):
+    assert quote_flags("--yolo") == "--yolo"
+
+
+def test_short_model_names_unchanged(quote_flags):
+    for name in ["opus", "sonnet", "haiku", "claude-opus-4-6", "claude-sonnet-4-6"]:
+        s = f"--model {name}"
+        assert quote_flags(s) == s, f"unchanged expected for {name}"
+
+
+# ── Other shell metacharacters that would also break ────────────────────────
+
+def test_semicolon_does_not_execute(quote_flags):
+    """Shell command separators get quoted, not executed."""
+    result = quote_flags("--model evil;rm")
+    assert shlex.split(result) == ["--model", "evil;rm"]
+
+
+def test_dollar_sign_quoted(quote_flags):
+    result = quote_flags("--model $HOME")
+    assert shlex.split(result) == ["--model", "$HOME"]
+
+
+def test_backtick_quoted(quote_flags):
+    result = quote_flags("--model `whoami`")
+    assert shlex.split(result) == ["--model", "`whoami`"]
+
+
+def test_pipe_quoted(quote_flags):
+    result = quote_flags("--model a|b")
+    assert shlex.split(result) == ["--model", "a|b"]
+
+
+def test_glob_star_quoted(quote_flags):
+    """The glob '*' must not expand at spawn time."""
+    result = quote_flags("--model *")
+    assert shlex.split(result) == ["--model", "*"]
+
+
+def test_newline_in_value_quoted(quote_flags):
+    """A newline inside a stored flag value must be preserved as part of
+    the same token, not split into multiple. shlex.quote handles this
+    correctly with literal-newline-inside-single-quotes."""
+    s = "--system-prompt 'first\nsecond'"
+    result = quote_flags(s)
+    assert shlex.split(result) == ["--system-prompt", "first\nsecond"]
+
+
+# ── Round-trip property ──────────────────────────────────────────────────────
+
+def test_round_trip_preserves_tokens(quote_flags):
+    """For any input, shlex.split(quote_flags(input)) == shlex.split(input)."""
+    cases = [
+        "--model opus",
+        "--model claude-opus-4-6[1m]",
+        "--model opus --effort high --yolo",
+        "--system-prompt hello",
+        "",
+    ]
+    for s in cases:
+        original_tokens = shlex.split(s) if s else []
+        quoted = quote_flags(s)
+        roundtrip_tokens = shlex.split(quoted) if quoted else []
+        assert roundtrip_tokens == original_tokens, f"round-trip failed for {s!r}"
+
+
+# ── Malformed input fallback (no longer raw passthrough) ────────────────────
+
+def test_unbalanced_quote_quoted_as_literal(quote_flags):
+    """Malformed input (unbalanced quote) gets quoted as a single literal
+    token rather than passed through raw — preserving the security invariant
+    that the shell never interprets stored data."""
+    s = '--model "unbalanced'
+    result = quote_flags(s)
+    assert result == shlex.quote(s)
+    reparsed = shlex.split(result)
+    assert reparsed == [s], f"expected [{s!r}], got {reparsed}"
+
+
+def test_malformed_with_metachars_still_safe(quote_flags):
+    """Even with shell metacharacters in malformed input, the result is safe."""
+    s = '--model "evil; rm -rf /'
+    result = quote_flags(s)
+    reparsed = shlex.split(result)
+    assert reparsed == [s], "malformed-with-metachars must round-trip as single token"
+
+
+# ── Defense-in-depth: PATCH endpoint validator ──────────────────────────────
+
+def test_validator_accepts_known_anthropic_models(model_id_re):
+    for m in ["opus", "sonnet", "haiku",
+              "claude-opus-4-6", "claude-opus-4-6[1m]",
+              "claude-sonnet-4-6", "claude-sonnet-4-6[1m]",
+              "claude-haiku-4-5-20251001"]:
+        assert model_id_re.match(m), f"{m} should be accepted"
+
+
+def test_validator_accepts_third_party_models(model_id_re):
+    """Bedrock, Vertex, OpenRouter, HuggingFace use slashes, at-signs, plus."""
+    for m in ["anthropic/claude-3-opus",
+              "claude-3-opus@20240229",
+              "anthropic.claude-3-sonnet-20240229-v1:0",
+              "openrouter/anthropic/claude-3.5-sonnet",
+              "meta-llama/Llama-3+chat"]:
+        assert model_id_re.match(m), f"{m} should be accepted"
+
+
+def test_validator_rejects_metachars(model_id_re):
+    for bad in ["opus; rm", "opus|cat", "opus$VAR", "opus`x`",
+                "opus>file", "opus<file", "opus&", "opus(x)",
+                "opus{x}", "opus x", "opus\nhostile", "opus\\evil",
+                "opus'quote", 'opus"quote']:
+        assert not model_id_re.match(bad), f"{bad} should be rejected"
+
+
+def test_validator_rejects_leading_hyphen(model_id_re):
+    """A model name starting with '-' would be reparsed as a flag by claude
+    after shell-quoting, enabling application-level argument injection."""
+    for bad in ["-p", "-malicious", "--api-key", "-injection",
+                "-rm", "-yolo", "--dangerously-skip-permissions"]:
+        assert not model_id_re.match(bad), f"{bad} should be rejected (leading hyphen)"
+
+
+def test_validator_accepts_local_paths(model_id_re):
+    """Leading '.', '/', and other harmless characters are allowed for
+    users driving non-Anthropic LLM CLIs through amux that accept local
+    model paths."""
+    for ok in ["./model", "/opt/local-model", "/home/me/llama-2-7b",
+               "[bracketed]", "@scoped", ".hidden"]:
+        assert model_id_re.match(ok), f"{ok} should be accepted (harmless leading char)"
+
+
+def test_validator_rejects_empty(model_id_re):
+    assert not model_id_re.match("")
+
+
+@pytest.fixture
+def validate_model_name(amux_server):
+    """Return the production _validate_model_name helper."""
+    return amux_server._validate_model_name
+
+
+def test_validate_model_name_accepts_known_models(validate_model_name):
+    for m in ["opus", "claude-opus-4-6", "claude-opus-4-6[1m]",
+              "anthropic/claude-3-opus"]:
+        ok, normalized, err = validate_model_name(m)
+        assert ok, f"{m} should be accepted: {err}"
+        assert normalized == m
+        assert err == ""
+
+
+def test_validate_model_name_strips_whitespace(validate_model_name):
+    ok, normalized, _ = validate_model_name("  opus  ")
+    assert ok
+    assert normalized == "opus"
+
+
+def test_validate_model_name_allows_empty(validate_model_name):
+    """Empty string is valid at this level — caller decides what empty means."""
+    ok, normalized, _err = validate_model_name("")
+    assert ok
+    assert normalized == ""
+
+
+def test_validate_model_name_rejects_non_string(validate_model_name):
+    for bad in [None, 42, ["opus"], {"model": "opus"}, True]:
+        ok, _, err = validate_model_name(bad)
+        assert not ok, f"{bad!r} should be rejected"
+        assert "string" in err.lower()
+
+
+def test_validate_model_name_rejects_too_long(validate_model_name):
+    """255-char limit prevents DoS via huge JSON payloads."""
+    ok, _, err = validate_model_name("a" * 256)
+    assert not ok
+    assert "too long" in err
+
+
+def test_validate_model_name_rejects_metachars(validate_model_name):
+    for bad in ["opus; rm", "opus|cat", "opus$VAR", "-injection"]:
+        ok, _, err = validate_model_name(bad)
+        assert not ok, f"{bad} should be rejected"
+        assert "invalid" in err
+
+
+def test_validator_does_not_choke_on_long_input(model_id_re):
+    """The regex itself is bounded — no catastrophic backtracking on long
+    inputs. The PATCH endpoint enforces a 255-char length limit before
+    calling this regex, but verify it would still match a long valid name
+    quickly (no ReDoS)."""
+    long_valid = "a" * 250
+    assert model_id_re.match(long_valid)
+    long_invalid = "a" * 200 + " " + "b" * 50
+    assert not model_id_re.match(long_invalid)
+
+
+# ── Regression: PATCH /api/settings/default-model preserves non-model flags ──
+
+@pytest.fixture
+def strip_model_from_flags(amux_server):
+    """Return the production _strip_model_from_flags helper."""
+    return amux_server._strip_model_from_flags
+
+
+@pytest.fixture
+def extract_model_from_flags(amux_server):
+    """Return the production _extract_model_from_flags helper."""
+    return amux_server._extract_model_from_flags
+
+
+def test_strip_model_basic(strip_model_from_flags):
+    """The original PR #18 data-loss bug: changing the default model wiped
+    --max-tokens. The strip helper must remove only --model X, not the rest."""
+    assert strip_model_from_flags("--model opus --max-tokens 4000") == "--max-tokens 4000"
+
+
+def test_strip_model_preserves_multiple_other_flags(strip_model_from_flags):
+    assert strip_model_from_flags(
+        "--model sonnet --max-tokens 4000 --effort high"
+    ) == "--max-tokens 4000 --effort high"
+
+
+def test_strip_model_handles_equals_form(strip_model_from_flags):
+    """The --model=X form must also be stripped, not just --model X."""
+    assert strip_model_from_flags(
+        "--model=opus --max-tokens 4000"
+    ) == "--max-tokens 4000"
+
+
+def test_strip_model_handles_quoted_bracketed(strip_model_from_flags):
+    """A quoted bracketed model name (round-trip from .env) must be stripped
+    correctly without breaking the rest of the flags."""
+    assert strip_model_from_flags(
+        "--model 'claude-opus-4-6[1m]' --effort high"
+    ) == "--effort high"
+
+
+def test_strip_model_no_model_present(strip_model_from_flags):
+    """Flags with no --model are returned unchanged (modulo shlex re-quoting)."""
+    assert strip_model_from_flags("--max-tokens 4000") == "--max-tokens 4000"
+
+
+def test_strip_model_empty(strip_model_from_flags):
+    assert strip_model_from_flags("") == ""
+
+
+def test_strip_model_only(strip_model_from_flags):
+    """Just a --model flag with no other flags returns empty string."""
+    assert strip_model_from_flags("--model opus") == ""
+
+
+def test_strip_model_malformed_raises(strip_model_from_flags):
+    """Malformed input (unbalanced quotes) MUST raise ValueError so the
+    PATCH endpoint can return 400 to the user. Silently returning empty
+    would wipe all the user's other flags during a routine model update,
+    which is a data-loss bug. The PATCH endpoints catch this exception
+    and surface a clear error message."""
+    with pytest.raises(ValueError):
+        strip_model_from_flags('--model "unbalanced')
+
+
+def test_extract_model_basic(extract_model_from_flags):
+    assert extract_model_from_flags("--model opus") == "opus"
+
+
+def test_extract_model_equals_form(extract_model_from_flags):
+    assert extract_model_from_flags("--model=opus") == "opus"
+
+
+def test_extract_model_bracketed(extract_model_from_flags):
+    assert extract_model_from_flags(
+        "--model claude-opus-4-6[1m] --effort high"
+    ) == "claude-opus-4-6[1m]"
+
+
+def test_extract_model_absent(extract_model_from_flags):
+    assert extract_model_from_flags("--max-tokens 4000") == ""
+
+
+def test_extract_model_empty(extract_model_from_flags):
+    assert extract_model_from_flags("") == ""


### PR DESCRIPTION
## Summary

Replaces closed #18 with a corrected version. #18 added a Default Model dropdown with 1M-context options like `claude-opus-4-6[1m]`, but selecting one bricked every new session start with `zsh:1: no matches found: claude-opus-4-6[1m]`. zsh interprets `[1m]` as a glob character class and aborts the spawn command before claude is invoked.

The root cause was broader than #18: stored flag strings were concatenated raw into shell commands in both spawn paths (`amux-server.py:start_session` and `amux:cmd_start`). The 1M model IDs just made an existing latent bug reachable from the UI. This PR fixes it at the consumer boundary so any producer (settings UI, REST API, bash CLI, hand-edited `.env` files) is automatically safe, AND includes the corrected version of the #18 default-model UI so users can actually use the 1M context variants.

## What's in this PR

**The fix from #18 (default-model UI):**
- Settings → Default Model dropdown
- `claude-opus-4-6[1m]` and `claude-sonnet-4-6[1m]` in the per-session model picker
- `PATCH /api/settings/default-model` endpoint
- Dynamic "Default (X)" label reflecting the configured default

**Plus the shell-safe quoting fix (the new part):**
- `_shell_quote_flags()` in `amux-server.py`: tokenize stored flag strings via `shlex.split` and re-quote each token via `shlex.quote`. Applied at all 4 concat sites in `start_session()`. On malformed input, wraps the whole raw string as a single `shlex.quote`'d literal so the security invariant holds.
- `quote_flags()` + `quote_argv()` in `amux` (bash CLI): delegate to python3 shlex via a shared `_run_py_safe` runner. Uses python3 shlex instead of bash's `printf '%q'` because `printf '%q'` produces bash-only `$'...'` syntax that breaks under `dash`. shlex.quote is universal POSIX single-quoting.
- `cmd_start` inline args (`amux start NAME -- …`) now use `quote_argv` instead of the broken `$*` form. Previously `$*` flattened argv back into a single string, losing quoting boundaries when the nested shell re-evaluated it — this enabled both quote-loss (`--system-prompt "hello world"` became 3 args) and command injection (`--system-prompt "wait; echo BOOM"` actually ran `echo BOOM`).
- Source-guard at bottom of `amux` lets the test suite `source` it without triggering CLI dispatch.

**Defense in depth:**
- `_MODEL_ID_RE = ^(?!-)[A-Za-z0-9._:\[\]@/+-]+$` — negative lookahead rejects leading hyphens (application-level argument injection like `-p` or `--api-key`) while permitting `[1m]` suffix, Bedrock `anthropic.foo:1`, Vertex `anthropic/foo`, HuggingFace `foo+bar`, and local paths `./foo` / `/opt/foo`.
- `_validate_model_name()` shared helper enforces type, 255-char length (DoS prevention), and the regex. Used by both PATCH endpoints.

**Bug fixes layered on #18's original code:**
- `_strip_model_from_flags()` preserves the user's other flags (like `--max-tokens`, `--effort`) when changing the default model. The original #18 code silently overwrote the entire `CC_DEFAULT_FLAGS` line. Uses shlex tokenization so both `--model X` and `--model=X` forms are handled. Raises `ValueError` on malformed input; PATCH callers catch and return 400 rather than silently losing data.
- `_atomic_write_secure()` helper creates files with mode `0o600` via `NamedTemporaryFile` + `flush` + `fsync` + `os.replace`. No TOCTOU window, durable across system crashes. Used by both `_write_env` (shared session env helper) and the default-model PATCH endpoint.
- `PATCH /api/settings/default-model` preserves comments and other env vars in `defaults.env` via line-by-line substitution, reading the file exactly once (eliminates TOCTOU race between two reads).
- `PATCH /api/sessions/{name}` model handler uses the same helpers so both PATCH endpoints share a single source of truth for validation and substitution.

## Breaking change (intentional)

Stored flag values are now treated as literal data, not as shell expressions. If a user previously stored `CC_FLAGS="--api-key $MY_API_KEY"` expecting the shell to expand `$MY_API_KEY` at spawn time, that pattern no longer works — the value is passed to claude as the literal string `$MY_API_KEY`. Stored shell fragments were exactly the kind of injection vector this fix exists to neutralize. Users wanting dynamic secrets should set them as environment variables in their shell profile. Documented in the `_shell_quote_flags` docstring.

## Tests

**123 tests total, 89 new across 3 files.** All 34 existing tests continue to pass.

- `tests/test_shell_quote_flags.py` — imports the real helpers via `importlib` (no copy-paste drift) and exercises edge cases: the `[1m]` regression, all shell metacharacters, malformed input fallback, third-party model formats (Bedrock/Vertex/OpenRouter/HuggingFace), the strip helper's data-preservation property across `--model X` / `--model=X` / quoted multi-word values, and the `_validate_model_name` helper.
- `tests/test_bash_quoting.py` — sources the live `amux` script via the new source guard and exercises both `quote_flags` and `quote_argv` through real bash subshells. Includes a parity test that imports the REAL python helper via importlib.
- `tests/test_inline_arg_quoting.py` — verifies the `cmd_start` argv quoting pattern survives nested-shell re-evaluation across bash, sh, dash, and zsh (parametrize + `shutil.which` to skip unavailable shells).

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('amux-server.py').read())"` → syntax OK
- [x] `bash -n amux` → syntax OK
- [x] `pytest tests/ -q` → 123 passed
- [x] Local install + restart a previously broken session that had `CC_DEFAULT_FLAGS="--model claude-opus-4-6[1m]"` in `defaults.env` → starts cleanly, no `no matches found` error
- [x] `PATCH /api/settings/default-model` with malicious models (`opus; rm -rf /`, `-p`, non-string, non-dict body) → all return 400 with clear error messages
- [x] Data-preservation: manually set `CC_DEFAULT_FLAGS="--model opus --max-tokens 4000 --effort high"` + `# my comment`, PATCH model to `claude-sonnet-4-6`, verify `--max-tokens 4000 --effort high` AND the comment survive
- [x] File permissions on `defaults.env` after PATCH → `0o600`

## Known residuals (explicitly out of scope)

- CSRF/SSRF audit of local API endpoints (separate security audit)
- Secrets exposure via `ps aux` (requires env-var refactor for sensitive flags)
- Concurrent read-modify-write on `.env` files (no `fcntl.flock` — pre-existing, acceptable for local single-user tool)
- Temp file leak on SIGINT during python3 exec in bash `_run_py_safe` (sub-100ms window, temp file contains only python stderr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)