### PR TITLE
fix(ui): stop accidental Files-tab teleport from session card clicks

### DIFF
--- a/amux-server.py
+++ b/amux-server.py
@@ -12504,6 +12504,7 @@ function render() {
           <button class="card-menu-btn" onclick="event.stopPropagation();toggleMenu('${s.name}')" title="Options">&#x22EF;</button>
           <div class="card-menu" id="menu-${s.name}">
           <div class="card-menu-item" onclick="event.stopPropagation();closeAllMenus();openPeek('${s.name}')"><span class="mi">&#x1F4BB;</span> Peek terminal</div>
+          ${s.dir ? `<div class="card-menu-item" onclick="event.stopPropagation();closeAllMenus();openExplore('${s.dir.replace(/'/g,"\\'")}','${s.name.replace(/'/g,"\\'")}')"><span class="mi">&#x1F4C1;</span> Browse files</div>` : ''}
           <div class="card-menu-item" onclick="event.stopPropagation();closeAllMenus();showSessionInfo('${s.name}')"><span class="mi">&#x2139;</span> Info</div>
           <div class="card-menu-item" onclick="event.stopPropagation();togglePin('${s.name}')"><span class="mi">${s.pinned?'&#x1F4CC;':'&#x1F4CC;'}</span> ${s.pinned ? 'Unpin' : 'Pin to top'}</div>
           <div class="card-menu-item" onclick="event.stopPropagation();editField('${s.name}','name','${esc(s.name)}')"><span class="mi">&#x270E;</span> Rename</div>
@@ -12534,7 +12535,7 @@ function render() {
           ${!online ? '<span class="cached-badge">cached</span>' : ''}
         </div>` : ''}
       </div>
-      ${s.dir ? `<div class="card-dir"><span class="card-dir-path" onclick="event.stopPropagation();openExplore('${s.dir.replace(/'/g,"\\'")}','${s.name.replace(/'/g,"\\'")}')" style="cursor:pointer;" title="Browse files">${esc(s.dir)}</span></div>` : ''}
+      ${s.dir ? `<div class="card-dir"><span class="card-dir-path" title="${esc(s.dir)}">${esc(s.dir)}</span></div>` : ''}
       ${s.creator ? `<div class="card-dir" style="font-size:0.72rem;">${esc(s.creator)}</div>` : ''}
       ${s.dir ? _renderBranchBadge(s.name, s.branch) : ''}
       ${isExp && s.desc ? `<div class="card-desc">${esc(s.desc)}</div>` : ''}
@@ -19520,11 +19521,7 @@ function switchView(view) {
   if (view === 'files') loadFiles(_filesPath);
   else {
     try { if (location.hash.startsWith('#path=')) history.replaceState({}, '', location.pathname); } catch(e) {}
-    if (view === 'sessions' && _exploreSession) {
-      const _sess = _exploreSession;
-      _exploreSession = null;
-      setTimeout(() => openPeek(_sess), 50);
-    }
+    if (view === 'sessions') _exploreSession = null;
   }
   if (view === 'notes') {
     _notesInitQuill(); _notesApplySidebarState(); _notesBindSwipeGestures();


### PR DESCRIPTION
## The bug

Clicking a session card in the Sessions tab would sometimes route you into the Files tab for that session instead of expanding the card. Then clicking the Sessions tab to return would dump you into the Terminal/peek view rather than back to the session list. Felt intermittent, but had a deterministic cause.

## Root cause

Two coupled click handlers:

1. **`_renderSessionCard` → `.card-dir-path`** (the directory line under the card header) had an `onclick` that called `openExplore(...)` → `switchView('files')`. The dir path is visually prominent inside the card but narrow vertically; when cards shift mid-click due to natural-sort reorder on activity changes, the cursor frequently landed on a neighbor's path → routed to Files.

2. **`switchView('sessions')`** had a deferred action: if `_exploreSession` was set (from step 1), it scheduled `setTimeout(() => openPeek(_sess), 50)`. So clicking the Sessions tab to recover would briefly show Sessions, then get teleported into the peek view.

## Changes

- Remove the `onclick` from `.card-dir-path`. The path is now informational text with a tooltip showing the full directory.
- Add **Browse files** as a card-menu item (`⋯` menu) next to **Peek terminal**. Explicit affordance, no accidental activation.
- In `switchView('sessions')`, clear `_exploreSession` without the auto-peek side effect. Sessions tab now reliably shows Sessions.

## What this doesn't break

- `_exploreSession` is still set by `openExplore()` and cleared only on Sessions-tab return, so the **Set dir for <session>** button inside Files view (uses `_exploreSession`) is unaffected.
- Card-menu pattern already has nine action items; adding a tenth fits the existing design.
- Click-to-Peek via the `card-preview-lines` element (line ~12566) is untouched — double-tap on header still opens peek too.

## Test plan

- [x] Python syntax (`ast.parse`)
- [x] Clicking anywhere on card body now reliably toggles expand/collapse
- [x] Card-menu &rarr; Browse files opens Files view rooted at the session's dir
- [x] Returning to Sessions tab from Files shows the session list, no peek teleport
- [x] Set-dir-for-session button in Files view still works