### PR TITLE
[codex] Fix release notes pagination and path containment

### DIFF
--- a/amux-server.py
+++ b/amux-server.py
@@ -80,6 +80,14 @@ def _safe_note_path(note_rel: str, base: Path = None) -> Path | None:
         return None  # traversal detected
     return candidate
 
+def _path_is_within(path: Path, base: Path) -> bool:
+    """Return True when path resolves inside base, not just under a string prefix."""
+    try:
+        path.resolve().relative_to(base.resolve())
+        return True
+    except (OSError, ValueError):
+        return False
+
 # ── Filesystem access control ────────────────────────────────────────────────
 _SENSITIVE_PATHS = {".ssh", ".gnupg", ".aws", ".kube", ".netrc", ".npmrc",
                     ".docker", ".config/gcloud", ".config/gh"}
@@ -31722,13 +31730,13 @@ class CCHandler(BaseHTTPRequestHandler):
             if not file_path:
                 return self._json({"error": "path required"}, 400)
             # Security: ensure file is within download dir
-            real = os.path.realpath(file_path)
-            if not real.startswith(os.path.realpath(_ARIA2_DOWNLOAD_DIR)):
+            real = Path(file_path).expanduser().resolve()
+            if not _path_is_within(real, Path(_ARIA2_DOWNLOAD_DIR).expanduser().resolve()):
                 return self._json({"error": "forbidden"}, 403)
-            if not os.path.isfile(real):
+            if not real.is_file():
                 return self._json({"error": "file not found"}, 404)
             # Determine content type
-            ext = os.path.splitext(real)[1].lower()
+            ext = real.suffix.lower()
             ct_map = {
                 ".mp4": "video/mp4", ".mkv": "video/x-matroska", ".avi": "video/x-msvideo",
                 ".mov": "video/quicktime", ".webm": "video/webm", ".m4v": "video/mp4",
@@ -31736,7 +31744,7 @@ class CCHandler(BaseHTTPRequestHandler):
                 ".pdf": "application/pdf",
             }
             ct = ct_map.get(ext, "application/octet-stream")
-            fsize = os.path.getsize(real)
+            fsize = real.stat().st_size
             # Support range requests for video streaming
             range_hdr = self.headers.get("Range")
             if range_hdr:
@@ -31753,7 +31761,7 @@ class CCHandler(BaseHTTPRequestHandler):
                     self.send_header("Content-Length", str(length))
                     self.send_header("Accept-Ranges", "bytes")
                     self.end_headers()
-                    with open(real, "rb") as fp:
+                    with real.open("rb") as fp:
                         fp.seek(start)
                         remaining = length
                         while remaining > 0:
@@ -31768,10 +31776,10 @@ class CCHandler(BaseHTTPRequestHandler):
             self.send_header("Content-Type", ct)
             self.send_header("Content-Length", str(fsize))
             self.send_header("Accept-Ranges", "bytes")
-            fname = os.path.basename(real)
+            fname = real.name
             self.send_header("Content-Disposition", f'inline; filename="{fname}"')
             self.end_headers()
-            with open(real, "rb") as fp:
+            with real.open("rb") as fp:
                 while True:
                     chunk = fp.read(65536)
                     if not chunk:
@@ -32055,12 +32063,11 @@ class CCHandler(BaseHTTPRequestHandler):
 
         # GET /api/release-notes — paginated JSON from docs/release-notes/notes.json
         if method == "GET" and path.startswith("/api/release-notes"):
-            qs = {}
-            if "?" in path:
-                import urllib.parse as _up
-                qs = dict(_up.parse_qsl(path.split("?", 1)[1]))
-            page = int(qs.get("page", "1"))
-            per_page = int(qs.get("per_page", "6"))
+            try:
+                page = max(1, int((qs.get("page") or ["1"])[0]))
+                per_page = max(1, min(100, int((qs.get("per_page") or ["6"])[0])))
+            except (TypeError, ValueError):
+                return self._json({"error": "invalid pagination"}, 400)
             notes_file = Path(__file__).parent / "docs" / "release-notes" / "notes.json"
             if notes_file.exists():
                 all_notes = json.loads(notes_file.read_text())
@@ -32224,7 +32231,7 @@ class CCHandler(BaseHTTPRequestHandler):
                 sub = qs.get("path", [""])[0]
                 target = (work / sub).resolve()
                 # Prevent path traversal
-                if not str(target).startswith(str(work)):
+                if not _path_is_within(target, work):
                     return self._json({"error": "invalid path"}, 400)
                 if target.is_file():
                     try:

--- a/tests/test_release_notes_and_path_containment.py
+++ b/tests/test_release_notes_and_path_containment.py
@@ -1,0 +1,94 @@
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).parent.parent
+SERVER_PATH = REPO_ROOT / "amux-server.py"
+
+
+@pytest.fixture(scope="module")
+def amux_server():
+    # Windows Python cannot import POSIX-only terminal modules used by live
+    # PTY routes. These tests do not exercise PTY behavior, so lightweight
+    # stubs keep the production module importable.
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setenv("AMUX_AUTH_TOKEN", "none")
+
+        pty_stub = types.ModuleType("pty")
+        pty_stub.fork = lambda: (_ for _ in ()).throw(NotImplementedError("pty unavailable"))
+        fcntl_stub = types.ModuleType("fcntl")
+        fcntl_stub.F_GETFL = 3
+        fcntl_stub.F_SETFL = 4
+        fcntl_stub.fcntl = lambda *args, **kwargs: 0
+        fcntl_stub.ioctl = lambda *args, **kwargs: 0
+        termios_stub = types.ModuleType("termios")
+        termios_stub.TIOCSWINSZ = 0x5414
+
+        mp.setitem(sys.modules, "pty", pty_stub)
+        mp.setitem(sys.modules, "fcntl", fcntl_stub)
+        mp.setitem(sys.modules, "termios", termios_stub)
+
+        spec = importlib.util.spec_from_file_location("amux_server_release_notes", SERVER_PATH)
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["amux_server_release_notes"] = mod
+        spec.loader.exec_module(mod)
+        yield mod
+
+
+def _handler_for_json(amux_server):
+    handler = object.__new__(amux_server.CCHandler)
+    calls = []
+
+    def _json(data, status=200):
+        calls.append((status, data))
+        return data
+
+    handler._check_auth = lambda method, path: True
+    handler._json = _json
+    handler._html = lambda html: html
+    return handler, calls
+
+
+def test_release_notes_route_uses_parsed_query_string(amux_server):
+    handler, calls = _handler_for_json(amux_server)
+    result = amux_server.CCHandler._route_inner(
+        handler,
+        "GET",
+        "/api/release-notes",
+        {"page": ["2"], "per_page": ["3"]},
+    )
+
+    all_notes = json.loads((REPO_ROOT / "docs" / "release-notes" / "notes.json").read_text())
+    assert result["page"] == 2
+    assert result["per_page"] == 3
+    assert result["notes"] == all_notes[3:6]
+    assert calls == [(200, result)]
+
+
+def test_release_notes_route_rejects_invalid_pagination(amux_server):
+    handler, calls = _handler_for_json(amux_server)
+    result = amux_server.CCHandler._route_inner(
+        handler,
+        "GET",
+        "/api/release-notes",
+        {"page": ["not-a-number"]},
+    )
+
+    assert result == {"error": "invalid pagination"}
+    assert calls == [(400, result)]
+
+
+def test_path_is_within_rejects_prefix_sibling(tmp_path, amux_server):
+    base = tmp_path / "work"
+    sibling = tmp_path / "work2"
+    base.mkdir()
+    sibling.mkdir()
+
+    assert amux_server._path_is_within(base / "file.txt", base)
+    assert not amux_server._path_is_within(sibling / "secret.txt", base)


### PR DESCRIPTION
Fixes release notes pagination query handling and canonical path containment checks for file routes. Validation: focused pytest suite passed with 77 tests; py_compile passed.