### PR TITLE
fix(ci): the JS syntax gate checked one script block out of eight

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,22 +19,14 @@ jobs:
         with: { node-version: '22' }
       - name: Python syntax (amux-server.py parses)
         run: python3 -c "import ast; ast.parse(open('amux-server.py').read())"
-      - name: JS syntax (inline dashboard script parses)
-        run: |
-          python3 - <<'PY'
-          import re, subprocess, sys, tempfile, os
-          content = open('amux-server.py').read()
-          m = re.search(r'<script>\s*\n(.*?)</script>', content, re.DOTALL)
-          if not m:
-              print('WARNING: no <script> block found'); sys.exit(0)
-          fd, path = tempfile.mkstemp(suffix='.js')
-          os.write(fd, m.group(1).encode()); os.close(fd)
-          r = subprocess.run(['node', '--check', path], capture_output=True, text=True)
-          os.unlink(path)
-          if r.returncode != 0:
-              print(r.stderr); sys.exit(1)
-          print('JS OK')
-          PY
+      # EVERY inline script block, not just the first. The inlined version of
+      # this step used re.search, which returns one match, so it validated
+      # 2,380 of ~1.27M characters of client code and stayed green with the
+      # main dashboard script broken. It lives in scripts/ rather than inline
+      # so the local PostToolUse hook can call the SAME code once #66 lands —
+      # a second copy of this logic is how the two drifted in the first place.
+      - name: JS syntax (every inline dashboard script parses)
+        run: python3 scripts/check-inline-js.py amux-server.py
       - name: Tests
         run: |
           pip install -q pytest psutil

--- a/scripts/check-inline-js.py
+++ b/scripts/check-inline-js.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Syntax-check the dashboard's inline <script> blocks.
+
+The check this replaces was:
+
+    m = re.search(r'<script>\\s*\\n(.*?)</script>', content, re.DOTALL)
+
+`re.search` returns the FIRST match, so it validated 2,380 of the file's
+~1.27M characters of client code. Injecting a deliberate syntax error into 10
+of the 11 inline blocks — including the 1MB main dashboard script — left it
+green. A gate that cannot see the thing it guards is worse than no gate.
+
+Scanning raw text turns up two things that look like a script block and are not:
+
+  1. A Python regex literal:  re.sub(r"<script\\b.*?</script>", "", frag)
+     Excluded by requiring a well-formed opening tag, so `<script\\b` misses.
+
+  2. An f-string that BUILDS a script at runtime:
+     f'<script>window._AMUX_AUTH_TOKEN={_json.dumps(AUTH_TOKEN)};'
+     Only valid JS after Python formats it. Checked with each interpolation
+     stubbed as `0`, which validates the template's SHAPE (a dropped brace or
+     paren still fails) without pretending to know the values.
+
+So the walk is over the AST, not the text. Anything the AST walk does not
+reach is listed as an explicit coverage gap rather than passing in silence —
+silence is how the original gap survived.
+"""
+import ast
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+SCRIPT_RE = re.compile(r"<script(?![^>]*\bsrc=)(?:\s[^>]*)?>(.*?)</script>",
+                       re.DOTALL | re.IGNORECASE)
+
+path = sys.argv[1] if len(sys.argv) > 1 else "amux-server.py"
+src = open(path).read()
+tree = ast.parse(src)
+
+
+def blocks_in(text, lineno, kind):
+    return [(lineno, kind, m.group(1)) for m in SCRIPT_RE.finditer(text)
+            if m.group(1).strip()]
+
+
+found = []
+for node in ast.walk(tree):
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        found += blocks_in(node.value, node.lineno, "literal")
+    elif isinstance(node, ast.JoinedStr):
+        flat = "".join(v.value if isinstance(v, ast.Constant) and isinstance(v.value, str)
+                       else "0" for v in node.values)
+        found += blocks_in(flat, node.lineno, "runtime-built")
+
+if not found:
+    print("ERROR: no inline <script> blocks found — the extractor is broken, "
+          "which is exactly the failure this check exists to catch", file=sys.stderr)
+    sys.exit(1)
+
+failed = 0
+for lineno, kind, body in found:
+    fd, tmp = tempfile.mkstemp(suffix=".js")
+    os.write(fd, body.encode())
+    os.close(fd)
+    r = subprocess.run(["node", "--check", tmp], capture_output=True, text=True)
+    os.unlink(tmp)
+    if r.returncode != 0:
+        failed += 1
+        print(f"--- {kind} <script> in the string starting at {path}:{lineno} ---",
+              file=sys.stderr)
+        print(r.stderr.replace(tmp, "<script block>"), file=sys.stderr)
+
+# Coverage report. A block whose <script> and </script> live in DIFFERENT
+# string literals (concatenation, or an f-string chain) is not reachable
+# verbatim by the AST walk, so it may be unchecked or checked only in its
+# stubbed form. Naming these keeps the remaining gap discoverable instead of
+# silent — silence is exactly how the original gap survived.
+seen = {b for _, _, b in found}
+gaps = [(src.count("\n", 0, m.start(1)) + 1, len(m.group(1)))
+        for m in SCRIPT_RE.finditer(src)
+        if m.group(1).strip() and m.group(1) not in seen]
+
+total = sum(len(b) for _, _, b in found)
+if failed:
+    print(f"JS FAILED: {failed}/{len(found)} inline script block(s) do not parse",
+          file=sys.stderr)
+    sys.exit(1)
+print(f"JS OK — {len(found)} inline script blocks, {total:,} chars checked")
+for line, size in gaps:
+    print(f"  note: {size} chars at {path}:{line} span string boundaries — "
+          f"not verified verbatim (see the coverage comment in this script)")


### PR DESCRIPTION
## What & why

`checks.yml` extracts the dashboard JS with:

```python
m = re.search(r'<script>\s*\n(.*?)</script>', content, re.DOTALL)
```

**`re.search` returns the first match.** That is **2,380 characters**. `amux-server.py` holds roughly **1.27M characters** of inline client code across **eight** blocks — including the 1,048,332-char main dashboard script and a 210,709-char second block. Everything past the first has been unparsed on every PR this repo has taken.

### Demonstrated, not argued

Break `_graphUpdateStats` in the main dashboard script and run the current CI step verbatim:

```
old check: JS OK — PASSES with the dashboard broken
```

Injecting a syntax error into each block in turn:

| | caught |
|---|---|
| Old step | **1 of 8** |
| This PR | **8 of 8** |

### Two more things now fail closed

1. The old step answered `WARNING: no <script> block found` with **exit 0**. A broken extractor read as a pass — the worst failure mode, because it needs no bad code to trigger. Now exits 1.
2. The check is a committed script (`scripts/check-inline-js.py`) rather than a heredoc, so the identical logic in `.claude/check-and-commit.sh` can call it once #66 lands. Two copies of one regex is how these drifted apart to begin with.

### Why a naive "scan all blocks" doesn't work

Probably why the original stayed narrow. Two things look like a script block and aren't:

```python
re.sub(r"<script\b.*?</script>", "", frag)     # a Python regex literal
```
Excluded by requiring a well-formed opening tag, so `<script\b` doesn't qualify.

```python
f'<script>window._AMUX_AUTH_TOKEN={_json.dumps(AUTH_TOKEN)};'   # a template
```
Only valid JS *after* Python formats it. Checked with each interpolation stubbed as `0`, which still catches a dropped brace or paren without pretending to know the values.

So the walk is over the **AST**, not the text: `ast.Constant` strings are literal, `ast.JoinedStr` are templates.

### The remaining gap is printed, not hidden

Three blocks whose `<script>` and `</script>` live in *different* string literals can't be reached verbatim by either path. The script names them with file and line on every run:

```
JS OK — 8 inline script blocks, 1,265,663 chars checked
  note: 17 chars at amux-server.py:18666 span string boundaries — not verified verbatim
  note: 1093 chars at amux-server.py:53348 span string boundaries — not verified verbatim
  note: 324 chars at amux-server.py:53424 span string boundaries — not verified verbatim
```

That last one is the service-worker registration — real JS, currently unverified. Naming it is the point: a gap nobody mentions is exactly how the original survived this long. Ethos rule 7, applied to the fix as well as the bug.

## How I tested

```
clean amux-server.py  -> exit 0   (8 blocks, 1,265,663 chars)
broken dashboard      -> exit 1
old step, same file   -> "JS OK"
```

Exit codes captured without a pipe (`$?` after `| tail` reports tail's status — I got that wrong on the first pass and re-ran it).

- Injected a syntax error into all 8 blocks individually — caught every time
- `checks.yml` parses as YAML; step list unchanged apart from the replaced one
- Verified the two false-positive classes above are excluded on clean `main`

## Checklist

- [x] **One focused change** — CI gate only; `amux-server.py` untouched
- [x] **It still parses:** `python3 -c "import ast; ast.parse(open('amux-server.py').read())"`
- [x] **Client change?** none — no `APP_VER` / `CACHE` bump needed
- [x] **Tested end-to-end** — ran the real step against clean and deliberately broken files
- [x] **Single-file rule respected** — `amux-server.py` not modified; new file is tooling under `scripts/`, alongside `watchdog.py`
- [x] Rebased on latest `main`

## Follow-up, not included here

`.claude/check-and-commit.sh` carries the **same** `re.search` bug. It's not fixed in this PR because #66 already rewrites that file and the two would conflict. Once both land, that hook should become a call to `scripts/check-inline-js.py` — happy to push that as a third PR or fold it into #66, whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtKaMqcRLDNJ7koDCqcyTC
