### PR TITLE
Add MiniMax provider to the session-aware Look up inference path

### DIFF
--- a/amux-server.py
+++ b/amux-server.py
@@ -1758,6 +1758,7 @@ _PROVIDER_LOOKUP_MODEL = {
     "claude": "haiku",
     "gemini": "gemini-2.5-flash-lite",
     "codex":  "gpt-5-mini",
+    "minimax": "MiniMax-M2.7",
 }
 
 
@@ -1794,6 +1795,40 @@ def _ollama_first_model() -> str:
     except Exception:
         pass
     return ""
+
+
+# MiniMax ships no first-party CLI, so its Look up shot rides the
+# OpenAI-compatible chat endpoint over HTTP. Two regions exist: the global
+# endpoint (api.minimax.io) and the China endpoint (api.minimaxi.com).
+_MINIMAX_OPENAI_BASE = {
+    "global_en": "https://api.minimax.io/v1",
+    "cn_zh":     "https://api.minimaxi.com/v1",
+}
+
+
+def _minimax_region(base_url: str) -> str:
+    """China (api.minimaxi.com) when the base URL names it, else global."""
+    return "cn_zh" if "minimaxi.com" in (base_url or "") else "global_en"
+
+
+def _minimax_session_endpoint(name: str) -> tuple:
+    """(openai_base_url, auth_token) for a MiniMax session's Look up shot.
+
+    Region follows whatever the session already points its base URL at, so a
+    session configured for the global or the China endpoint is honored as-is
+    (defaulting to global). Auth reuses the session's own token, kept in
+    ANTHROPIC_AUTH_TOKEN, and falls back to MINIMAX_API_KEY.
+    """
+    base = token = ""
+    try:
+        cfg = parse_env_file(CC_SESSIONS / f"{name}.env")
+        base = (cfg.get("ANTHROPIC_BASE_URL") or "").strip()
+        token = (cfg.get("ANTHROPIC_AUTH_TOKEN")
+                 or cfg.get("MINIMAX_API_KEY") or "").strip()
+    except Exception:
+        pass
+    token = token or os.environ.get("MINIMAX_API_KEY", "")
+    return (_MINIMAX_OPENAI_BASE[_minimax_region(base)], token)
 
 
 def _lookup_via_claude(prompt: str, timeout: int = 35) -> tuple:
@@ -1841,6 +1876,24 @@ def _lookup_via_provider(provider: str, prompt: str, name: str = "", timeout: in
                     capture_output=True, text=True, timeout=timeout, cwd=str(CC_HOME))
                 if r.returncode == 0 and r.stdout.strip():
                     return (r.stdout.strip(), "")
+        elif provider == "minimax":
+            base, token = _minimax_session_endpoint(name)
+            if token:
+                payload = json.dumps({
+                    "model": _PROVIDER_LOOKUP_MODEL["minimax"],
+                    "messages": [{"role": "user", "content": prompt}],
+                    "max_tokens": 400,
+                }).encode()
+                req = urllib.request.Request(
+                    f"{base}/chat/completions", data=payload, method="POST",
+                    headers={"Content-Type": "application/json",
+                             "Authorization": f"Bearer {token}"})
+                with urllib.request.urlopen(req, timeout=timeout) as resp:
+                    data = json.loads(resp.read().decode())
+                out = ((data.get("choices") or [{}])[0]
+                       .get("message", {}).get("content", "") or "").strip()
+                if out:
+                    return (out, "")
     except Exception:
         pass
     return ("", "")   # fall back to claude

--- a/tests/test_minimax_lookup.py
+++ b/tests/test_minimax_lookup.py
@@ -1,0 +1,59 @@
+"""MiniMax Look up inference-path checks.
+
+Loads the real definitions out of amux-server.py via AST (the same technique
+as test_peek_parity.py) so the session-aware Look up routing for a MiniMax
+session is covered without booting the whole server.
+"""
+
+import ast
+import os
+
+_SERVER = os.path.join(os.path.dirname(__file__), "..", "amux-server.py")
+_WANTED = {"_PROVIDER_LOOKUP_MODEL", "_MINIMAX_OPENAI_BASE", "_minimax_region"}
+
+
+def _load():
+    ns = {}
+    tree = ast.parse(open(_SERVER, encoding="utf-8").read())
+    for node in tree.body:
+        name = None
+        if isinstance(node, ast.FunctionDef):
+            name = node.name
+        elif isinstance(node, ast.Assign) and isinstance(node.targets[0], ast.Name):
+            name = node.targets[0].id
+        if name in _WANTED:
+            mod = ast.Module(body=[node], type_ignores=[])
+            exec(compile(mod, "amux-server.py", "exec"), ns)
+    missing = _WANTED - set(ns)
+    assert not missing, f"definitions not found: {missing}"
+    return ns
+
+
+NS = _load()
+_PROVIDER_LOOKUP_MODEL = NS["_PROVIDER_LOOKUP_MODEL"]
+_MINIMAX_OPENAI_BASE = NS["_MINIMAX_OPENAI_BASE"]
+_minimax_region = NS["_minimax_region"]
+
+
+def test_minimax_lookup_model_registered():
+    # The Look up shot rides the lighter model for a cheap, snappy answer.
+    assert _PROVIDER_LOOKUP_MODEL["minimax"] == "MiniMax-M2.7"
+
+
+def test_region_defaults_to_global():
+    # No base URL configured -> global endpoint.
+    assert _minimax_region("") == "global_en"
+    assert _minimax_region(None) == "global_en"
+    assert _MINIMAX_OPENAI_BASE["global_en"] == "https://api.minimax.io/v1"
+
+
+def test_region_follows_global_base_url():
+    assert _minimax_region("https://api.minimax.io/anthropic") == "global_en"
+    assert _MINIMAX_OPENAI_BASE[_minimax_region("https://api.minimax.io/anthropic")] \
+        == "https://api.minimax.io/v1"
+
+
+def test_region_follows_china_base_url():
+    assert _minimax_region("https://api.minimaxi.com/anthropic") == "cn_zh"
+    assert _MINIMAX_OPENAI_BASE[_minimax_region("https://api.minimaxi.com/anthropic")] \
+        == "https://api.minimaxi.com/v1"


### PR DESCRIPTION
Reason: A MiniMax-backed session was treated as an unknown provider in the Look up path and fell back to Claude instead of using MiniMax.

## What changed

The session-aware **Look up** inference path (`/api/lookup`) rides whatever
provider the peeked session already runs on, using that provider's lightest
model for a cheap, snappy answer. It had explicit handling for the existing
providers but none for MiniMax, so a MiniMax-backed session fell through to the
Claude fallback.

This adds first-class MiniMax handling in `amux-server.py`:

- Register `MiniMax-M2.7` as the Look up model for the `minimax` provider in
  `_PROVIDER_LOOKUP_MODEL` (the lighter of the two models — a cheap, snappy
  shot, consistent with the per-provider intent).
- Add `_minimax_region()` / `_MINIMAX_OPENAI_BASE` and
  `_minimax_session_endpoint()`, which resolve the OpenAI-compatible endpoint
  from the session's configured base URL: the China endpoint
  (`api.minimaxi.com`) when the session points there, otherwise the global
  endpoint (`api.minimax.io`). Auth reuses the session's own token
  (`ANTHROPIC_AUTH_TOKEN`), falling back to `MINIMAX_API_KEY`.
- Handle `provider == "minimax"` in `_lookup_via_provider()` by calling the
  OpenAI-compatible `chat/completions` endpoint over HTTP (MiniMax ships no
  first-party CLI). Any failure falls through to the existing Claude fallback,
  exactly like the other provider branches.

No session-creation or UI surfaces are changed; this mirrors how the existing
non-whitelisted provider is already handled in the Look up path only.

## Checks

- `python3 -c "import ast; ast.parse(open('amux-server.py').read())"` — passes
  (the CI syntax gate).
- `python3 -m pytest tests/ -q` — 156 passed, 19 skipped, including the new
  `tests/test_minimax_lookup.py` (4 tests covering model registration and
  region resolution for the global and China endpoints).
