### PR TITLE
fix: dashboard restart never relaunched Claude after stop

### DIFF
--- a/amux-server.py
+++ b/amux-server.py
@@ -14134,7 +14134,7 @@ async function doRestart(name) {
     let alreadyStopped = false;
     let sessionGone = false;
     try {
-      const pre = await fetch(INFO_URL);
+      const pre = await fetch(INFO_URL, { signal: AbortSignal.timeout(5000) });
       if (pre.status === 404) {
         sessionGone = true;
       } else if (pre.ok) {
@@ -14168,7 +14168,7 @@ async function doRestart(name) {
     const MAX_POLLS = 58; // 1s warmup + 58 * 500ms ≈ 30s total
     for (let i = 0; i < MAX_POLLS; i++) {
       try {
-        const r = await fetch(INFO_URL);
+        const r = await fetch(INFO_URL, { signal: AbortSignal.timeout(3000) });
         if (r.status === 404) {
           showToast('Session no longer exists');
           return;

--- a/amux-server.py
+++ b/amux-server.py
@@ -14111,24 +14111,79 @@ async function copyMoshCmd(name) {
   }
 }
 
+// Module-level guard so multiple Restart entry points (card menu, peek menu)
+// can't pile up overlapping polling loops + queued /start commands.
+const _restartingSessions = new Set();
+
 async function doRestart(name) {
-  await apiCall(API + '/api/sessions/' + name + '/stop', { method: 'POST' });
-  // Poll until stopped (up to 20s for graceful /exit). If it never stops,
-  // bail out instead of racing doStart against a still-running session.
-  let stopped = false;
-  for (let i = 0; i < 40; i++) {
-    await new Promise(r => setTimeout(r, 500));
-    await fetchSessions();
-    if (!sessions.find(s => s.name === name && s.running)) {
-      stopped = true;
-      break;
-    }
-  }
-  if (!stopped) {
-    showToast("Stop didn't take effect, try again");
+  if (_restartingSessions.has(name)) {
+    showToast('Restart already in progress');
     return;
   }
-  await doStart(name);
+  _restartingSessions.add(name);
+  try {
+    const encodedName = encodeURIComponent(name);
+    const SINGLE_URL = API + '/api/sessions/' + encodedName;
+    const STOP_URL = SINGLE_URL + '/stop';
+
+    // Pre-check: if Claude already isn't running (crashed, externally killed),
+    // skip /stop entirely and go straight to doStart. Without this, the queued
+    // _bg_stop worker can race a freshly-launched Claude and kill it.
+    // Use raw fetch so we can distinguish 404 from 5xx; apiCall flattens both.
+    try {
+      const pre = await fetch(SINGLE_URL);
+      if (pre.status === 404) {
+        showToast('Session no longer exists');
+        return;
+      }
+      if (pre.ok) {
+        const data = await pre.json();
+        if (!data.running) {
+          await doStart(name);
+          return;
+        }
+      }
+    } catch (e) {
+      // Network blip on pre-check — fall through to standard stop+poll flow.
+    }
+
+    const stopResp = await apiCall(STOP_URL, { method: 'POST' });
+    if (!stopResp) return; // apiCall already surfaced the error
+
+    // Poll the SINGLE-session endpoint, not the list. The list endpoint reports
+    // running == "tmux session exists", which never flips false because
+    // stop_session keeps tmux alive. The single endpoint uses is_running()
+    // which correctly returns false once Claude exits.
+    // Worst case server-side stop is ~21s (rename + 15s exit + 1s settle), so
+    // poll for 30s with a 1s warmup before the first poll.
+    await new Promise(r => setTimeout(r, 1000));
+    let stopped = false;
+    const MAX_POLLS = 58; // 1s warmup + 58 * 500ms ≈ 30s total
+    for (let i = 0; i < MAX_POLLS; i++) {
+      try {
+        const r = await fetch(SINGLE_URL);
+        if (r.status === 404) {
+          showToast('Session no longer exists');
+          return;
+        }
+        if (r.ok) {
+          const data = await r.json();
+          if (!data.running) { stopped = true; break; }
+        }
+      } catch (e) {
+        // Network blip — keep polling.
+      }
+      await new Promise(r => setTimeout(r, 500));
+    }
+    if (!stopped) {
+      showToast("Stop didn't take effect, try again");
+      return;
+    }
+    await fetchSessions(); // refresh card UI before doStart
+    await doStart(name);
+  } finally {
+    _restartingSessions.delete(name);
+  }
 }
 
 // ── Sending indicator ──

--- a/amux-server.py
+++ b/amux-server.py
@@ -14123,37 +14123,44 @@ async function doRestart(name) {
   _restartingSessions.add(name);
   try {
     const encodedName = encodeURIComponent(name);
-    const SINGLE_URL = API + '/api/sessions/' + encodedName;
-    const STOP_URL = SINGLE_URL + '/stop';
+    const INFO_URL = API + '/api/sessions/' + encodedName + '/info';
+    const STOP_URL = API + '/api/sessions/' + encodedName + '/stop';
 
     // Pre-check: if Claude already isn't running (crashed, externally killed),
-    // skip /stop entirely and go straight to doStart. Without this, the queued
-    // _bg_stop worker can race a freshly-launched Claude and kill it.
+    // skip /stop entirely. Without this, the queued _bg_stop worker can race a
+    // freshly-launched Claude and kill it.
     // Use raw fetch so we can distinguish 404 from 5xx; apiCall flattens both.
+    // (window.fetch is monkey-patched at line 11878 to inject auth headers.)
+    let alreadyStopped = false;
+    let sessionGone = false;
     try {
-      const pre = await fetch(SINGLE_URL);
+      const pre = await fetch(INFO_URL);
       if (pre.status === 404) {
-        showToast('Session no longer exists');
-        return;
-      }
-      if (pre.ok) {
+        sessionGone = true;
+      } else if (pre.ok) {
         const data = await pre.json();
-        if (!data.running) {
-          await doStart(name);
-          return;
-        }
+        if (!data.running) alreadyStopped = true;
       }
     } catch (e) {
       // Network blip on pre-check — fall through to standard stop+poll flow.
+    }
+    if (sessionGone) {
+      showToast('Session no longer exists');
+      return;
+    }
+    if (alreadyStopped) {
+      await fetchSessions();
+      await doStart(name);
+      return;
     }
 
     const stopResp = await apiCall(STOP_URL, { method: 'POST' });
     if (!stopResp) return; // apiCall already surfaced the error
 
-    // Poll the SINGLE-session endpoint, not the list. The list endpoint reports
-    // running == "tmux session exists", which never flips false because
-    // stop_session keeps tmux alive. The single endpoint uses is_running()
-    // which correctly returns false once Claude exits.
+    // Poll the SINGLE-session info endpoint, not the list. The list endpoint
+    // reports running == "tmux session exists", which never flips false because
+    // stop_session keeps tmux alive. /info uses is_running() which correctly
+    // returns false once Claude exits.
     // Worst case server-side stop is ~21s (rename + 15s exit + 1s settle), so
     // poll for 30s with a 1s warmup before the first poll.
     await new Promise(r => setTimeout(r, 1000));
@@ -14161,7 +14168,7 @@ async function doRestart(name) {
     const MAX_POLLS = 58; // 1s warmup + 58 * 500ms ≈ 30s total
     for (let i = 0; i < MAX_POLLS; i++) {
       try {
-        const r = await fetch(SINGLE_URL);
+        const r = await fetch(INFO_URL);
         if (r.status === 404) {
           showToast('Session no longer exists');
           return;

--- a/amux-server.py
+++ b/amux-server.py
@@ -1498,10 +1498,14 @@ def _claude_ui_visible(clean_output: str) -> bool:
         ls = l.strip().lower()
         if "\u23f5\u23f5" in l or "bypass permissions" in ls or "plan mode" in ls:
             return True
-    # Check last 12 lines for an active spinner (dingbat + ellipsis)
+    # Check last 12 lines for an active spinner (dingbat-prefixed status line
+    # like "\u273b Crunched for 1m 38s"). Exclude U+276F \u276f \u2014 that's Claude's input
+    # prompt, also the user's typed input in scrollback. After /exit, lines
+    # like "\u276f /exit" stay in scrollback within this 12-line window and were
+    # tripping a false positive that made is_running() return True forever.
     for l in lines[-12:]:
         s = l.strip()
-        if s and "\u2700" <= s[0] <= "\u27bf":
+        if s and "\u2700" <= s[0] <= "\u27bf" and s[0] != "\u276f":
             return True
     return False
 

--- a/amux-server.py
+++ b/amux-server.py
@@ -14173,11 +14173,14 @@ async function doRestart(name) {
     // stop_session keeps tmux alive. /info uses is_running() which correctly
     // returns false once Claude exits.
     // Worst case server-side stop is ~21s (rename + 15s exit + 1s settle), so
-    // poll for 30s with a 1s warmup before the first poll.
+    // poll for 30s with a 1s warmup before the first poll. Use a wall-clock
+    // deadline rather than an iteration count: with a 3s per-poll timeout,
+    // a fixed 60-iter loop would actually run for >3 minutes if the network
+    // is hanging.
     await new Promise(r => setTimeout(r, 1000));
     let stopped = false;
-    const MAX_POLLS = 58; // 1s warmup + 58 * 500ms ≈ 30s total
-    for (let i = 0; i < MAX_POLLS; i++) {
+    const deadline = Date.now() + 30000;
+    while (Date.now() < deadline) {
       try {
         const r = await _fetchTimeout(INFO_URL, 3000);
         if (r.status === 404) {
@@ -14191,6 +14194,7 @@ async function doRestart(name) {
       } catch (e) {
         // Network blip — keep polling.
       }
+      if (Date.now() >= deadline) break;
       await new Promise(r => setTimeout(r, 500));
     }
     if (!stopped) {

--- a/amux-server.py
+++ b/amux-server.py
@@ -14115,6 +14115,17 @@ async function copyMoshCmd(name) {
 // can't pile up overlapping polling loops + queued /start commands.
 const _restartingSessions = new Set();
 
+// fetch() with a hard timeout, so a hanging network request can't trap the
+// caller inside an await. Using AbortController + setTimeout instead of
+// AbortSignal.timeout() for broader Safari/iOS compat (AbortSignal.timeout
+// is Safari 16+; AbortController is universal). Aborts surface as a
+// DOMException, which the caller's try/catch handles like any network error.
+function _fetchTimeout(url, ms) {
+  const ctl = new AbortController();
+  const t = setTimeout(() => ctl.abort(), ms);
+  return fetch(url, { signal: ctl.signal }).finally(() => clearTimeout(t));
+}
+
 async function doRestart(name) {
   if (_restartingSessions.has(name)) {
     showToast('Restart already in progress');
@@ -14134,7 +14145,7 @@ async function doRestart(name) {
     let alreadyStopped = false;
     let sessionGone = false;
     try {
-      const pre = await fetch(INFO_URL, { signal: AbortSignal.timeout(5000) });
+      const pre = await _fetchTimeout(INFO_URL, 5000);
       if (pre.status === 404) {
         sessionGone = true;
       } else if (pre.ok) {
@@ -14168,7 +14179,7 @@ async function doRestart(name) {
     const MAX_POLLS = 58; // 1s warmup + 58 * 500ms ≈ 30s total
     for (let i = 0; i < MAX_POLLS; i++) {
       try {
-        const r = await fetch(INFO_URL, { signal: AbortSignal.timeout(3000) });
+        const r = await _fetchTimeout(INFO_URL, 3000);
         if (r.status === 404) {
           showToast('Session no longer exists');
           return;


### PR DESCRIPTION
## Summary

The dashboard's "Restart" button (running session card → Restart, card menu → Restart) leaves the tmux pane at a bare shell prompt — Claude is killed by /stop but never relaunched. User has to manually run `claude` in the pane to recover.

## Root cause

Two interacting bugs in two layers, both required to reproduce:

### Layer 1: dashboard polled the wrong endpoint

Three commits combined into a deadlock:
1. `51c6f7c` (Feb 22) — `/api/sessions` list endpoint changed `running` from `is_running(name)` to `tmux_name(name) in tmux_info` (perf optimization, 100×).
2. `bb1f935` (Apr 8) — `doRestart` added; polled `fetchSessions()` for `s.running === false` then called `doStart`.
3. `stop_session` design — keeps tmux alive (only kills Claude, not the pane).

Result: after /stop, the list endpoint's `running` stays `true` forever (tmux is alive). Polling timed out at 20s, fired `showToast("Stop didn't take effect, try again")`, and skipped `doStart` entirely.

### Layer 2: even the "right" endpoint was lying

The single-session endpoint `/api/sessions/{name}/info` uses `is_running()` which calls `_claude_ui_visible()` to detect "Claude UI present in last 12 lines of pane". That check matched ANY line starting with a dingbat character (`✀`–`➿`). The Claude prompt char `❯` (U+276F) is in that range — so the user's `❯ /exit` input sits in scrollback within the 12-line window and trips the heuristic forever after Claude exits.

This second bug also affected `stop_session`: it uses the same `_at_shell_prompt` detector to know when Claude has exited, so every restart was hitting the 15s graceful-exit timeout and falling through to hard-kill, even when Claude exited cleanly in <1s.

## Empirical confirmation

```
2026-04-28 01:52:48 [phone] POST /api/sessions/scripts-4/stop 202 8ms
(no matching POST /start anywhere)
~01:54   user manually ran 'claude --dangerously-skip-permissions' to recover
```

Live verification on `coaching` session:
- Before fix: `/info` reported `running:true` for 30s+ after /stop, polling timed out, /start short-circuited with "already running" because `is_running` was lying. Claude actually died and was never relaunched.
- After fix: `/info` flipped to `false` at T+1.2s after /stop. Polling exited cleanly, /start fired and relaunched Claude.

Headless WebKit run via Playwright (`window.doRestart('coaching')` called directly):
- T+1.07s: `running=false` observed
- T+5.28s: `running=true` again — full restart cycle in 5.3s
- 0 page errors / 0 console errors / 0 console warnings / 0 request failures

## Fix

**JS (commits 1–5):** switch `doRestart` poll target from `fetchSessions()` (list) to `/api/sessions/{name}/info` (single). Plus hardening from successive panel review rounds:
- Pre-check for already-stopped → skip /stop entirely (avoids TOCTOU where `_bg_stop` kills a freshly-launched Claude)
- Bare `fetch` with explicit 404 handling (apiCall returns null on 4xx and toasts a generic error)
- Module-level Set guards against overlapping calls from card menu + peek menu
- `AbortController + setTimeout` for hard fetch timeouts (Safari 16 compat over `AbortSignal.timeout()`)
- Wall-clock deadline instead of fixed iteration count (so 3s per-poll timeout doesn't extend the 30s window to 3 min)
- Polling window 30s with 1s warmup, since worst-case `stop_session` is ~21s

**Python (commit 6):** exclude `❯` from `_claude_ui_visible`'s dingbat-prefix scan. Real spinner chars are `✻ ✶ ⏺ ✦` etc. — never `❯` — so this removes a false positive without breaking genuine spinner detection.

## Out of scope

- Semantic inconsistency between list endpoint (line 4576: tmux-existence) and single endpoint (line 4609: process-state). Worth a follow-up to either fix the list endpoint with a TTL cache on `is_running`, or rename the keys. Not bundled here.
- Bash CLI `amux restart` (line ~2494). Already works via RLock serialization in `_get_session_lock` — no change needed, even with the `_claude_ui_visible` bug, because RLock blocks /start until _bg_stop completes.
- Auto-restart watcher (line 1622-1636). Calls `start_session` directly. The `_claude_ui_visible` fix actually helps it too — previously the watcher couldn't detect Claude exits cleanly on sessions where `❯ <last input>` was still in scrollback.

## Test plan

- [x] **Server-side `is_running()` correctly flips false ~1s after `/exit`** — verified with curl on `coaching`, `/info` returns `running:false` at T+1.2s
- [x] **Full restart cycle via API** — /stop → /info flips false → /start succeeds → Claude relaunched, `start_count` increments (14 → 15 → 16 → 17 across three runs)
- [x] **Dashboard JS in headless WebKit** — Playwright loaded the dashboard, called `window.doRestart('coaching')`, observed full cycle in 5.3s with 0 page/console errors. Verifies the fixed JS parses and runs end-to-end in the browser engine the PWA actually targets.
- [ ] Manual: dashboard Restart on session whose Claude already crashed → pre-check fires, skips /stop, doStart launches Claude
- [ ] Manual: dashboard Restart, immediately click again → second click toasts "Restart already in progress"
- [ ] Manual: dashboard Restart on non-existent session → "Session no longer exists" toast within 1s

🤖 Generated with [Claude Code](https://claude.com/claude-code)