### PR TITLE
feat: --bind host[,host,...] for amux serve + network exposure docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,4 +252,33 @@ See how amux compares to other AI coding tools:
 
 ## Security
 
-Local-first. No auth built in — use Tailscale or bind to localhost. Never expose port 8822 to the internet.
+Local-first. No auth built in — use Tailscale or bind to localhost. **Never expose port 8822 to the internet.**
+
+### Network exposure & `--bind`
+
+`amux serve` binds to `0.0.0.0` by default. On a workstation behind a router this is fine; on a public VPS it makes the dashboard reachable from the internet the moment the server starts. Verify with `ss -tlnp | grep 8822` after launch, and `curl -k https://<public-ip>:8822/` from outside.
+
+Restrict the listening interfaces with `--bind` (comma-separated list of IPs):
+
+```bash
+amux serve                                   # default: 0.0.0.0 (all interfaces)
+amux serve 8822 --bind 127.0.0.1             # loopback only
+amux serve 8822 --bind 127.0.0.1,100.64.0.5  # loopback + Tailscale IP
+amux serve 8822 --bind 127.0.0.1,172.17.0.1  # loopback + docker0 (containers)
+amux serve 8822 --bind 0.0.0.0               # opt in to every interface
+```
+
+One HTTPS server (and one HTTP cert helper on `port+1`) is spawned per listed host. `amux serve 8822` with no `--bind` keeps the current behavior.
+
+### Firewall (belt-and-braces)
+
+Even with `--bind`, a firewall rule is recommended on multi-homed hosts. Example for `iptables` (allow localhost + docker0, drop the rest):
+
+```bash
+sudo iptables -I INPUT -p tcp --dport 8822 -s 127.0.0.1     -j ACCEPT
+sudo iptables -I INPUT -p tcp --dport 8822 -s 172.17.0.0/16 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 8822 -j DROP
+sudo netfilter-persistent save   # survive reboot (Debian/Ubuntu)
+```
+
+Validate the lockdown from outside the host: `curl -k --connect-timeout 4 https://<public-ip>:8822/` should time out.

--- a/amux
+++ b/amux
@@ -932,6 +932,38 @@ EOF
 }
 
 cmd_serve() {
+  # --help / -h short-circuit
+  for _a in "$@"; do
+    case "$_a" in
+      -h|--help|help)
+        cat <<EOF
+${BOLD}amux serve${RESET} - start the web dashboard (HTTPS by default)
+
+${BOLD}Usage:${RESET}
+  amux serve [port] [--bind host[,host,...]] [--no-tls]
+
+${BOLD}Args:${RESET}
+  port                  TCP port to listen on (default: 8822). Cert helper uses port+1.
+  --bind host[,host..]  Comma-separated list of interface IPs to bind. Default: 0.0.0.0
+                        (every interface). Pass 127.0.0.1 to restrict to loopback,
+                        or e.g. 127.0.0.1,172.17.0.1 for loopback + docker0.
+  --no-tls              Serve plain HTTP instead of HTTPS (offline mode/PWA needs HTTPS).
+
+${BOLD}Examples:${RESET}
+  amux serve
+  amux serve 8822
+  amux serve 8822 --bind 127.0.0.1
+  amux serve 8822 --bind 127.0.0.1,172.17.0.1
+  amux serve 9000 --no-tls
+
+${BOLD}Security note:${RESET} the default 0.0.0.0 bind exposes the dashboard on every
+network interface this host is connected to (including public Wi-Fi LANs and
+public IPs). Use --bind to restrict, or layer a firewall rule on top.
+EOF
+        return 0
+        ;;
+    esac
+  done
   # Resolve cc-server.py relative to the real location of this script
   local script_dir
   script_dir="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")")" && pwd)"

--- a/amux
+++ b/amux
@@ -932,7 +932,6 @@ EOF
 }
 
 cmd_serve() {
-  local port="${1:-8822}"
   # Resolve cc-server.py relative to the real location of this script
   local script_dir
   script_dir="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")")" && pwd)"
@@ -941,7 +940,8 @@ cmd_serve() {
   [[ -f "$server" ]] || server="$script_dir/cc-server.py"
   [[ -f "$server" ]] || die "amux-server.py not found at $script_dir"
   command -v python3 &>/dev/null || die "python3 is required for amux serve"
-  exec python3 "$server" "$port"
+  # Pass all args through: amux-server.py parses the positional port and any --bind flag.
+  exec python3 "$server" "$@"
 }
 
 cmd_help() {
@@ -972,7 +972,7 @@ ${BOLD}Dashboard:${RESET}
   amux                           Interactive dashboard (optimized for phone)
 
 ${BOLD}Web Dashboard:${RESET}
-  amux serve [port]              Start web dashboard (default: 8822)
+  amux serve [port] [--bind host[,host,...]]  Start web dashboard (default: 8822, all interfaces)
 
 ${BOLD}Board:${RESET}
   amux board ls                  List all board issues

--- a/amux-server.py
+++ b/amux-server.py
@@ -36483,17 +36483,19 @@ def main():
     slog(f"[startup] server starting — pid={os.getpid()}, port={port}, scheme={scheme}, python={sys.version.split()[0]}")
     _log_resource_snapshot("startup")
     print("\033[1m\033[34mamux\033[0m web dashboard running")
-    print(f"  Bind:    {', '.join(bind_hosts)}:{port}")
+    print(f"  Bind:    {', '.join(f'{h}:{port}' for h in bind_hosts)}")
     if "0.0.0.0" in bind_hosts:
         print("\033[33m  ⚠ Bound to 0.0.0.0 — reachable on every network interface (incl. public IP).\033[0m")
         print(f"\033[33m    Restrict with: amux serve {port} --bind 127.0.0.1[,<other-ips>]\033[0m")
     print(f"  Local:   {scheme}://localhost:{port}")
     if ts_hostname:
         print(f"  Tailscale: {scheme}://{ts_hostname}:{port}")
-    print(f"  Network: {scheme}://{lan_ip}:{port}")
+    _net_reachable = "0.0.0.0" in bind_hosts or lan_ip in bind_hosts
+    if _net_reachable:
+        print(f"  Network: {scheme}://{lan_ip}:{port}")
     if ts_hostname:
         print(f"\n  Open on your phone → \033[1m{scheme}://{ts_hostname}:{port}\033[0m")
-    else:
+    elif _net_reachable:
         print(f"\n  Open on your phone → {scheme}://{lan_ip}:{port}")
     if scheme == "https":
         if ts_hostname:

--- a/amux-server.py
+++ b/amux-server.py
@@ -36386,6 +36386,23 @@ def main():
     #   amux serve 8822
     #   amux serve 8822 --bind 127.0.0.1
     #   amux serve 8822 --bind 127.0.0.1,172.17.0.1
+    if any(a in ("-h", "--help") for a in sys.argv[1:]):
+        print(
+            "Usage: amux-server.py [port] [--bind host[,host,...]] [--no-tls]\n"
+            "\n"
+            "  port                  TCP port to listen on (default: 8822).\n"
+            "                        The cert helper uses port+1.\n"
+            "  --bind host[,host..]  Comma-separated list of interface IPs to bind.\n"
+            "                        Default: 0.0.0.0 (every interface). Pass 127.0.0.1\n"
+            "                        to restrict to loopback, or e.g.\n"
+            "                        127.0.0.1,172.17.0.1 for loopback + docker0.\n"
+            "  --no-tls              Serve plain HTTP instead of HTTPS.\n"
+            "\n"
+            "Default 0.0.0.0 exposes the dashboard on every interface this host is\n"
+            "attached to (incl. public Wi-Fi LANs and public IPs). Use --bind to\n"
+            "restrict, or add a firewall rule on top."
+        )
+        return
     port = 8822
     bind_hosts = ["0.0.0.0"]
     _args = sys.argv[1:]

--- a/amux-server.py
+++ b/amux-server.py
@@ -36380,7 +36380,26 @@ def _kill_stale_port(port: int):
 
 
 def main():
-    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8822
+    # CLI: optional positional port, optional --bind host[,host,...]
+    # Examples:
+    #   amux serve
+    #   amux serve 8822
+    #   amux serve 8822 --bind 127.0.0.1
+    #   amux serve 8822 --bind 127.0.0.1,172.17.0.1
+    port = 8822
+    bind_hosts = ["0.0.0.0"]
+    _args = sys.argv[1:]
+    _i = 0
+    while _i < len(_args):
+        _a = _args[_i]
+        if _a == "--bind" and _i + 1 < len(_args):
+            bind_hosts = [h.strip() for h in _args[_i + 1].split(",") if h.strip()]
+            _i += 2
+        elif _a.isdigit():
+            port = int(_a)
+            _i += 1
+        else:
+            _i += 1
     lan_ip = get_lan_ip()
     no_tls = "--no-tls" in sys.argv
 
@@ -36409,17 +36428,20 @@ def main():
     # Pre-configure ~/.claude.json to skip interactive setup wizard
     _init_claude_config()
 
-    # Retry binding in case port is in TIME_WAIT after a restart
-    for _attempt in range(10):
-        try:
-            server = ResilientHTTPSServer(("0.0.0.0", port), CCHandler)
-            break
-        except OSError as e:
-            if e.errno == 48 and _attempt < 9:  # Address already in use
-                slog(f"[startup] port {port} busy, retrying ({_attempt + 1}/10)...")
-                time.sleep(2)
-            else:
-                raise
+    # Bind one HTTPS server per host in bind_hosts. Retry on TIME_WAIT after restart.
+    servers = []
+    for _host in bind_hosts:
+        for _attempt in range(10):
+            try:
+                servers.append(ResilientHTTPSServer((_host, port), CCHandler))
+                break
+            except OSError as e:
+                if e.errno == 48 and _attempt < 9:  # Address already in use
+                    slog(f"[startup] {_host}:{port} busy, retrying ({_attempt + 1}/10)...")
+                    time.sleep(2)
+                else:
+                    raise
+    server = servers[0]  # primary: used by file watcher & graceful shutdown
 
     scheme = "http"
     ts_hostname = ""
@@ -36434,7 +36456,8 @@ def main():
                     if server_name != ts_hostname:
                         sock.context = fb_ctx
                 ctx.sni_callback = _sni_cb
-            server.ssl_ctx = ctx  # per-connection TLS in process_request_thread()
+            for _s in servers:
+                _s.ssl_ctx = ctx  # per-connection TLS in process_request_thread()
             scheme = "https"
         except Exception as e:
             print(f"\033[33m  TLS setup failed ({e}), falling back to HTTP\033[0m")
@@ -36443,6 +36466,10 @@ def main():
     slog(f"[startup] server starting — pid={os.getpid()}, port={port}, scheme={scheme}, python={sys.version.split()[0]}")
     _log_resource_snapshot("startup")
     print("\033[1m\033[34mamux\033[0m web dashboard running")
+    print(f"  Bind:    {', '.join(bind_hosts)}:{port}")
+    if "0.0.0.0" in bind_hosts:
+        print("\033[33m  ⚠ Bound to 0.0.0.0 — reachable on every network interface (incl. public IP).\033[0m")
+        print(f"\033[33m    Restrict with: amux serve {port} --bind 127.0.0.1[,<other-ips>]\033[0m")
     print(f"  Local:   {scheme}://localhost:{port}")
     if ts_hostname:
         print(f"  Tailscale: {scheme}://{ts_hostname}:{port}")
@@ -36467,7 +36494,7 @@ def main():
 
     # Plain HTTP cert server (so phones can fetch cert before trusting it)
     if scheme == "https":
-        def _cert_server(port):
+        def _cert_server(port, _host):
             from http.server import HTTPServer, BaseHTTPRequestHandler
             class H(BaseHTTPRequestHandler):
                 def do_GET(self):
@@ -36504,13 +36531,14 @@ def main():
                 allow_reuse_port = True
             for _att in range(10):
                 try:
-                    IPv4HTTPServer(("0.0.0.0", port + 1), H).serve_forever()
+                    IPv4HTTPServer((_host, port + 1), H).serve_forever()
                     break
                 except OSError:
                     if _att < 9:
                         time.sleep(2)
                     # silently give up after retries — cert server is optional
-        threading.Thread(target=_cert_server, args=(port,), daemon=True).start()
+        for _h in bind_hosts:
+            threading.Thread(target=_cert_server, args=(port, _h), daemon=True).start()
         print(f"  Cert:    http://{lan_ip}:{port + 1}/api/cert")
 
     # Register all recurring jobs with the unified scheduler
@@ -36546,11 +36574,18 @@ def main():
     # Warm the metrics cache in background so first UI open is fast
     threading.Thread(target=_refresh_metrics_cache, daemon=True).start()
 
+    # Run secondary servers in background threads; primary in main thread
+    for _s in servers[1:]:
+        threading.Thread(target=_s.serve_forever, daemon=True).start()
     try:
         server.serve_forever()
     except KeyboardInterrupt:
         print("\n\033[2mStopped.\033[0m")
-        server.server_close()
+        for _s in servers:
+            try:
+                _s.server_close()
+            except Exception:
+                pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #30.

## Summary
- Adds a `--bind` flag to `amux serve` that accepts a comma-separated list of host addresses. One HTTPS server (and one HTTP cert helper on `port+1`) is spawned per listed address.
- Default behavior is **unchanged** (`0.0.0.0`), so Tailscale / LAN / mobile PWA workflows keep working with zero migration.
- Prints a startup warning when the bind list contains `0.0.0.0`, pointing at `--bind` as the way to restrict the listeners.
- Expands the `Security` section in `README.md` with a `Network exposure & --bind` subsection and a firewall example.

## Why
The current behavior is fine on a workstation behind a router, but `0.0.0.0` means *reachable on every interface this host is attached to*. Concretely:
- On a public VPS, the dashboard is reachable from the internet the moment `amux serve` starts.
- On a laptop joined to cafe / coworking / hotel / conference Wi-Fi, every other client on that LAN can reach `http(s)://<laptop-ip>:8822`. Combined with `--yolo` sessions that bypass permission prompts, this lets anyone on the same Wi-Fi drive the agents (send prompts, claim board tasks, peek output, browse session working dirs through the file explorer).

`--bind` lets users opt into the narrower exposure they actually need without losing the mobile / Tailscale flow that depends on a real network bind.

## CLI shape
```bash
amux serve                                   # default: 0.0.0.0 (all interfaces) - unchanged
amux serve 8822                              # bare port (unchanged)
amux serve 8822 --bind 127.0.0.1             # loopback only
amux serve 8822 --bind 127.0.0.1,100.64.0.5  # loopback + Tailscale IP
amux serve 8822 --bind 127.0.0.1,172.17.0.1  # loopback + docker0 (containers reach it)
amux serve 8822 --bind 0.0.0.0               # explicit opt-in to every interface
```

Positional port stays the first numeric arg; flag order is free. `--no-tls` and other existing flags are untouched.

## Implementation
`amux-server.py`:
- New small arg-parsing loop in `main()` that recognizes `--bind` and a positional port; leaves `sys.argv` intact so other `\"--flag\" in sys.argv` checks elsewhere keep working.
- `ResilientHTTPSServer` is now created per host into a `servers` list; the first is treated as "primary" (used by the file-watcher / graceful shutdown path); the rest run in background threads.
- `server.ssl_ctx = ctx` is applied to every server in the list.
- Cert helper (`_cert_server`) takes a host parameter and is launched once per bind address.
- Startup banner adds a `Bind:    <hosts>:<port>` line and a yellow warning when `0.0.0.0` is in the list.

`README.md`:
- Expands the existing one-line `Security` section with two subsections: `Network exposure & --bind` and `Firewall (belt-and-braces)`.

## Test plan
- [x] `python3 -c \"import ast; ast.parse(open('amux-server.py').read())\"` - syntax clean
- [x] `amux serve 18822 --bind 127.0.0.1 --no-tls` - one listener on `127.0.0.1:18822`, HTTP 200 from localhost, public IP refused
- [x] `amux serve 18822 --bind 127.0.0.1,172.17.0.1 --no-tls` - two listeners on same pid (one per addr), both reachable from their own iface, public IP refused
- [x] `amux serve 18822 --bind 0.0.0.0 --no-tls` - listener on `0.0.0.0`, warning banner printed
- [x] `amux serve 8822` (no `--bind`) - unchanged: bound to `0.0.0.0`, current behavior

## Notes for reviewers
- I chose to keep `0.0.0.0` as the default (rather than making this a breaking change to localhost-only) because the mobile PWA / Tailscale story specifically needs a non-loopback bind. The warning + docs route is the minimum-friction path.