### PR TITLE
fix(hooks): the syntax gate never ran, and could not block when it did

### DIFF
--- a/.claude/check-and-commit.sh
+++ b/.claude/check-and-commit.sh
@@ -3,31 +3,55 @@
 # Receives JSON on stdin with tool_input.file_path
 set -euo pipefail
 
-REPO="/Users/ethan/Dev/amux"
+# The repo root is wherever THIS script lives (<repo>/.claude/check-and-commit.sh),
+# never a hardcoded path. A hardcoded checkout path matches on exactly one machine;
+# everywhere else the path comparison below fails and the script exits 0 — reporting
+# success while checking nothing. That is ethos rule 7 ("can your check actually
+# fail?") in its worst form, because the silence looks like a pass.
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 SERVER="$REPO/amux-server.py"
 
-# Read the file path from hook input
-FILE_PATH=$(cat | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('file_path',''))" 2>/dev/null || echo "")
+# Read the edited path from hook input, resolved, so a symlinked checkout or a
+# relative path still matches the file we are about to check.
+FILE_PATH=$(cat | python3 -c "
+import sys, json, os
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+p = d.get('tool_input', {}).get('file_path', '')
+print(os.path.realpath(p) if p else '')
+" 2>/dev/null || echo "")
+
+SERVER_REAL=$(python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$SERVER")
 
 # Only check if amux-server.py was edited
-if [ "$FILE_PATH" != "$SERVER" ]; then
+if [ "$FILE_PATH" != "$SERVER_REAL" ]; then
   exit 0
 fi
 
-# Check Python syntax
-if ! python3 -c "import ast; ast.parse(open('$SERVER').read())" 2>/tmp/amux-check-err.txt; then
-  echo "Python syntax error in amux-server.py:" >&2
-  cat /tmp/amux-check-err.txt >&2
+# Check Python syntax. The path goes in as argv, not interpolated into the source,
+# so a checkout path containing a quote can't break (or rewrite) the check.
+if ! python3 -c "
+import ast, sys
+ast.parse(open(sys.argv[1]).read())
+" "$SERVER"; then
+  echo "Python syntax error in amux-server.py (see traceback above)" >&2
   exit 2  # blocks the action
 fi
 
-# Extract JS and check with node
-python3 -c "
+# Extract JS and check with node.
+# This runs under `if !` rather than a post-hoc `$?` test: with `set -e` the script
+# aborts the moment the checker returns non-zero, so a trailing `[ $? -ne 0 ]` is
+# unreachable — and the abort carries the checker's exit code (1), which Claude Code
+# treats as a non-blocking error. Only exit 2 blocks, so a JS syntax error used to
+# sail straight through the one gate meant to stop it.
+if ! python3 -c "
 import re, subprocess, sys, tempfile, os
-with open('$SERVER') as f:
-    content = f.read()
+content = open(sys.argv[1]).read()
 m = re.search(r'<script>\s*\n(.*?)</script>', content, re.DOTALL)
 if not m:
+    print('WARNING: no <script> block found in amux-server.py', file=sys.stderr)
     sys.exit(0)
 fd, path = tempfile.mkstemp(suffix='.js')
 os.write(fd, m.group(1).encode())
@@ -38,8 +62,7 @@ if r.returncode != 0:
     print('JS syntax error in amux-server.py:', file=sys.stderr)
     print(r.stderr, file=sys.stderr)
     sys.exit(1)
-"
-if [ $? -ne 0 ]; then
+" "$SERVER"; then
   exit 2  # blocks the action
 fi
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,19 @@
 {
   "model": "claude-opus-4-6",
   "thinking": true,
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/check-and-commit.sh"
+          }
+        ]
+      }
+    ]
+  },
   "permissions": {
     "allow": [
       "Bash(python3 -c \"import ast*\")",


### PR DESCRIPTION
## What & why

`.claude/check-and-commit.sh` is the PostToolUse gate that's supposed to block an edit that breaks `amux-server.py`. It has never done that for anyone cloning this repo, and it reports success while doing nothing. Three defects, found while setting up a fresh checkout:

**1. The repo path was hardcoded to one machine.**
```bash
REPO="/Users/ethan/Dev/amux"
if [ "$FILE_PATH" != "$SERVER" ]; then exit 0; fi
```
Any other checkout path fails that comparison, so the script takes its early `exit 0` on every edit. `exit 0` is success — so it's silent, and the silence looks like a pass. Now derived from `${BASH_SOURCE[0]}`: the repo root is wherever the script lives.

**2. The JS check could not block — including on the maintainer's machine.**
The `node --check` step ended with a post-hoc `if [ $? -ne 0 ]; then exit 2`. Under `set -euo pipefail` the script already aborted at the failing `python3`, so that line was **unreachable**, and the abort carried the checker's exit code of `1`. Claude Code only treats **exit 2** as blocking. So a JS syntax error — the exact bug class `node --check` exists to catch — passed straight through the gate. This one is independent of the path bug: it was live wherever the hook did run. Now runs under `if !` with an explicit `exit 2`.

**3. Nothing ever invoked it.**
`.claude/settings.json` had `model`, `thinking` and `permissions` but no `hooks` key, so the script only ran for whoever had it wired in a gitignored `settings.local.json` — which is likely why the hardcoded path went unnoticed for so long. Fixing the script alone leaves a correct check that nobody runs, so the second commit registers it as `PostToolUse` on `Edit|Write|MultiEdit` via `$CLAUDE_PROJECT_DIR`.

Also hardened while in here: both paths now go in as `argv` instead of being interpolated into the python source, so a checkout path containing a quote can't break (or rewrite) the check.

### Why this is worth a PR rather than a local tweak

This is [ethos rule 7](../blob/main/.claude/rules/ethos.md) twice over — *"a green check that cannot detect the bug is theatre, and it is worse than no check, because it confers false confidence"* — and the registration gap is rule 1, *"an extension point nobody is enrolled in is decoration."* The rules file already cites `ast.parse` being blind to the client as the reason this hook exists; the hook then couldn't act on what `node --check` found.

## How I tested

Built a fixture repo (a small `amux-server.py` with a `<script>` block) and drove the hook through its real stdin contract, since a check that can't fail is the whole subject of this PR:

| Case | Before | After | Want |
|---|---|---|---|
| Unrelated file edited | 0 | **0** | 0 |
| Valid server edited | 0 | **0** | 0 |
| Broken **Python** edited | **0** ❌ | **2** ✅ | 2 (blocks) |
| Broken **JS** edited | **0** ❌ | **2** ✅ | 2 (blocks) |

To prove defect 2 is separate from defect 1, I re-ran the **pre-fix** script with *only* the path corrected — i.e. simulating the machine where it does match:

```
BROKEN PYTHON -> exit 2   (blocks, correct)
BROKEN JS     -> exit 1   (does NOT block)
```

Then against the real thing:

- `./.claude/check-and-commit.sh` vs the actual 60,792-line `amux-server.py` → `exit=0` in **0.6s** (fine for a per-edit hook)
- `bash -n .claude/check-and-commit.sh` → OK
- `.claude/settings.json` parses, `hooks.PostToolUse` present
- `python3 -m pytest tests/ -q` → **178 passed**

No change to `amux-server.py`, so no `APP_VER` / `CACHE` bump needed.

## Checklist

- [x] **One focused change** — tooling only, no `amux-server.py` edit
- [x] **It still parses:** `python3 -c "import ast; ast.parse(open('amux-server.py').read())"`
- [x] **Client change?** n/a — no client code touched, no version bump required
- [x] **Tested end-to-end** — drove the hook's real stdin contract in all four states, plus the real server file
- [x] **Single-file rule respected** — no new modules or asset files
- [x] Rebased on latest `main`

## One judgment call for you

Commit 2 (registering the hook) means **every contributor's checkout starts running this script on edit**. That's the opt-out shape ethos rule 1 asks for, and it moves syntax failures from CI to the keystroke — but it is a behaviour change for other people's machines. It's split into its own commit so you can drop it and keep the script fix alone if you'd rather leave enrollment to `settings.local.json`.

(Minor, not done here to keep scope tight: the script is named `check-and-commit.sh` but doesn't commit anything.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtKaMqcRLDNJ7koDCqcyTC
