### PR TITLE
fix(walkthrough): restore the use-case chapter menu after the linear tour

### DIFF
--- a/amux-server.py
+++ b/amux-server.py
@@ -37849,7 +37849,10 @@ async function pullFromRemote(btn) {
     { revealTab: 'skills', action: function() { switchView('skills'); }, wait: 460,
       target: '#skills-view', targetFallback: '#tab-skills', pos: 'bottom',
       title: '8 — Skills: reusable workflows',
-      body: 'Package a workflow once and any agent can run it — deploy steps, review checklists, research harnesses. That’s your command center, set up. You’re ready.' }
+      body: 'Package a workflow once and any agent can run it — deploy steps, review checklists, research harnesses. That’s your command center, set up.' },
+    { menu: true,
+      title: 'That’s the core. Go deeper?',
+      body: 'Four short chapters — pick what matters to you. Each is under a minute.' }
   ];
   var _WT_CHAPTERS = {
     fleet: { label: '\u26A1 Run a fleet, not a chatbot', steps: [


### PR DESCRIPTION
## Summary
- `e24d42b` replaced the old 3-step-core + chapter menu with a flat 8-step linear tour, and dropped the `{ menu: true, ... }` step in the same array swap — the commit message never mentions removing it, so it reads as an oversight.
- That left `_WT_CHAPTERS` (fleet/phone/auto/build — the four use-case chapters) fully defined but unreachable: nothing set `menu: true` anymore to render the chapter-picker buttons.
- Re-appends the menu step as step 9, after the new 8-step tour, so "Go deeper?" and the four use-case chapters are reachable again.

## Test plan
- [ ] `python3 -c "import ast; ast.parse(open('amux-server.py').read())"` passes
- [ ] Open Settings → Walkthrough, click through all 8 steps, confirm a "That's the core. Go deeper?" step appears with 4 chapter buttons
- [ ] Pick a chapter, finish it, confirm it returns to the menu step with a checkmark on the completed chapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vH6N2vUWXJpEjCuHN9KU3