### PR TITLE
fix(send): target the session's active pane so send-keys works on tmux 3.7b

### DIFF
--- a/amux
+++ b/amux
@@ -497,7 +497,7 @@ cmd_send() {
   # Check for --keys flag
   if [[ "${1:-}" == "--keys" ]]; then
     shift
-    tmux send-keys -t "=$tname" "$@"
+    tmux send-keys -t "=$tname:" "$@"
     echo "${GREEN}sent keys${RESET} to $name"
   else
     local text="$*"
@@ -505,9 +505,9 @@ cmd_send() {
     # Send text literally (-l), then Enter as a separate key after a short
     # delay. Claude Code's TUI buffers/debounces input; sending text and Enter
     # in one send-keys call lets Enter arrive before the text is processed.
-    tmux send-keys -t "=$tname" -l "$text"
+    tmux send-keys -t "=$tname:" -l "$text"
     sleep 0.05
-    tmux send-keys -t "=$tname" Enter
+    tmux send-keys -t "=$tname:" Enter
     echo "${GREEN}sent${RESET} to $name: $text"
   fi
 }


### PR DESCRIPTION
## Summary

`amux send <name>` and `amux send <name> --keys …` fail on **tmux 3.7b** with:

```
can't find pane: =amux-<name>
```

even though the session is running and `amux peek` reads it fine. This makes it
impossible to drive a session from the CLI (or anything built on `cmd_send`) on
that tmux version.

## Root cause

`cmd_send` targets the send-keys calls at a **bare session name**, `-t "=$tname"`:

```sh
tmux send-keys -t "=$tname" "$@"        # --keys
tmux send-keys -t "=$tname" -l "$text"
tmux send-keys -t "=$tname" Enter
```

On tmux 3.7b, `=<name>` as a **pane** target is rejected — a session name alone
is not a valid pane target there, so tmux reports `can't find pane`. Older tmux
versions resolved a bare `=<session>` to the session's active pane, which is why
this went unnoticed.

`cmd_peek` already does it the portable way — a **trailing colon**, `=$tname:`,
which resolves to the session's active window/pane:

```sh
tmux capture-pane -t "=$tname:" -p -S "-$lines"
```

So `send` and `peek` simply disagreed on the target syntax.

## Fix

Align `cmd_send` with `cmd_peek` by adding the trailing colon to all three
`send-keys` targets (`=$tname` → `=$tname:`). One-line-per-call, no behavior
change beyond correct pane resolution.

## Reproduction

```sh
# tmux 3.7b
amux register demo --dir /tmp/demo --model sonnet
amux start demo --detach
amux send demo "hello"        # before: can't find pane: =amux-demo
amux peek demo                # (peek was always fine)
```

Confirm the target resolves with the colon form:

```sh
tmux display-message -t "=amux-demo:" -p "#{session_name} #{pane_id}"
# amux-demo %1
tmux send-keys -t "=amux-demo" -l x    # can't find pane: =amux-demo
tmux send-keys -t "=amux-demo:" -l x   # ok
```

## Testing

- `tmux 3.7b` on macOS 26.5 (Apple Silicon), amux `v0.3.0`.
- After the change: `amux send` (text) and `amux send --keys Enter` both deliver
  to the running Claude Code TUI; verified the prompt received the input via
  `amux peek`.
- `amux peek` behavior unchanged (already used the colon form).

## Related observation (not addressed in this PR)

Separately, `amux start` / `start-all` exit non-zero in a **non-interactive**
shell (e.g. CI, a script, an agent driving amux). The session is created
correctly, but the final `tmux attach` step has no TTY and fails, so the exit
code is `1` and `start-all` stops after the first session. `--detach` still
creates the session but returns the same non-zero code. This looks like expected
behavior for interactive use; flagging only in case a clean exit code for
scripted/`--detach` callers is desirable. Happy to open a separate PR if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
