### PR TITLE
feat: add AMUX_CLAUDE_CMD override and --dry-run flag

### DIFF
--- a/amux
+++ b/amux
@@ -104,9 +104,10 @@ load_defaults() {
   if [[ -f "$_se" ]]; then
     local _k _v
     while IFS='=' read -r _k _v; do
-      _k="${_k## }"; _k="${_k%% }"
-      _v="${_v## }"; _v="${_v%% }"
-      _v="${_v%$'\r'}"          # tolerate CRLF line endings
+      # Trim all leading/trailing whitespace (matches Python's .strip()).
+      # Standard glob [![:space:]] — no extglob needed.
+      _k="${_k#"${_k%%[![:space:]]*}"}"; _k="${_k%"${_k##*[![:space:]]}"}"
+      _v="${_v#"${_v%%[![:space:]]*}"}"; _v="${_v%"${_v##*[![:space:]]}"}"
       [[ -z "$_k" || "$_k" == \#* || -z "$_v" ]] && continue
       export "$_k=$_v"
     done < "$_se"
@@ -306,7 +307,9 @@ cmd_start() {
     dry_run=true
     shift
   done
-  need_tmux
+  # dry-run is a pure command preview — no tmux session is spawned, so the
+  # tmux dependency only matters for the real start path.
+  $dry_run || need_tmux
   load_defaults
   load_session "$name"
 

--- a/amux
+++ b/amux
@@ -95,6 +95,22 @@ load_session() {
 # Load global defaults
 load_defaults() {
   [[ -f "$CC_DEFAULTS" ]] && source "$CC_DEFAULTS"
+  # Load ~/.amux/server.env so CLI-spawned sessions see the same AMUX_* knobs
+  # the server process uses (e.g. AMUX_CLAUDE_CMD). Parsed manually rather than
+  # `source`d so values are never shell-expanded — mirrors the Python loader at
+  # the top of amux-server.py, which treats entries as literal key=value pairs
+  # and is safe for values containing $, backticks, etc.
+  local _se="$CC_HOME/server.env"
+  if [[ -f "$_se" ]]; then
+    local _k _v
+    while IFS='=' read -r _k _v; do
+      _k="${_k## }"; _k="${_k%% }"
+      _v="${_v## }"; _v="${_v%% }"
+      _v="${_v%$'\r'}"          # tolerate CRLF line endings
+      [[ -z "$_k" || "$_k" == \#* || -z "$_v" ]] && continue
+      export "$_k=$_v"
+    done < "$_se"
+  fi
 }
 
 # Get tmux session name (prefixed to avoid conflicts)
@@ -281,9 +297,15 @@ EOF
 }
 
 cmd_start() {
-  local name
+  local name dry_run=false
   name=$(resolve_session "${1:-}")
   shift 2>/dev/null || true
+  # Strip our own --dry-run flag(s) before inline claude args. Placed before
+  # `--` so `amux start NAME --dry-run -- --some-claude-flag` still works.
+  while [[ "${1:-}" == "--dry-run" ]]; do
+    dry_run=true
+    shift
+  done
   need_tmux
   load_defaults
   load_session "$name"
@@ -291,7 +313,7 @@ cmd_start() {
   local tname
   tname=$(tmux_name "$name")
 
-  if is_running "$name"; then
+  if ! $dry_run && is_running "$name"; then
     echo "${YELLOW}already running:${RESET} $name — attaching..."
     tmux attach-session -t "=$tname"
     return
@@ -326,7 +348,7 @@ cmd_start() {
       cmd="codex"
     fi
   else
-    cmd="claude"
+    cmd="${AMUX_CLAUDE_CMD:-claude}"
   fi
   # Apply global defaults from defaults.env (skip for codex — Claude flags don't apply)
   if [[ "$provider" != "codex" && -n "${CC_DEFAULT_FLAGS:-}" ]]; then
@@ -377,6 +399,11 @@ cmd_start() {
     if [[ -f "$HOME/.claude.json" ]] && grep -q '"oauthAccount"' "$HOME/.claude.json" 2>/dev/null; then
       shell_setup="${shell_setup}unset ANTHROPIC_API_KEY; "
     fi
+  fi
+  if $dry_run; then
+    echo "${BOLD}$name${RESET} in $dir"
+    echo "  ${DIM}$cmd${RESET}"
+    return
   fi
   tmux new-session -d -s "$tname" -n "$name" -c "$dir" "${shell_setup}cd $(printf '%q' "$dir"); $cmd"
   # Lock the window name so Claude can't overwrite it with escape sequences
@@ -991,7 +1018,8 @@ ${BOLD}amux${RESET} — phone-friendly Claude Code session manager ${DIM}v${CC_V
 
 ${BOLD}Session management:${RESET}
   amux register <name> [flags]   Register a session with Claude Code flags
-  amux start <name>              Start a registered session in tmux
+  amux start <name> [--dry-run]  Start a registered session in tmux
+                                (--dry-run: print the command without spawning)
   amux exec <name> [flags]       Register + start in one step
   amux stop <name>               Stop a running session
   amux rm <name>                 Remove a session (stops if running)

--- a/amux-server.py
+++ b/amux-server.py
@@ -8240,7 +8240,8 @@ def start_session(name: str, extra_flags: str = "", _skip_conv_id: bool = False)
                 cmd = f"gemini{_gemini_opts} --session-id {shlex.quote(gemini_session_id)}"
                 print(f"[start] {name}: gemini fresh start {gemini_session_id}")
         else:
-            cmd = "claude"
+            _custom_claude = os.environ.get("AMUX_CLAUDE_CMD", "").strip()
+            cmd = _custom_claude or "claude"
             if default_flags:
                 cmd += f" {_shell_quote_flags(default_flags)}"
             if flags:
@@ -8259,6 +8260,7 @@ def start_session(name: str, extra_flags: str = "", _skip_conv_id: bool = False)
             # Default to sonnet if no --model specified anywhere
             if "--model" not in cmd:
                 cmd += " --model sonnet"
+            print(f"[start] {name}: cmd={cmd}")
         try:
             tmux_sess = tmux_name(name)
             # Build shell setup string — skip Claude env cleanup for codex

--- a/amux-server.py
+++ b/amux-server.py
@@ -8260,7 +8260,11 @@ def start_session(name: str, extra_flags: str = "", _skip_conv_id: bool = False)
             # Default to sonnet if no --model specified anywhere
             if "--model" not in cmd:
                 cmd += " --model sonnet"
-            print(f"[start] {name}: cmd={cmd}")
+            # Only log when a custom executable is active — avoids leaking
+            # flags (e.g. --system-prompt, paths) into server logs, matching
+            # the codex/gemini paths which log provider+action only.
+            if _custom_claude:
+                print(f"[start] {name}: AMUX_CLAUDE_CMD={_custom_claude}")
         try:
             tmux_sess = tmux_name(name)
             # Build shell setup string — skip Claude env cleanup for codex


### PR DESCRIPTION
## Summary

Adds two features for customizing how sessions launch:

1. **`AMUX_CLAUDE_CMD`** — override the `claude` binary with a wrapper or alternative command, set via `~/.amux/server.env`.
2. **`--dry-run`** — preview the assembled command for `amux start` without spawning a tmux session.

## Motivation

There is currently no way to wrap the `claude` binary — it is hardcoded as `cmd = "claude"` in both code paths:

| Code path | Location |
|---|---|
| CLI (`amux start`) | `amux` (bash), `cmd_start()` |
| Server (`/api/sessions/.../start`) | `amux-server.py`, `start_session()` |

Existing mechanisms do not cover this gap:
- `CC_PROVIDER` switches between `claude`/`codex`/`gemini` but cannot replace the claude binary itself
- `CC_DEFAULT_FLAGS` / `CC_FLAGS` append flags but cannot swap the executable

Use cases: profiling wrappers, custom launch scripts, alternative claude-compatible CLIs, pre-launch environment setup.

## Changes

### `AMUX_CLAUDE_CMD` (both files)

```bash
# ~/.amux/server.env
AMUX_CLAUDE_CMD=/usr/local/bin/my-claude-wrapper
```

- **`amux` (bash):** `cmd="${AMUX_CLAUDE_CMD:-claude}"`
- **`amux-server.py`:** `_custom_claude or "claude"`

Treated as an unquoted literal (same trust level as the existing `claude`/`codex`/`gemini` literals). For wrappers that need arguments, write a wrapper script rather than embedding args in the env var.

### `server.env` loader in bash CLI (`amux`)

The Python server already loads `~/.amux/server.env` at startup (+ 15s reload thread). The bash CLI did **not** — it only sourced `defaults.env`. This meant `AMUX_*` settings were invisible to CLI-spawned sessions.

Added a manual parser (not `source`d) that mirrors the Python loader: values are treated as literal `key=value` pairs, safe for values containing `$`, backticks, etc. Includes CRLF tolerance.

### `--dry-run` flag (`amux` CLI)

```bash
$ amux start myproject --dry-run
myproject in ~/Dev/myproject
  claude --model sonnet
```

Shows the full assembled command (after all `CC_DEFAULT_FLAGS` / `CC_FLAGS` / inline args are applied) without creating a tmux session.

## Design decisions

- **Why not quote `AMUX_CLAUDE_CMD`?** It replaces the `claude` literal, which is also unquoted. `server.env` is a trusted file (same trust as `defaults.env`, which is `source`d directly). Quoting would be inconsistent with how `claude`/`codex`/`gemini` are handled.
- **`--model sonnet` default still applies.** If the wrapper is not claude-compatible, suppress it via `CC_DEFAULT_FLAGS=--model xxx` (the existing `if "--model" not in cmd` guard handles this).
- **`print(f"[start] {name}: cmd={cmd}")`** — the codex and gemini paths already print a `[start]` line. The claude path was the only one that did not; this fills that gap and surfaces the custom command in the server log.

## Verification

- `bash -n amux` — OK
- `python3 -c "import ast; ast.parse(open('amux-server.py').read())"` — OK
- `pytest tests/test_bash_quoting.py tests/test_shell_quote_flags.py` — 61 passed