### PR TITLE
fix(install): ship assets/ — the dashboard asks for icons the installer never copies

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,9 +35,19 @@ $SUDO cp "$SCRIPT_DIR/amux-server.py" "$INSTALL_DIR/amux-server.py"
 $SUDO cp "$SCRIPT_DIR/amux-remote" "$INSTALL_DIR/amux-remote"
 $SUDO chmod +x "$INSTALL_DIR/amux-remote"
 
+# Copy the icon assets. The dashboard links /icon.svg, /icon.png and the PWA
+# manifest references icon-192/512; the server resolves those relative to
+# amux-server.py's own directory. Without this the endpoints 404 and the
+# dashboard has no favicon or installable app icon.
+if [[ -d "$SCRIPT_DIR/assets" ]]; then
+  $SUDO mkdir -p "$INSTALL_DIR/assets"
+  $SUDO cp "$SCRIPT_DIR"/assets/icon*.png "$SCRIPT_DIR"/assets/icon.svg "$INSTALL_DIR/assets/"
+fi
+
 echo "${GREEN}✓${RESET} installed ${BOLD}amux${RESET} → $INSTALL_DIR/amux"
 echo "${GREEN}✓${RESET} installed ${BOLD}amux-server.py${RESET} → $INSTALL_DIR/amux-server.py"
 echo "${GREEN}✓${RESET} installed ${BOLD}amux-remote${RESET} → $INSTALL_DIR/amux-remote"
+[[ -d "$INSTALL_DIR/assets" ]] && echo "${GREEN}✓${RESET} installed ${BOLD}icon assets${RESET} → $INSTALL_DIR/assets/"
 echo ""
 echo "Quick start:"
 echo "  amux register myproject --dir ~/Dev/myproject --yolo"


### PR DESCRIPTION
## What happens

After installing via `install.sh`, every icon endpoint returns 404:

```
/icon.svg      404
/icon.png      404
/icon-192.png  404
/icon-512.png  404
```

The browser tab has no favicon, and installing the dashboard as a PWA gives a
blank app icon.

## Cause

The dashboard links the icons:

```html
<link rel="icon" type="image/svg+xml" href="/icon.svg">
<link rel="icon" type="image/png" sizes="180x180" href="/icon.png">
<link rel="apple-touch-icon" href="/icon.png">
```

and `manifest.json` references `icon-192.png` / `icon-512.png`. The handler
resolves them relative to the server script:

```python
icon_path = Path(__file__).resolve().parent / "assets" / path.lstrip("/")
```

But `install.sh` copies only `amux`, `amux-server.py` and `amux-remote` — never
`assets/`. That directory doesn't exist next to the installed server, so the
fallback fails.

The `~/.amux/branding/icon.*` white-label override still works, so anyone with
custom branding wouldn't see this.

## Reproduce

```bash
AMUX_INSTALL_DIR=$HOME/.local/bin ./install.sh
amux serve
curl -sk -o /dev/null -w '%{http_code}\n' https://localhost:8822/icon.svg   # 404
```

Confirmed on `main` @ `cfec3e5`.

## The fix

`install.sh` copies `assets/icon*.png` and `assets/icon.svg` into
`$INSTALL_DIR/assets/`, guarded by a directory check so it is a no-op if
`assets/` is absent. One added confirmation line in the installer output.

No change to `amux-server.py`, so no `APP_VER` / `CACHE` bump is needed.

## Verification

Per CONTRIBUTING's "verify it works end-to-end, not just that it parses":

```
before:  /icon.svg → 404      after:  /icon.svg     → 200  image/svg+xml   5376b
         /icon.png → 404              /icon.png     → 200  image/png       7717b
         /icon-192.png → 404          /icon-192.png → 200  image/png      12832b
         /icon-512.png → 404          /icon-512.png → 200  image/png      43638b
```

`bash -n install.sh` clean. Installer re-run against a real prefix
(`AMUX_INSTALL_DIR=$HOME/.local/bin`), server restarted, and the favicon
confirmed rendering in a browser.

---
Authored with AI assistance — AI-C ([attribution model](https://langd0n.com/ai-attribution)).
