### PR TITLE
fix(resume): repair amux session resume — it has never once fired

### DIFF
--- a/amux-server.py
+++ b/amux-server.py
@@ -3277,6 +3277,19 @@ def _cc_session_id_for_name(session_name: str, work_dir: str) -> str:
     return candidates[0].stem if candidates else ""
 
 
+def _resolve_cc_session_name(meta: dict, name: str) -> str:
+    """Return the Claude-side session name for an amux session.
+
+    amux always launches Claude with `--name <amux session name>`, so this is
+    derivable and never needed persisting. It used to be read from meta alone,
+    and meta was only written in stop_session() — so any ending that was not a
+    graceful stop lost it and forced a fresh start on a resumable session.
+
+    A name persisted in meta still wins, so `/rename` inside Claude is honoured.
+    """
+    return meta.get("cc_session_name") or name
+
+
 # Per-session token cache — refreshed every 30s, keyed by resolved dir
 _token_cache = {"data": {}, "timestamps": {}, "time": 0}
 _TOKEN_CACHE_TTL = 120
@@ -15449,7 +15462,7 @@ def start_session(name: str, extra_flags: str = "", _skip_conv_id: bool = False)
         provider = cfg.get("CC_PROVIDER", "claude").strip().lower()
         _uuid_re = re.compile(r'^[0-9a-fA-F-]{36}$')
         if not _skip_conv_id and provider == "claude":
-            cc_session_name = meta.get("cc_session_name", "")
+            cc_session_name = _resolve_cc_session_name(meta, name)
             conv_id = meta.get("cc_conversation_id", "")
             if cc_session_name and _validate_cc_session_name(cc_session_name):
                 _sid = _cc_session_id_for_name(cc_session_name, work_dir)
@@ -15457,19 +15470,6 @@ def start_session(name: str, extra_flags: str = "", _skip_conv_id: bool = False)
                     # Use UUID to resume — bypasses interactive picker
                     session_flag = f'--resume {_sid}'
                     print(f"[start] {name}: resume={cc_session_name} (uuid={_sid})")
-                elif _cc_session_exists_in_project(cc_session_name, work_dir):
-                    # Multiple sessions with this name — fall back to UUID if available
-                    if conv_id and _uuid_re.match(conv_id):
-                        conv_file = CLAUDE_HOME / "projects" / _project_name(work_dir) / f"{conv_id}.jsonl"
-                        if conv_file.exists():
-                            session_flag = f'--resume {conv_id}'
-                            print(f"[start] {name}: resume via UUID fallback (ambiguous name '{cc_session_name}', uuid={conv_id})")
-                        else:
-                            session_flag = f'--name {shlex.quote(name)}'
-                            print(f"[start] {name}: fresh start (ambiguous name, stale uuid)")
-                    else:
-                        session_flag = f'--name {shlex.quote(name)}'
-                        print(f"[start] {name}: fresh start (ambiguous session name '{cc_session_name}')")
                 else:
                     meta.pop("cc_session_name", None)
                     meta.pop("cc_conversation_id", None)

--- a/amux-server.py
+++ b/amux-server.py
@@ -3234,8 +3234,11 @@ def _jsonl_has_messages(path: Path, max_lines: int = 2000) -> bool:
 
 def _cc_session_candidates(session_name: str, work_dir: str) -> list[Path]:
     """Resumable conversation files titled `session_name`, newest first."""
-    proj_dir = CLAUDE_HOME / "projects" / _project_name(work_dir)
-    if not proj_dir.is_dir():
+    try:
+        proj_dir = CLAUDE_HOME / "projects" / _project_name(work_dir)
+        if not proj_dir.is_dir():
+            return []
+    except (OSError, RuntimeError):
         return []
     scored: list[tuple[float, Path]] = []
     try:

--- a/amux-server.py
+++ b/amux-server.py
@@ -3175,6 +3175,63 @@ def _validate_cc_session_name(name: str) -> bool:
     return bool(name and len(name) <= 64 and _VALID_CC_SESSION_NAME.match(name))
 
 
+# Claude Code writes the session title as a `custom-title` entry inside the
+# conversation file's header block — in practice line 2, behind `last-prompt`
+# or `queue-operation`. The lookups below used to read only the first line,
+# which matched nothing on any install and left resume permanently dead.
+_CC_TITLE_SCAN_LINES = 30
+
+
+def _cc_session_title(path: Path, max_lines: int = _CC_TITLE_SCAN_LINES) -> str:
+    """Return the session title recorded in a conversation JSONL, or ''.
+
+    Reads at most `max_lines` lines — this runs for every conversation file in
+    a project on each session-list refresh, so it must not scan whole files.
+    """
+    try:
+        with path.open(errors="replace") as fh:
+            for i, line in enumerate(fh):
+                if i >= max_lines:
+                    break
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(rec, dict):
+                    continue
+                title = rec.get("customTitle") or rec.get("sessionName")
+                if title:
+                    return title
+    except OSError:
+        pass
+    return ""
+
+
+def _jsonl_has_messages(path: Path, max_lines: int = 2000) -> bool:
+    """True if a conversation has at least one user/assistant turn.
+
+    `claude --resume` exits immediately on a snapshot-only file, so offering
+    one as a resume target produces a fresh start with extra steps.
+    """
+    try:
+        with path.open(errors="replace") as fh:
+            for i, line in enumerate(fh):
+                if i >= max_lines:
+                    break
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(rec, dict) and rec.get("type") in ("user", "assistant"):
+                    return True
+    except OSError:
+        pass
+    return False
+
+
 def _cc_session_exists_in_project(session_name: str, work_dir: str) -> bool:
     """Check if a Claude Code session with this name exists in the project directory."""
     proj_dir = CLAUDE_HOME / "projects" / _project_name(work_dir)

--- a/amux-server.py
+++ b/amux-server.py
@@ -3290,6 +3290,72 @@ def _resolve_cc_session_name(meta: dict, name: str) -> str:
     return meta.get("cc_session_name") or name
 
 
+def _resume_strategy(meta: dict, name: str, work_dir: str) -> tuple[str, list[str], str]:
+    """Decide how a Claude-provider session should (re)start.
+
+    Returns `(session_flag, meta_keys_to_clear, log_message)`. Pure with
+    respect to `meta` and disk — it never mutates `meta` and never writes
+    anything. `start_session` applies the result: it launches with
+    `session_flag`, pops `meta_keys_to_clear` (saving only if that list is
+    non-empty), and prints `log_message`.
+
+    `start_session` is ~700 lines with tmux side effects and cannot be unit
+    tested; this is the one real decision in that function, pulled out so it
+    is actually covered.
+
+    Precedence, newest/most-reliable first:
+    1. Title match via `_cc_session_name` — the common case after this fix,
+       since the name is now derived rather than persisted-only.
+    2. `cc_conversation_id` — the PostToolUse hook's deterministic pointer
+       (refreshed on every tool call from Claude's live session id). Title
+       matching is unreliable in shared workdirs where titles go stale, so
+       this is consulted before giving up, not only in the legacy migration
+       branch below.
+    3. `cc_conversation_id` alone (migration path, pre-dates title tracking).
+    4. Fresh start.
+    """
+    _uuid_re = re.compile(r'^[0-9a-fA-F-]{36}$')
+    cc_session_name = _resolve_cc_session_name(meta, name)
+    conv_id = meta.get("cc_conversation_id", "")
+
+    def _conv_file(cid: str) -> Path:
+        return CLAUDE_HOME / "projects" / _project_name(work_dir) / f"{cid}.jsonl"
+
+    def _resumable(cid: str) -> bool:
+        try:
+            cf = _conv_file(cid)
+            return cf.exists() and _jsonl_has_messages(cf)
+        except (OSError, RuntimeError):
+            return False
+
+    if cc_session_name and _validate_cc_session_name(cc_session_name):
+        _sid = _cc_session_id_for_name(cc_session_name, work_dir)
+        if _sid:
+            return (f'--resume {_sid}', [],
+                    f"resume={cc_session_name} (uuid={_sid})")
+        if conv_id and _uuid_re.match(conv_id) and _resumable(conv_id):
+            return (f'--resume {conv_id}', [],
+                    f"resume via conversation id (title '{cc_session_name}' "
+                    f"not found, uuid={conv_id})")
+        keys = [k for k in ("cc_session_name", "cc_conversation_id") if k in meta]
+        if keys:
+            msg = f"fresh start (session '{cc_session_name}' not found in project)"
+        else:
+            msg = "fresh start (no prior conversation)"
+        return (f'--name {shlex.quote(name)}', keys, msg)
+    elif conv_id and _uuid_re.match(conv_id):
+        # Migration path: old UUID-based session, pre-dates title tracking.
+        try:
+            exists = _conv_file(conv_id).exists()
+        except (OSError, RuntimeError):
+            exists = False
+        if exists:
+            return (f'--resume {conv_id}', [], f"resume (migration) uuid={conv_id}")
+        return (f'--name {shlex.quote(name)}', [], "fresh start (stale uuid)")
+    else:
+        return (f'--name {shlex.quote(name)}', [], "fresh start (new session)")
+
+
 # Per-session token cache — refreshed every 30s, keyed by resolved dir
 _token_cache = {"data": {}, "timestamps": {}, "time": 0}
 _TOKEN_CACHE_TTL = 120
@@ -15460,37 +15526,13 @@ def start_session(name: str, extra_flags: str = "", _skip_conv_id: bool = False)
         # Determine session resume strategy: name-based (new) > UUID (migration) > fresh
         meta = _load_meta(name)
         provider = cfg.get("CC_PROVIDER", "claude").strip().lower()
-        _uuid_re = re.compile(r'^[0-9a-fA-F-]{36}$')
         if not _skip_conv_id and provider == "claude":
-            cc_session_name = _resolve_cc_session_name(meta, name)
-            conv_id = meta.get("cc_conversation_id", "")
-            if cc_session_name and _validate_cc_session_name(cc_session_name):
-                _sid = _cc_session_id_for_name(cc_session_name, work_dir)
-                if _sid:
-                    # Use UUID to resume — bypasses interactive picker
-                    session_flag = f'--resume {_sid}'
-                    print(f"[start] {name}: resume={cc_session_name} (uuid={_sid})")
-                else:
-                    meta.pop("cc_session_name", None)
-                    meta.pop("cc_conversation_id", None)
-                    _save_meta(name, meta)
-                    session_flag = f'--name {shlex.quote(name)}'
-                    print(f"[start] {name}: fresh start (session '{cc_session_name}' not found in project)")
-            elif conv_id and _uuid_re.match(conv_id):
-                # Migration path: old UUID-based session
-                conv_file = (
-                    CLAUDE_HOME / "projects" / _project_name(work_dir) / f"{conv_id}.jsonl"
-                )
-                if conv_file.exists():
-                    session_flag = f"--resume {conv_id}"
-                    print(f"[start] {name}: resume (migration) uuid={conv_id}")
-                else:
-                    session_flag = f'--name {shlex.quote(name)}'
-                    print(f"[start] {name}: fresh start (stale uuid)")
-            else:
-                # First-ever start
-                session_flag = f'--name {shlex.quote(name)}'
-                print(f"[start] {name}: fresh start (new session)")
+            session_flag, _clear_keys, _log_msg = _resume_strategy(meta, name, work_dir)
+            if _clear_keys:
+                for k in _clear_keys:
+                    meta.pop(k, None)
+                _save_meta(name, meta)
+            print(f"[start] {name}: {_log_msg}")
         else:
             session_flag = ""
     

--- a/amux-server.py
+++ b/amux-server.py
@@ -3232,52 +3232,46 @@ def _jsonl_has_messages(path: Path, max_lines: int = 2000) -> bool:
     return False
 
 
-def _cc_session_exists_in_project(session_name: str, work_dir: str) -> bool:
-    """Check if a Claude Code session with this name exists in the project directory."""
+def _cc_session_candidates(session_name: str, work_dir: str) -> list[Path]:
+    """Resumable conversation files titled `session_name`, newest first."""
     proj_dir = CLAUDE_HOME / "projects" / _project_name(work_dir)
     if not proj_dir.is_dir():
-        return False
+        return []
+    scored: list[tuple[float, Path]] = []
     try:
         for jf in proj_dir.glob("*.jsonl"):
             try:
-                first_line = jf.open().readline()
-                if not first_line:
+                if _cc_session_title(jf) != session_name:
                     continue
-                rec = json.loads(first_line)
-                if rec.get("customTitle") == session_name or rec.get("sessionName") == session_name:
-                    return True
-            except Exception:
+                if not _jsonl_has_messages(jf):
+                    continue
+                scored.append((jf.stat().st_mtime, jf))
+            except OSError:
                 continue
-    except Exception:
-        pass
-    return False
+    except OSError:
+        return []
+    scored.sort(key=lambda pair: pair[0], reverse=True)
+    return [p for _, p in scored]
+
+
+def _cc_session_exists_in_project(session_name: str, work_dir: str) -> bool:
+    """Check if a resumable Claude Code session with this name exists."""
+    return bool(_cc_session_candidates(session_name, work_dir))
 
 
 def _cc_session_id_for_name(session_name: str, work_dir: str) -> str:
-    """Return the UUID of a uniquely-named Claude Code session, or '' if ambiguous/missing.
+    """Return the UUID of the most recent resumable session with this name, or ''.
 
-    When exactly one session matches, return its UUID so we can --resume <uuid>
-    (which bypasses the interactive picker). When multiple match, return '' to
-    force a fresh --name start instead of opening the picker."""
-    proj_dir = CLAUDE_HOME / "projects" / _project_name(work_dir)
-    if not proj_dir.is_dir():
-        return ""
-    matches = []
-    try:
-        for jf in proj_dir.glob("*.jsonl"):
-            try:
-                first_line = jf.open().readline()
-                if not first_line:
-                    continue
-                rec = json.loads(first_line)
-                if rec.get("customTitle") == session_name or rec.get("sessionName") == session_name:
-                    sid = rec.get("sessionId", jf.stem)
-                    matches.append(sid)
-            except Exception:
-                continue
-    except Exception:
-        pass
-    return matches[0] if len(matches) == 1 else ""
+    Multiple matches are not genuinely ambiguous: two *live* amux sessions
+    cannot share a name within one install and project directory, so extra
+    matches are always older incarnations of the same logical session.
+
+    Requiring a unique match (as this did) was self-defeating — every fresh
+    start wrote another identically-named conversation, so the second failure
+    guaranteed all subsequent ones. Taking the newest breaks that spiral.
+    """
+    candidates = _cc_session_candidates(session_name, work_dir)
+    return candidates[0].stem if candidates else ""
 
 
 # Per-session token cache — refreshed every 30s, keyed by resolved dir

--- a/amux-server.py
+++ b/amux-server.py
@@ -3185,8 +3185,11 @@ _CC_TITLE_SCAN_LINES = 30
 def _cc_session_title(path: Path, max_lines: int = _CC_TITLE_SCAN_LINES) -> str:
     """Return the session title recorded in a conversation JSONL, or ''.
 
-    Reads at most `max_lines` lines — this runs for every conversation file in
-    a project on each session-list refresh, so it must not scan whole files.
+    Reads at most `max_lines` lines. Conversation files grow without bound
+    (hundreds of MB on long-lived sessions) and every candidate in a project
+    directory is opened on the resume path and on peek transcript resolution,
+    so this must never scan a whole file. The header block Claude writes is a
+    handful of lines; anything past the window is not a header.
     """
     try:
         with path.open(errors="replace") as fh:
@@ -3232,15 +3235,30 @@ def _jsonl_has_messages(path: Path, max_lines: int = 2000) -> bool:
     return False
 
 
-def _cc_session_candidates(session_name: str, work_dir: str) -> list[Path]:
-    """Resumable conversation files titled `session_name`, newest first."""
+def _cc_session_candidates(session_name: str, work_dir: str,
+                           fresh_after: float = 0,
+                           this_session: str = "") -> list[Path]:
+    """Resumable conversation files titled `session_name`, newest first.
+
+    `fresh_after` is a reset watermark (`meta["cc_fresh_after"]`): any
+    conversation last modified at or before it was abandoned by an explicit
+    "start a fresh conversation" action and must never be offered again. It is
+    a timestamp rather than a flag precisely so the conversation the reset
+    itself creates — newer than the mark — stays resumable on later restarts.
+
+    `this_session` enables the ownership guard: a conversation another amux
+    session's meta already claims is skipped, because two sessions sharing one
+    conversation makes each pane mirror the other (AMUX-1730).
+
+    Total by construction: never raises, whatever the filesystem does.
+    """
     try:
         proj_dir = CLAUDE_HOME / "projects" / _project_name(work_dir)
         if not proj_dir.is_dir():
             return []
     except (OSError, RuntimeError):
         return []
-    scored: list[tuple[float, Path]] = []
+    scored: list[tuple[float, str, Path]] = []
     try:
         for jf in proj_dir.glob("*.jsonl"):
             try:
@@ -3248,21 +3266,29 @@ def _cc_session_candidates(session_name: str, work_dir: str) -> list[Path]:
                     continue
                 if not _jsonl_has_messages(jf):
                     continue
-                scored.append((jf.stat().st_mtime, jf))
+                mtime = jf.stat().st_mtime
+                if fresh_after and mtime <= fresh_after:
+                    continue
+                if this_session:
+                    try:
+                        if _conversation_owned_by_other(jf.stem, this_session):
+                            continue
+                    except Exception:
+                        pass
+                scored.append((mtime, jf.stem, jf))
             except OSError:
                 continue
     except OSError:
         return []
-    scored.sort(key=lambda pair: pair[0], reverse=True)
-    return [p for _, p in scored]
+    # Secondary key so identical mtimes resolve the same way every run instead
+    # of following glob (filesystem) order.
+    scored.sort(key=lambda triple: (-triple[0], triple[1]))
+    return [p for _, _, p in scored]
 
 
-def _cc_session_exists_in_project(session_name: str, work_dir: str) -> bool:
-    """Check if a resumable Claude Code session with this name exists."""
-    return bool(_cc_session_candidates(session_name, work_dir))
-
-
-def _cc_session_id_for_name(session_name: str, work_dir: str) -> str:
+def _cc_session_id_for_name(session_name: str, work_dir: str,
+                            fresh_after: float = 0,
+                            this_session: str = "") -> str:
     """Return the UUID of the most recent resumable session with this name, or ''.
 
     Multiple matches are not genuinely ambiguous: two *live* amux sessions
@@ -3272,8 +3298,12 @@ def _cc_session_id_for_name(session_name: str, work_dir: str) -> str:
     Requiring a unique match (as this did) was self-defeating — every fresh
     start wrote another identically-named conversation, so the second failure
     guaranteed all subsequent ones. Taking the newest breaks that spiral.
+
+    `fresh_after` / `this_session` are forwarded to `_cc_session_candidates`.
     """
-    candidates = _cc_session_candidates(session_name, work_dir)
+    candidates = _cc_session_candidates(session_name, work_dir,
+                                        fresh_after=fresh_after,
+                                        this_session=this_session)
     return candidates[0].stem if candidates else ""
 
 
@@ -3313,10 +3343,24 @@ def _resume_strategy(meta: dict, name: str, work_dir: str) -> tuple[str, list[st
        branch below.
     3. `cc_conversation_id` alone (migration path, pre-dates title tracking).
     4. Fresh start.
+
+    Every one of those is vetoed by `meta["cc_fresh_after"]`, the watermark an
+    explicit reset writes. Reset used to work by DELETING the pointers, which
+    only forced a fresh start while the title lookup was dead; now that the
+    name is derived, absence says nothing and the marker is what says it.
     """
     _uuid_re = re.compile(r'^[0-9a-fA-F-]{36}$')
     cc_session_name = _resolve_cc_session_name(meta, name)
+    if cc_session_name and not _validate_cc_session_name(cc_session_name):
+        # A persisted name that fails validation is a bad read, not a verdict:
+        # fall back to the name Claude was actually launched with rather than
+        # letting one corrupt meta poison resume for this session forever.
+        cc_session_name = name
     conv_id = meta.get("cc_conversation_id", "")
+    try:
+        fresh_after = float(meta.get("cc_fresh_after", 0) or 0)
+    except (TypeError, ValueError):
+        fresh_after = 0.0
 
     def _conv_file(cid: str) -> Path:
         return CLAUDE_HOME / "projects" / _project_name(work_dir) / f"{cid}.jsonl"
@@ -3324,12 +3368,18 @@ def _resume_strategy(meta: dict, name: str, work_dir: str) -> tuple[str, list[st
     def _resumable(cid: str) -> bool:
         try:
             cf = _conv_file(cid)
-            return cf.exists() and _jsonl_has_messages(cf)
+            if not cf.exists():
+                return False
+            if fresh_after and cf.stat().st_mtime <= fresh_after:
+                return False  # dropped by an explicit reset
+            return _jsonl_has_messages(cf)
         except (OSError, RuntimeError):
             return False
 
     if cc_session_name and _validate_cc_session_name(cc_session_name):
-        _sid = _cc_session_id_for_name(cc_session_name, work_dir)
+        _sid = _cc_session_id_for_name(cc_session_name, work_dir,
+                                       fresh_after=fresh_after,
+                                       this_session=name)
         if _sid:
             return (f'--resume {_sid}', [],
                     f"resume={cc_session_name} (uuid={_sid})")
@@ -3345,11 +3395,9 @@ def _resume_strategy(meta: dict, name: str, work_dir: str) -> tuple[str, list[st
         return (f'--name {shlex.quote(name)}', keys, msg)
     elif conv_id and _uuid_re.match(conv_id):
         # Migration path: old UUID-based session, pre-dates title tracking.
-        try:
-            exists = _conv_file(conv_id).exists()
-        except (OSError, RuntimeError):
-            exists = False
-        if exists:
+        # Same guards as step 2 — a file that exists but holds no turns bounces
+        # `claude --resume` straight back out, and a reset still vetoes.
+        if _resumable(conv_id):
             return (f'--resume {conv_id}', [], f"resume (migration) uuid={conv_id}")
         return (f'--name {shlex.quote(name)}', [], "fresh start (stale uuid)")
     else:
@@ -4329,14 +4377,11 @@ def _session_jsonl_path_uncached(name: str):
         # resolve to THIS session's own conversation by matching Claude Code's
         # per-conversation title (set from the launch `--name`) to the amux
         # session name. Files are mtime-desc, so the first match is this
-        # session's newest conversation.
+        # session's newest conversation. Read the title with _cc_session_title:
+        # Claude puts it in the header block, not on line 1, so the readline()
+        # this used to do matched nothing and the branch never fired.
         for jf in files:
-            try:
-                with jf.open() as fh:
-                    rec = json.loads(fh.readline() or "{}")
-            except Exception:
-                continue
-            if rec.get("customTitle") == name or rec.get("sessionName") == name:
+            if _cc_session_title(jf) == name:
                 return jf
         # No titled match. Do NOT fall back to the newest file — in a shared
         # workdir that's a SIBLING session's transcript bleeding into this one
@@ -16292,8 +16337,11 @@ def reset_session(name: str) -> tuple[bool, str]:
     start_session always resumes cc_conversation_id — so "I am out of context"
     meant "this lane is finished", which it never was.
 
-    Clearing the conversation pointer makes the next start a fresh one. The
-    session then rebuilds its own context from the board on boot: the existing
+    Dropping the conversation pointer and stamping `cc_fresh_after` makes the
+    next start a fresh one — the stamp is load-bearing, because the Claude-side
+    session name is derived from the amux name, so an absent pointer alone
+    would let the next start title-match right back onto this conversation.
+    The session then rebuilds its own context from the board on boot: the existing
     boot briefing already sends _board_digest(name), which carries what is in
     flight across the fleet plus this session's own queued work. That is the
     board being the source of truth doing the job it exists for — the
@@ -16321,6 +16369,12 @@ def reset_session(name: str) -> tuple[bool, str]:
     meta = _load_meta(name)
     dropped = meta.pop("cc_conversation_id", None)
     meta.pop("cc_session_name", None)
+    # Clearing the pointers is not enough: the session name is DERIVED from the
+    # amux name now, so the next start would title-match and resume the very
+    # conversation this call abandoned. The watermark is what makes the reset
+    # real — everything older than it is off the table, everything the fresh
+    # start goes on to create is not.
+    meta["cc_fresh_after"] = int(time.time())
     _save_meta(name, meta)
     slog(f"[reset] {name}: dropped conversation {dropped or '(none)'}; lane kept")
     _ilog("session", "reset", actor=name, target=name,
@@ -62046,6 +62100,11 @@ p{{color:#888;margin:12px 0 28px;font-size:0.9rem;line-height:1.5}}
                         return self._json({"error": "stop the session before starting a new conversation"}, 409)
                     meta = _load_meta(name)
                     meta.pop("cc_conversation_id", None)
+                    # Same watermark as reset_session(): with the session name
+                    # derived from the amux name, dropping the pointer alone
+                    # would let the next start title-match straight back onto
+                    # the conversation the user just asked to leave behind.
+                    meta["cc_fresh_after"] = int(time.time())
                     _save_meta(name, meta)
                     return self._json({"ok": True, "message": "conversation reset — next start will be a fresh conversation"})
 

--- a/docs/superpowers/plans/2026-07-31-session-resume-repair.md
+++ b/docs/superpowers/plans/2026-07-31-session-resume-repair.md
@@ -509,7 +509,8 @@ def _resolve_cc_session_name(meta: dict, name: str) -> str:
     return meta.get("cc_session_name") or name
 ```
 
-Then in `start_session`, replace line 14922:
+Then in `start_session`, replace the `cc_session_name` assignment (locate it by
+content — Tasks 1 and 2 shifted the line numbers):
 
 ```python
             cc_session_name = meta.get("cc_session_name", "")
@@ -521,9 +522,62 @@ with:
             cc_session_name = _resolve_cc_session_name(meta, name)
 ```
 
-Change nothing else in the branch. The existing not-found path (which pops the
-meta keys and falls back to `--name`) stays correct: with derivation, a pop
-simply means the next start derives the name again.
+- [ ] **Step 3b: Remove the branch Task 2 made unreachable**
+
+**Amendment, ruled by the human partner after Task 2's review.** The plan
+originally said "change nothing else in the branch." That is overridden here:
+Task 2 made one branch of this exact `if/elif` chain dead, and this task is
+already editing the chain.
+
+Task 2 rebuilt `_cc_session_id_for_name` and `_cc_session_exists_in_project` as
+thin wrappers over the same `_cc_session_candidates` call, so each is truthy
+exactly when the other is. That makes the `elif` below unreachable: whenever it
+would be `True`, `_sid` is already truthy and the `if` above it has fired. The
+branch existed to handle an ambiguous name, a state Task 2 deliberately made
+impossible. Delete the whole `elif` clause:
+
+```python
+                elif _cc_session_exists_in_project(cc_session_name, work_dir):
+                    # Multiple sessions with this name — fall back to UUID if available
+                    if conv_id and _uuid_re.match(conv_id):
+                        conv_file = CLAUDE_HOME / "projects" / _project_name(work_dir) / f"{conv_id}.jsonl"
+                        if conv_file.exists():
+                            session_flag = f'--resume {conv_id}'
+                            print(f"[start] {name}: resume via UUID fallback (ambiguous name '{cc_session_name}', uuid={conv_id})")
+                        else:
+                            session_flag = f'--name {shlex.quote(name)}'
+                            print(f"[start] {name}: fresh start (ambiguous name, stale uuid)")
+                    else:
+                        session_flag = f'--name {shlex.quote(name)}'
+                        print(f"[start] {name}: fresh start (ambiguous session name '{cc_session_name}')")
+```
+
+leaving the chain as:
+
+```python
+            if cc_session_name and _validate_cc_session_name(cc_session_name):
+                _sid = _cc_session_id_for_name(cc_session_name, work_dir)
+                if _sid:
+                    # Use UUID to resume — bypasses interactive picker
+                    session_flag = f'--resume {_sid}'
+                    print(f"[start] {name}: resume={cc_session_name} (uuid={_sid})")
+                else:
+                    meta.pop("cc_session_name", None)
+                    meta.pop("cc_conversation_id", None)
+                    _save_meta(name, meta)
+                    session_flag = f'--name {shlex.quote(name)}'
+                    print(f"[start] {name}: fresh start (session '{cc_session_name}' not found in project)")
+```
+
+Nothing else in the enclosing `if not _skip_conv_id and provider == "claude":`
+block changes. In particular **keep** the outer `elif conv_id and
+_uuid_re.match(conv_id):` migration branch that follows. It is still reachable:
+it runs when `cc_session_name` fails `_validate_cc_session_name`, which happens
+for amux session names that do not match `^[a-zA-Z0-9][a-zA-Z0-9_.\-]*$`. Both
+`conv_id` and `_uuid_re` therefore remain in use — do not delete them.
+
+The remaining not-found path stays correct: with derivation, popping the meta
+keys simply means the next start derives the name again.
 
 - [ ] **Step 4: Run the full suite**
 

--- a/docs/superpowers/plans/2026-07-31-session-resume-repair.md
+++ b/docs/superpowers/plans/2026-07-31-session-resume-repair.md
@@ -413,7 +413,7 @@ Expected: PASS (20 passed)
 - [ ] **Step 5: Run the full suite for regressions**
 
 Run: `python3 -m pytest tests/ -q`
-Expected: PASS, no failures. (Baseline before this plan: 193 passed.)
+Expected: PASS, no failures. (Baseline before this plan: 178 passed.)
 
 - [ ] **Step 6: Commit**
 
@@ -435,56 +435,81 @@ resolve multiple matches to the most recently modified."
 ### Task 3: Stop requiring the session name to be persisted
 
 **Files:**
+- Modify: `amux-server.py` — add `_resolve_cc_session_name` immediately after `_cc_session_id_for_name` (the function Task 2 rewrites)
 - Modify: `amux-server.py:14922` (one line, inside `start_session`)
 - Test: `tests/test_session_resume.py` (append)
 
 **Interfaces:**
 - Consumes: `_cc_session_id_for_name` (Task 2)
-- Produces: no new symbols — changes the resume-strategy branch's input
+- Produces: `_resolve_cc_session_name(meta: dict, name: str) -> str`
 
-- [ ] **Step 1: Write the failing test**
+The derivation lives in its own helper rather than inline in `start_session`.
+`start_session` is ~700 lines with tmux side effects and cannot be unit tested;
+inlining the logic would leave the fix's only real decision covered by nothing
+but a test that re-implements it. A named helper makes the production code
+itself the thing under test.
+
+- [ ] **Step 1: Write the failing tests**
 
 Append to `tests/test_session_resume.py`:
 
 ```python
 # ── name derivation ─────────────────────────────────────────────────────────
 
-def test_session_name_is_derivable_without_meta(amux_server, project):
-    """amux always launches with `--name <session name>`, so the Claude-side
-    name never needed storing. It was written only in stop_session(), so any
-    ending that was not a graceful stop — crash, reboot, sleep, server restart
-    — lost it and forced a fresh start on a session that was fully resumable.
+def test_derives_amux_name_when_meta_is_empty(amux_server):
+    """The crash case. cc_session_name was written only in stop_session(), so
+    any ending that was not a graceful stop — crash, reboot, sleep, server
+    restart — left meta empty and forced a fresh start on a session that was
+    fully resumable. amux always launches with `--name <session name>`, so the
+    name was derivable the whole time."""
+    assert amux_server._resolve_cc_session_name({}, "Amux-gtm") == "Amux-gtm"
 
-    This pins the property the one-line change in start_session relies on:
-    resolution works from the amux session name alone, with empty meta.
-    """
+
+def test_persisted_meta_name_wins(amux_server):
+    """A /rename inside Claude must still be honoured over the amux name."""
+    assert amux_server._resolve_cc_session_name(
+        {"cc_session_name": "Renamed-By-User"}, "Amux-gtm") == "Renamed-By-User"
+
+
+def test_blank_meta_name_falls_back_to_amux_name(amux_server):
+    """An empty string is not a rename — it is absence, and must not win."""
+    assert amux_server._resolve_cc_session_name(
+        {"cc_session_name": ""}, "Amux-gtm") == "Amux-gtm"
+
+
+def test_derived_name_resolves_to_a_conversation(amux_server, project):
+    """End to end: empty meta, as after a crash, still finds the conversation."""
     add, work_dir = project
     add("aaaaaaaa-0000-0000-0000-000000000000", "Amux-gtm", time.time())
-    meta = {}                                    # nothing persisted, as after a crash
-    cc_session_name = meta.get("cc_session_name") or "Amux-gtm"
-    assert amux_server._validate_cc_session_name(cc_session_name)
-    assert amux_server._cc_session_id_for_name(cc_session_name, work_dir) == \
+    resolved = amux_server._resolve_cc_session_name({}, "Amux-gtm")
+    assert amux_server._cc_session_id_for_name(resolved, work_dir) == \
         "aaaaaaaa-0000-0000-0000-000000000000"
-
-
-def test_persisted_meta_name_overrides_amux_name(amux_server, project):
-    """A /rename inside Claude is still honoured over the amux name."""
-    add, work_dir = project
-    add("bbbbbbbb-0000-0000-0000-000000000000", "Renamed-By-User", time.time())
-    meta = {"cc_session_name": "Renamed-By-User"}
-    cc_session_name = meta.get("cc_session_name") or "Amux-gtm"
-    assert amux_server._cc_session_id_for_name(cc_session_name, work_dir) == \
-        "bbbbbbbb-0000-0000-0000-000000000000"
 ```
 
-- [ ] **Step 2: Run tests to verify they pass or fail meaningfully**
+- [ ] **Step 2: Run tests to verify they fail**
 
-Run: `python3 -m pytest tests/test_session_resume.py -k derivab -v`
-Expected: PASS — these assert the property Task 2 already provides. They exist to lock it in before the production line changes; if they fail, Task 2 is wrong and Task 3 must not proceed.
+Run: `.venv/bin/python -m pytest tests/test_session_resume.py -k resolve_cc -v`
+Expected: FAIL — `AttributeError: module 'amux_server' has no attribute '_resolve_cc_session_name'`
 
-- [ ] **Step 3: Change the production line**
+- [ ] **Step 3: Write the implementation**
 
-In `amux-server.py`, in `start_session`, replace line 14922:
+In `amux-server.py`, immediately after `_cc_session_id_for_name`, add:
+
+```python
+def _resolve_cc_session_name(meta: dict, name: str) -> str:
+    """Return the Claude-side session name for an amux session.
+
+    amux always launches Claude with `--name <amux session name>`, so this is
+    derivable and never needed persisting. It used to be read from meta alone,
+    and meta was only written in stop_session() — so any ending that was not a
+    graceful stop lost it and forced a fresh start on a resumable session.
+
+    A name persisted in meta still wins, so `/rename` inside Claude is honoured.
+    """
+    return meta.get("cc_session_name") or name
+```
+
+Then in `start_session`, replace line 14922:
 
 ```python
             cc_session_name = meta.get("cc_session_name", "")
@@ -493,16 +518,12 @@ In `amux-server.py`, in `start_session`, replace line 14922:
 with:
 
 ```python
-            # amux always launches Claude with `--name <session name>`, so the
-            # Claude-side name is derivable and never needed persisting. It used
-            # to be written only in stop_session(), which meant any ending that
-            # was not a graceful stop — crash, reboot, sleep, server restart —
-            # lost it and forced a fresh start on a fully resumable session.
-            # meta still wins, so a /rename inside Claude is honoured.
-            cc_session_name = meta.get("cc_session_name") or name
+            cc_session_name = _resolve_cc_session_name(meta, name)
 ```
 
-Change nothing else in the branch. The existing not-found path (which pops the meta keys and falls back to `--name`) stays correct: with derivation, a pop simply means the next start derives the name again.
+Change nothing else in the branch. The existing not-found path (which pops the
+meta keys and falls back to `--name`) stays correct: with derivation, a pop
+simply means the next start derives the name again.
 
 - [ ] **Step 4: Run the full suite**
 
@@ -599,7 +620,7 @@ Note: the repo's pre-push guard mis-fires on new branches, listing every ancesto
 **Spec coverage (Part A):**
 | Spec item | Task |
 |---|---|
-| A1 derive session name | Task 3 |
+| A1 derive session name | Task 3 (`_resolve_cc_session_name`) |
 | A2 scan JSONL header block | Task 1 (`_cc_session_title`) + Task 2 (both call sites) |
 | A3 recency tie-break | Task 2 (`_cc_session_candidates` sort) |
 | A3 skip snapshot-only files | Task 1 (`_jsonl_has_messages`) + Task 2 (filter) |

--- a/docs/superpowers/plans/2026-07-31-session-resume-repair.md
+++ b/docs/superpowers/plans/2026-07-31-session-resume-repair.md
@@ -1,0 +1,615 @@
+# Session Resume Repair (Part A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `claude --resume` actually fire when an amux session restarts, so sessions stop waking up with no memory of prior work.
+
+**Architecture:** Three defects in `amux-server.py` each independently break resume. Fix them bottom-up: first add two bounded JSONL-reading helpers, then rebuild the two name-lookup functions on top of them, then stop requiring that the session name be persisted at all. No new files in the server; one new test file.
+
+**Tech Stack:** Python 3.14, pytest, single-file server (`amux-server.py`). Tests load the server via `importlib` — its `if __name__ == "__main__":` guard prevents the HTTP server from starting on import.
+
+## Global Constraints
+
+- Target file is `amux-server.py` at the repo root. It is one large module by design; do not restructure or split it.
+- Tests go in `tests/`, loaded via the `importlib` fixture pattern established in `tests/test_shell_quote_flags.py`. Copy that fixture; do not invent a new loading scheme.
+- All new file reads must be **bounded** — never `read_text()` a whole conversation JSONL. These run in the session-list hot path.
+- Every new helper must swallow `OSError` and malformed JSON and return a falsy value. Nothing here may raise into session startup.
+- Existing behaviour to preserve: zero matches still returns `""` and falls through to a fresh `--name` start.
+- Spec: `docs/superpowers/specs/2026-07-31-session-context-recovery-design.md`.
+- Part B (the resume brief) is **out of scope for this plan**. Do not add hooks or memory-writing code.
+
+---
+
+### Task 1: Bounded JSONL header helpers
+
+**Files:**
+- Modify: `amux-server.py` — insert both helpers immediately after `_validate_cc_session_name` (currently ends at line 2934), before `_cc_session_exists_in_project`
+- Test: `tests/test_session_resume.py` (create)
+
+**Interfaces:**
+- Consumes: `CLAUDE_HOME`, `json`, `Path` (already imported at module top)
+- Produces:
+  - `_cc_session_title(path: Path, max_lines: int = 30) -> str`
+  - `_jsonl_has_messages(path: Path, max_lines: int = 2000) -> bool`
+  - `_CC_TITLE_SCAN_LINES: int = 30`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_session_resume.py`:
+
+```python
+"""Unit tests for amux session resume — the path that decides whether a
+restarting session resumes its conversation or wakes up blank.
+
+Three defects made this dead code on every install. These tests pin all three:
+the title lives on line 2 and the lookup only read line 1; the lookup demanded
+a unique name match while every fresh start added another identically-named
+conversation; and the name was only persisted on graceful stop.
+
+Loaded via importlib like tests/test_shell_quote_flags.py so no drift is possible.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+SERVER_PATH = REPO_ROOT / "amux-server.py"
+
+
+@pytest.fixture(scope="module")
+def amux_server():
+    spec = importlib.util.spec_from_file_location("amux_server", SERVER_PATH)
+    assert spec is not None and spec.loader is not None, f"could not load {SERVER_PATH}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["amux_server"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_jsonl(path: Path, entries):
+    path.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+
+
+def _header(title):
+    """The header block Claude Code writes: custom-title is NOT line 1."""
+    return [
+        {"type": "last-prompt", "leafUuid": "abc"},
+        {"type": "custom-title", "customTitle": title, "sessionId": "x"},
+    ]
+
+
+def _msg(role="user"):
+    return {"type": role, "message": {"role": role, "content": "hi"}}
+
+
+# ── _cc_session_title ────────────────────────────────────────────────────────
+
+def test_title_on_line_two_is_found(amux_server, tmp_path):
+    """The regression: Claude Code writes custom-title on line 2, and the old
+    lookup read only line 1, so it matched nothing on any install."""
+    f = tmp_path / "conv.jsonl"
+    _write_jsonl(f, _header("Amux-gtm") + [_msg()])
+    assert amux_server._cc_session_title(f) == "Amux-gtm"
+
+
+def test_title_on_line_one_is_found(amux_server, tmp_path):
+    f = tmp_path / "conv.jsonl"
+    _write_jsonl(f, [{"type": "custom-title", "customTitle": "Solo"}])
+    assert amux_server._cc_session_title(f) == "Solo"
+
+
+def test_session_name_key_is_accepted(amux_server, tmp_path):
+    f = tmp_path / "conv.jsonl"
+    _write_jsonl(f, [{"type": "meta"}, {"sessionName": "Legacy"}])
+    assert amux_server._cc_session_title(f) == "Legacy"
+
+
+def test_title_absent_returns_empty(amux_server, tmp_path):
+    f = tmp_path / "conv.jsonl"
+    _write_jsonl(f, [_msg(), _msg("assistant")])
+    assert amux_server._cc_session_title(f) == ""
+
+
+def test_title_scan_is_bounded(amux_server, tmp_path):
+    """A title past the scan window is not found — the read must stay bounded
+    because this runs on every session-list refresh."""
+    f = tmp_path / "conv.jsonl"
+    _write_jsonl(f, [_msg()] * 40 + [{"type": "custom-title", "customTitle": "TooLate"}])
+    assert amux_server._cc_session_title(f, max_lines=30) == ""
+
+
+def test_malformed_lines_are_skipped(amux_server, tmp_path):
+    f = tmp_path / "conv.jsonl"
+    f.write_text("not json\n" + json.dumps({"customTitle": "Survivor"}) + "\n")
+    assert amux_server._cc_session_title(f) == "Survivor"
+
+
+def test_missing_file_returns_empty(amux_server, tmp_path):
+    assert amux_server._cc_session_title(tmp_path / "nope.jsonl") == ""
+
+
+def test_non_dict_json_line_is_skipped(amux_server, tmp_path):
+    f = tmp_path / "conv.jsonl"
+    f.write_text('["a list"]\n' + json.dumps({"customTitle": "Survivor"}) + "\n")
+    assert amux_server._cc_session_title(f) == "Survivor"
+
+
+# ── _jsonl_has_messages ─────────────────────────────────────────────────────
+
+def test_has_messages_true_for_real_conversation(amux_server, tmp_path):
+    f = tmp_path / "conv.jsonl"
+    _write_jsonl(f, _header("X") + [_msg("assistant")])
+    assert amux_server._jsonl_has_messages(f) is True
+
+
+def test_has_messages_false_for_snapshot_only(amux_server, tmp_path):
+    """claude --resume exits instantly on these, so resuming one is a fresh
+    start with extra steps."""
+    f = tmp_path / "conv.jsonl"
+    _write_jsonl(f, _header("X") + [{"type": "file-history-snapshot"}])
+    assert amux_server._jsonl_has_messages(f) is False
+
+
+def test_has_messages_false_for_missing_file(amux_server, tmp_path):
+    assert amux_server._jsonl_has_messages(tmp_path / "nope.jsonl") is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_session_resume.py -q`
+Expected: FAIL — `AttributeError: module 'amux_server' has no attribute '_cc_session_title'`
+
+If `pytest` is missing, create a venv first:
+`python3 -m venv .venv && .venv/bin/pip install -q pytest` then use `.venv/bin/python -m pytest`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `amux-server.py`, directly after `_validate_cc_session_name` (line 2934) and before `_cc_session_exists_in_project`, insert:
+
+```python
+# Claude Code writes the session title as a `custom-title` entry inside the
+# conversation file's header block — in practice line 2, behind `last-prompt`
+# or `queue-operation`. The lookups below used to read only the first line,
+# which matched nothing on any install and left resume permanently dead.
+_CC_TITLE_SCAN_LINES = 30
+
+
+def _cc_session_title(path: Path, max_lines: int = _CC_TITLE_SCAN_LINES) -> str:
+    """Return the session title recorded in a conversation JSONL, or ''.
+
+    Reads at most `max_lines` lines — this runs for every conversation file in
+    a project on each session-list refresh, so it must not scan whole files.
+    """
+    try:
+        with path.open(errors="replace") as fh:
+            for i, line in enumerate(fh):
+                if i >= max_lines:
+                    break
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(rec, dict):
+                    continue
+                title = rec.get("customTitle") or rec.get("sessionName")
+                if title:
+                    return title
+    except OSError:
+        pass
+    return ""
+
+
+def _jsonl_has_messages(path: Path, max_lines: int = 2000) -> bool:
+    """True if a conversation has at least one user/assistant turn.
+
+    `claude --resume` exits immediately on a snapshot-only file, so offering
+    one as a resume target produces a fresh start with extra steps.
+    """
+    try:
+        with path.open(errors="replace") as fh:
+            for i, line in enumerate(fh):
+                if i >= max_lines:
+                    break
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(rec, dict) and rec.get("type") in ("user", "assistant"):
+                    return True
+    except OSError:
+        pass
+    return False
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_session_resume.py -q`
+Expected: PASS (12 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add amux-server.py tests/test_session_resume.py
+git commit -m "feat(resume): bounded helpers for JSONL title and message detection
+
+Claude Code writes custom-title inside the conversation header block, not on
+line 1. Both helpers cap their reads because they run for every conversation
+file in a project on each session-list refresh."
+```
+
+---
+
+### Task 2: Rebuild the name lookups on the helpers
+
+**Files:**
+- Modify: `amux-server.py:2937-2982` — replace `_cc_session_exists_in_project` and `_cc_session_id_for_name` wholesale
+- Test: `tests/test_session_resume.py` (append)
+
+**Interfaces:**
+- Consumes: `_cc_session_title`, `_jsonl_has_messages` (Task 1), `_project_name`, `CLAUDE_HOME`
+- Produces:
+  - `_cc_session_candidates(session_name: str, work_dir: str) -> list[Path]` — resumable matches, newest first
+  - `_cc_session_exists_in_project(session_name: str, work_dir: str) -> bool` — unchanged signature
+  - `_cc_session_id_for_name(session_name: str, work_dir: str) -> str` — unchanged signature, returns the conversation UUID (the file stem, which is what `--resume` takes)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_session_resume.py`:
+
+```python
+# ── name → conversation id ──────────────────────────────────────────────────
+
+@pytest.fixture
+def project(amux_server, tmp_path, monkeypatch):
+    """Build a fake ~/.claude/projects/<slug>/ and return a writer + work_dir."""
+    monkeypatch.setattr(amux_server, "CLAUDE_HOME", tmp_path)
+    work_dir = "/Users/someone/Projects/demo"
+    proj = tmp_path / "projects" / amux_server._project_name(work_dir)
+    proj.mkdir(parents=True)
+
+    def add(uuid, title, mtime, with_messages=True):
+        f = proj / f"{uuid}.jsonl"
+        entries = _header(title) + ([_msg()] if with_messages else
+                                    [{"type": "file-history-snapshot"}])
+        _write_jsonl(f, entries)
+        os.utime(f, (mtime, mtime))
+        return f
+
+    return add, work_dir
+
+
+def test_resolves_title_recorded_on_line_two(amux_server, project):
+    """End-to-end for the line-1 bug: nothing resolved before this."""
+    add, work_dir = project
+    add("aaaaaaaa-0000-0000-0000-000000000000", "Amux-gtm", time.time())
+    assert amux_server._cc_session_id_for_name("Amux-gtm", work_dir) == \
+        "aaaaaaaa-0000-0000-0000-000000000000"
+
+
+def test_many_same_named_sessions_resolve_to_newest(amux_server, project):
+    """The death spiral: each fresh start added another 'Amux-gtm' conversation,
+    and the old code required exactly one match — so once it had failed twice it
+    could never succeed again. Newest wins instead."""
+    add, work_dir = project
+    now = time.time()
+    add("11111111-0000-0000-0000-000000000000", "Amux-gtm", now - 500_000)
+    add("22222222-0000-0000-0000-000000000000", "Amux-gtm", now - 100_000)
+    add("33333333-0000-0000-0000-000000000000", "Amux-gtm", now - 10)
+    add("44444444-0000-0000-0000-000000000000", "Amux-gtm", now - 200_000)
+    assert amux_server._cc_session_id_for_name("Amux-gtm", work_dir) == \
+        "33333333-0000-0000-0000-000000000000"
+
+
+def test_snapshot_only_files_are_not_resume_targets(amux_server, project):
+    """A newer snapshot-only file must not beat an older real conversation."""
+    add, work_dir = project
+    now = time.time()
+    add("aaaaaaaa-0000-0000-0000-000000000000", "Amux-gtm", now - 1000)
+    add("bbbbbbbb-0000-0000-0000-000000000000", "Amux-gtm", now, with_messages=False)
+    assert amux_server._cc_session_id_for_name("Amux-gtm", work_dir) == \
+        "aaaaaaaa-0000-0000-0000-000000000000"
+
+
+def test_no_match_returns_empty(amux_server, project):
+    add, work_dir = project
+    add("aaaaaaaa-0000-0000-0000-000000000000", "Other-Session", time.time())
+    assert amux_server._cc_session_id_for_name("Amux-gtm", work_dir) == ""
+
+
+def test_missing_project_dir_returns_empty(amux_server, tmp_path, monkeypatch):
+    monkeypatch.setattr(amux_server, "CLAUDE_HOME", tmp_path)
+    assert amux_server._cc_session_id_for_name("Amux-gtm", "/no/such/dir") == ""
+
+
+def test_exists_in_project_sees_line_two_title(amux_server, project):
+    add, work_dir = project
+    add("aaaaaaaa-0000-0000-0000-000000000000", "Amux-gtm", time.time())
+    assert amux_server._cc_session_exists_in_project("Amux-gtm", work_dir) is True
+
+
+def test_exists_in_project_false_when_absent(amux_server, project):
+    add, work_dir = project
+    add("aaaaaaaa-0000-0000-0000-000000000000", "Other", time.time())
+    assert amux_server._cc_session_exists_in_project("Amux-gtm", work_dir) is False
+
+
+def test_candidates_are_ordered_newest_first(amux_server, project):
+    add, work_dir = project
+    now = time.time()
+    add("11111111-0000-0000-0000-000000000000", "S", now - 300)
+    add("22222222-0000-0000-0000-000000000000", "S", now - 100)
+    got = [p.stem[:8] for p in amux_server._cc_session_candidates("S", work_dir)]
+    assert got == ["22222222", "11111111"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_session_resume.py -q`
+Expected: FAIL — `AttributeError: ... has no attribute '_cc_session_candidates'`, and `test_many_same_named_sessions_resolve_to_newest` fails returning `''`.
+
+- [ ] **Step 3: Write the implementation**
+
+Replace `amux-server.py:2937-2982` entirely (both existing functions) with:
+
+```python
+def _cc_session_candidates(session_name: str, work_dir: str) -> list[Path]:
+    """Resumable conversation files titled `session_name`, newest first."""
+    proj_dir = CLAUDE_HOME / "projects" / _project_name(work_dir)
+    if not proj_dir.is_dir():
+        return []
+    scored: list[tuple[float, Path]] = []
+    try:
+        for jf in proj_dir.glob("*.jsonl"):
+            try:
+                if _cc_session_title(jf) != session_name:
+                    continue
+                if not _jsonl_has_messages(jf):
+                    continue
+                scored.append((jf.stat().st_mtime, jf))
+            except OSError:
+                continue
+    except OSError:
+        return []
+    scored.sort(key=lambda pair: pair[0], reverse=True)
+    return [p for _, p in scored]
+
+
+def _cc_session_exists_in_project(session_name: str, work_dir: str) -> bool:
+    """Check if a resumable Claude Code session with this name exists."""
+    return bool(_cc_session_candidates(session_name, work_dir))
+
+
+def _cc_session_id_for_name(session_name: str, work_dir: str) -> str:
+    """Return the UUID of the most recent resumable session with this name, or ''.
+
+    Multiple matches are not genuinely ambiguous: two *live* amux sessions
+    cannot share a name within one install and project directory, so extra
+    matches are always older incarnations of the same logical session.
+
+    Requiring a unique match (as this did) was self-defeating — every fresh
+    start wrote another identically-named conversation, so the second failure
+    guaranteed all subsequent ones. Taking the newest breaks that spiral.
+    """
+    candidates = _cc_session_candidates(session_name, work_dir)
+    return candidates[0].stem if candidates else ""
+```
+
+Note: the returned id is the file stem. That is the conversation UUID `--resume` accepts, and the same key `detect_active_model` uses to locate `{conversation_id}.jsonl`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_session_resume.py -q`
+Expected: PASS (20 passed)
+
+- [ ] **Step 5: Run the full suite for regressions**
+
+Run: `python3 -m pytest tests/ -q`
+Expected: PASS, no failures. (Baseline before this plan: 193 passed.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add amux-server.py tests/test_session_resume.py
+git commit -m "fix(resume): match titles past line 1 and break the ambiguity spiral
+
+The lookups read only the first line of each conversation JSONL while Claude
+Code writes custom-title on line 2, so they matched nothing. They also required
+a unique name match — but every fresh start appends another identically-named
+conversation, so once the lookup had failed twice it could never succeed again.
+
+Scan the header block, skip snapshot-only files that --resume exits on, and
+resolve multiple matches to the most recently modified."
+```
+
+---
+
+### Task 3: Stop requiring the session name to be persisted
+
+**Files:**
+- Modify: `amux-server.py:14922` (one line, inside `start_session`)
+- Test: `tests/test_session_resume.py` (append)
+
+**Interfaces:**
+- Consumes: `_cc_session_id_for_name` (Task 2)
+- Produces: no new symbols — changes the resume-strategy branch's input
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_session_resume.py`:
+
+```python
+# ── name derivation ─────────────────────────────────────────────────────────
+
+def test_session_name_is_derivable_without_meta(amux_server, project):
+    """amux always launches with `--name <session name>`, so the Claude-side
+    name never needed storing. It was written only in stop_session(), so any
+    ending that was not a graceful stop — crash, reboot, sleep, server restart
+    — lost it and forced a fresh start on a session that was fully resumable.
+
+    This pins the property the one-line change in start_session relies on:
+    resolution works from the amux session name alone, with empty meta.
+    """
+    add, work_dir = project
+    add("aaaaaaaa-0000-0000-0000-000000000000", "Amux-gtm", time.time())
+    meta = {}                                    # nothing persisted, as after a crash
+    cc_session_name = meta.get("cc_session_name") or "Amux-gtm"
+    assert amux_server._validate_cc_session_name(cc_session_name)
+    assert amux_server._cc_session_id_for_name(cc_session_name, work_dir) == \
+        "aaaaaaaa-0000-0000-0000-000000000000"
+
+
+def test_persisted_meta_name_overrides_amux_name(amux_server, project):
+    """A /rename inside Claude is still honoured over the amux name."""
+    add, work_dir = project
+    add("bbbbbbbb-0000-0000-0000-000000000000", "Renamed-By-User", time.time())
+    meta = {"cc_session_name": "Renamed-By-User"}
+    cc_session_name = meta.get("cc_session_name") or "Amux-gtm"
+    assert amux_server._cc_session_id_for_name(cc_session_name, work_dir) == \
+        "bbbbbbbb-0000-0000-0000-000000000000"
+```
+
+- [ ] **Step 2: Run tests to verify they pass or fail meaningfully**
+
+Run: `python3 -m pytest tests/test_session_resume.py -k derivab -v`
+Expected: PASS — these assert the property Task 2 already provides. They exist to lock it in before the production line changes; if they fail, Task 2 is wrong and Task 3 must not proceed.
+
+- [ ] **Step 3: Change the production line**
+
+In `amux-server.py`, in `start_session`, replace line 14922:
+
+```python
+            cc_session_name = meta.get("cc_session_name", "")
+```
+
+with:
+
+```python
+            # amux always launches Claude with `--name <session name>`, so the
+            # Claude-side name is derivable and never needed persisting. It used
+            # to be written only in stop_session(), which meant any ending that
+            # was not a graceful stop — crash, reboot, sleep, server restart —
+            # lost it and forced a fresh start on a fully resumable session.
+            # meta still wins, so a /rename inside Claude is honoured.
+            cc_session_name = meta.get("cc_session_name") or name
+```
+
+Change nothing else in the branch. The existing not-found path (which pops the meta keys and falls back to `--name`) stays correct: with derivation, a pop simply means the next start derives the name again.
+
+- [ ] **Step 4: Run the full suite**
+
+Run: `python3 -m pytest tests/ -q`
+Expected: PASS, no failures.
+
+- [ ] **Step 5: Verify against the real home directory**
+
+This asserts the fix works on actual data rather than fixtures. Run from the repo root:
+
+```bash
+python3 - <<'EOF'
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("amux_server", "amux-server.py")
+m = importlib.util.module_from_spec(spec); sys.modules["amux_server"] = m
+spec.loader.exec_module(m)
+wd = "/Users/dorongreenspan/Projects/amux-gtm"
+print("resolved:", m._cc_session_id_for_name("Amux-gtm", wd) or "(none)")
+EOF
+```
+
+Expected: a UUID, not `(none)`. Before this plan it returned `''` for every session.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add amux-server.py tests/test_session_resume.py
+git commit -m "fix(resume): derive the Claude session name instead of persisting it
+
+cc_session_name was written only in stop_session(), so any ending that was not
+a graceful stop lost it and forced a fresh start. amux always launches with
+--name <session name>, so the name was derivable all along; meta still takes
+precedence so a /rename inside Claude is honoured.
+
+Removes the crash window entirely and repairs existing sessions with no
+migration — their conversation files already carry the right title."
+```
+
+---
+
+### Task 4: Manual acceptance
+
+**Files:** none — this task verifies behaviour, it does not change code.
+
+**Interfaces:**
+- Consumes: all of Tasks 1–3
+
+- [ ] **Step 1: Restart a session through amux**
+
+Restart `Amux-gtm` from the amux dashboard (card menu → Restart), or:
+
+```bash
+curl -sk -X POST "$AMUX_URL/api/sessions/Amux-gtm/restart"
+```
+
+- [ ] **Step 2: Confirm the resume path was taken**
+
+```bash
+grep "\[start\] Amux-gtm" ~/.amux/serve.log | tail -3
+```
+
+Expected: `[start] Amux-gtm: resume=Amux-gtm (uuid=…)`
+Failure signal: `fresh start (new session)` — resume is still broken; do not mark this plan complete.
+
+- [ ] **Step 3: Confirm the session actually retained context**
+
+Send the restarted session: `what were you working on before this restart?`
+
+Expected: it answers from the prior conversation without being handed a log. This is the acceptance criterion the whole plan exists for — a passing test suite with a session that still wakes up blank is a failure.
+
+- [ ] **Step 4: Confirm no cross-session contamination**
+
+```bash
+grep "^\[start\]" ~/.amux/serve.log | tail -8
+```
+
+Expected: each session resolves to its own uuid; no two sessions report the same one. If two do, `_cc_session_candidates` is matching across project directories — stop and re-check `_project_name(work_dir)` scoping.
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+git push -u origin fix/session-resume-and-recovery-brief
+gh pr create --base main \
+  --title "fix(resume): repair amux session resume — three compounding bugs" \
+  --body "See docs/superpowers/specs/2026-07-31-session-context-recovery-design.md"
+```
+
+Note: the repo's pre-push guard mis-fires on new branches, listing every ancestor commit as "foreign". Verify with `git log --oneline origin/main..HEAD` that only your commits are present, then re-run with `AMUX_ALLOW_FOREIGN=1` prefixed.
+
+---
+
+## Self-Review
+
+**Spec coverage (Part A):**
+| Spec item | Task |
+|---|---|
+| A1 derive session name | Task 3 |
+| A2 scan JSONL header block | Task 1 (`_cc_session_title`) + Task 2 (both call sites) |
+| A3 recency tie-break | Task 2 (`_cc_session_candidates` sort) |
+| A3 skip snapshot-only files | Task 1 (`_jsonl_has_messages`) + Task 2 (filter) |
+| Bounded reads | Task 1, `max_lines` on both helpers; `test_title_scan_is_bounded` |
+| Zero matches → `""` | Task 2, `test_no_match_returns_empty` |
+| Live `Amux-gtm` resolution | Task 3 Step 5 |
+| Manual `serve.log` acceptance | Task 4 |
+
+Part B (resume brief) and Part C (Load log retier) are explicitly out of scope, per the Global Constraints.
+
+**Placeholder scan:** none — every step carries runnable code or an exact command.
+
+**Type consistency:** `_cc_session_title(Path, int) -> str`, `_jsonl_has_messages(Path, int) -> bool`, `_cc_session_candidates(str, str) -> list[Path]`, `_cc_session_id_for_name(str, str) -> str`, `_cc_session_exists_in_project(str, str) -> bool`. Task 2 consumes Task 1's helpers under the names Task 1 defines. `_cc_session_id_for_name` returns `.stem` (a `str`), matching its existing callers at `:14925` and `:14932`, which interpolate it into a `--resume` flag.

--- a/docs/superpowers/specs/2026-07-31-session-context-recovery-design.md
+++ b/docs/superpowers/specs/2026-07-31-session-context-recovery-design.md
@@ -1,0 +1,249 @@
+# Session context recovery
+
+**Date:** 2026-07-31
+**Status:** approved, not yet implemented
+
+## Problem
+
+Reopening an amux session frequently shows an agent with no memory of prior work.
+The available workaround is the peek UI's "Load log" button, which sends the
+session a prompt telling it to read `~/.amux/logs/.plain/<name>.log`. For
+`Amux-gtm` that file is 2.6 MB / 59,900 lines, of which roughly 74% is redundant
+terminal redraw (35,176 lines with content, 9,123 of them unique). It does not
+fit in a context window, so the recovery path does not work.
+
+A context-less session is not merely forgetful. It reverses decisions that were
+already made — re-doing work, undoing conventions, contradicting earlier
+instructions — because nothing tells it those decisions exist.
+
+## Root cause
+
+"Load log" is a workaround for a resume path that has never functioned.
+
+`start_session` already tries to resume: it reads `cc_session_name` /
+`cc_conversation_id` from the session's `meta.json` and launches
+`claude --resume <uuid>` (`amux-server.py:14917-14963`). That branch has never
+been taken. From `~/.amux/serve.log`, every session on this install:
+
+```
+[start] Amux-gtm: fresh start (new session)
+[start] Amux: fresh start (new session)
+[start] amux-helper: fresh start (new session)
+[start] Kids-Daily-Prep: fresh start (new session)
+[start] windsor-suits-rebuild: fresh start (new session)
+[start] Family-Command-and-Control-Center: fresh start (new session)
+[start] AI---Work-Course: fresh start (new session)
+```
+
+None of the 8 sessions has either key in `meta.json`. `Amux-gtm.meta.json` shows
+`start_count: 13` — thirteen restarts, thirteen blank slates.
+
+Three independent defects each break resume on their own.
+
+### Bug 1 — the session name is only persisted on graceful stop
+
+`cc_session_name` is written in exactly two places, both inside `stop_session()`
+(`amux-server.py:15559` and `:15584`). The only other write (`:15415`) is a
+migration path gated on `cc_conversation_id` already being set, which it never
+is.
+
+So the name survives only when a session is shut down through amux's stop path.
+Every other ending — crash, reboot, machine sleep, tmux kill, amux server
+restart — leaves it unset, and the next start is fresh. Long-lived sessions
+rarely end gracefully, which is why this looks intermittent but is in practice
+total.
+
+### Bug 2 — the name lookup reads only the first line
+
+`_cc_session_id_for_name` (`:2970`) and `_cc_session_exists_in_project`
+(`:2945`) both do `first_line = jf.open().readline()` and match `customTitle` /
+`sessionName` on it.
+
+Claude Code writes `custom-title` on **line 2**. Line 1 is `last-prompt` or
+`queue-operation`. Measured across all 26 JSONL files in the `amux-gtm` project
+directory: zero first-line matches. The lookup cannot succeed for any session.
+
+### Bug 3 — ambiguity is fatal, and self-inflicted
+
+`_cc_session_id_for_name` ends with `return matches[0] if len(matches) == 1 else ""`.
+
+Scanning past line 1, six files in the `amux-gtm` project carry
+`customTitle: "Amux-gtm"` — one per fresh start. With Bug 2 fixed, the lookup
+would find six matches, fail the uniqueness test, and still return `""`.
+
+This is the reason the condition never self-corrected: each fresh start creates
+another identically-named session, which makes the next lookup more ambiguous,
+which guarantees another fresh start.
+
+## Design
+
+Two parts, shipped in order. Part A removes the cause; Part B is the safety net
+for context loss that resume cannot address. **Part A is independently
+shippable and is expected to resolve the majority of the reported pain.**
+
+### Part A — repair resume
+
+**A1. Derive the session name rather than persisting it.**
+
+amux always launches Claude with `--name <amux session name>`, so the Claude
+session name is knowable without being stored. Change the lookup in
+`start_session` to:
+
+```python
+cc_session_name = meta.get("cc_session_name") or name
+```
+
+This removes the crash-window entirely — there is no longer state that can be
+lost — and retroactively repairs all existing sessions with no migration step,
+because their historical JSONL files already carry the correct `customTitle`.
+The `meta` field is retained as an override for sessions renamed with `/rename`
+inside Claude.
+
+**A2. Scan the JSONL header block instead of line 1.**
+
+Add a helper:
+
+```python
+def _cc_session_title(path: Path, max_lines: int = 30) -> str:
+    """Return a JSONL conversation's session title, or "".
+
+    Claude Code writes the title as a `custom-title` entry within the file's
+    header block, not necessarily on line 1.
+    """
+```
+
+It reads at most `max_lines` lines and returns on the first match of
+`custom-title` / `customTitle` / `sessionName`. Both `_cc_session_id_for_name`
+and `_cc_session_exists_in_project` call it. The read stays bounded — no
+full-file scan is introduced.
+
+**A3. Resolve ambiguity by recency, and skip unresumable files.**
+
+Replace the uniqueness requirement with "most recently modified match wins."
+Within a single amux install and project directory, two *live* sessions cannot
+share a name, so multiple matches are always older incarnations of the same
+logical session; the newest is the one the user means. Zero matches still
+returns `""`.
+
+Candidates are additionally filtered to files containing at least one
+user/assistant message, reusing the existing snapshot-only check noted at
+`:13113` — `claude --resume` exits immediately on a snapshot-only file, which
+would present as a fresh start with extra steps.
+
+### Part B — the resume brief
+
+Covers what resume cannot: deliberate `/clear`, auto-compaction, and any
+residual resume failure.
+
+**Storage and delivery.** The brief is a marker-delimited block inside
+`~/.amux/memory/<session>.md`. No new delivery mechanism is required:
+`_ensure_memory` → `_write_claude_memory` (`:13927`) already composes that file
+into `~/.claude/projects/<project>/memory/MEMORY.md`, which Claude Code loads
+into context at session start. This was verified directly — the session that
+produced this spec received that file's contents in its opening context.
+`_capture_claude_memory_changes` handles the write-back, and
+`_fold_memory_overflow` already bounds the file's size.
+
+**Format.** Markers let the agent rewrite only its own block, preserving
+hand-written memory above and below it:
+
+```markdown
+<!-- amux:brief 2026-07-31T18:12 -->
+**Working on:** amux session resume — 3 bugs found, fix pending
+
+**Standing decisions** — do not reverse without asking
+- Fix resume before building the brief (07-31)
+- Agent commits keep the `[bot]` prefix
+
+**In flight**
+- PR #75 (model badge) — open, awaiting review
+
+**Next step**
+- Implement A1–A3 + tests
+<!-- /amux:brief -->
+```
+
+Capped at 25 lines. **Standing decisions is the load-bearing section**: it is
+what prevents a recovered session from reversing settled decisions, which is the
+specific harm being designed against.
+
+The opening timestamp is required. It lets a recovering session reason about its
+own staleness — "this brief is 40 minutes old, so check `git log` for anything
+after it" — rather than trusting it blindly.
+
+**Write triggers.** Three Claude Code hooks:
+
+| Hook | Why |
+|---|---|
+| `PreCompact` | Fires exactly when context is about to be lost. The highest-value trigger. |
+| `SessionEnd` | Clean exits. |
+| `Stop` | Throttled: rewrite only if the existing brief is >10 minutes old, bounding crash loss to 10 minutes without paying tokens every turn. |
+
+**Hook configuration and session identity.** The hooks are configured once, in
+the user-level `~/.claude/settings.json`, not per project — amux drives many
+sessions across many directories and per-project configuration would have to be
+re-established for each new one.
+
+A single global hook therefore has to know *which* session it is running in. It
+reads `$AMUX_SESSION`, which amux already exports into every session's pane
+(verified: `AMUX_SESSION=Amux-gtm` in this session's environment, and it is the
+same variable the board and scheduler integrations already rely on, e.g.
+`amux-server.py:8300`). The hook writes to
+`~/.amux/memory/$AMUX_SESSION.md` and is a no-op when `$AMUX_SESSION` is unset,
+so a plain non-amux `claude` session in any directory is unaffected.
+
+### Part C — retier "Load log" (optional, deferred)
+
+`peekLoadLogIntoSession` (`:32425`) currently instructs the session to read the
+entire log. Replace with a tiered prompt: read the brief, then `git log`, then
+the log's last ~2,000 lines with a note that the file is heavily
+redraw-duplicated and should be deduplicated before analysis. Reading the full
+log remains available as an explicit choice.
+
+**Not scheduled.** Included for completeness; sequence after A and B land and
+re-evaluate whether it is still needed.
+
+## Error handling
+
+| Failure | Behaviour |
+|---|---|
+| Hook does not fire (hard crash) | Brief is stale but present and timestamped; the session cross-checks `git log` for later activity. |
+| Brief missing or malformed | Fall back to `git log` plus recent prompts. A malformed file is never overwritten wholesale — if the markers cannot be located, the block is appended rather than replacing unrecognised content. |
+| Resume target deleted between lookup and launch | Existing stale-uuid path already falls back to a fresh `--name` start. |
+| `--resume` opens the interactive picker | Existing detection at `:15315` already catches this and recovers. |
+| Memory compose fails | `_write_claude_memory` is already wrapped in a bare `except` and cannot block startup. Preserve that property. |
+
+## Testing
+
+**Part A** — unit tests over synthetic `~/.claude/projects` trees, following the
+`importlib` loading convention established in `tests/test_shell_quote_flags.py`:
+
+- title on line 2 resolves (Bug 2 regression)
+- six identically-named files resolve to the most recently modified (Bug 3)
+- snapshot-only files are excluded from candidates
+- zero matches returns `""`
+- a session with no `cc_session_name` in meta still resolves via the amux name (A1)
+- `_cc_session_title` stops within `max_lines` and does not read whole files
+
+Plus a live assertion that `Amux-gtm` resolves to `642f49e4-…`, the currently
+newest matching conversation.
+
+**Part B**
+
+- the hook replaces only the marked block; surrounding memory is byte-identical
+- the 25-line cap is enforced
+- a file with absent or corrupted markers is not truncated or wiped
+- the brief survives a `_write_claude_memory` / `_capture_claude_memory_changes`
+  round trip without duplication
+
+**Manual acceptance:** restart `Amux-gtm` and confirm `~/.amux/serve.log` reports
+`resume=Amux-gtm (uuid=…)` rather than `fresh start (new session)`, and that the
+session can answer what it was working on beforehand.
+
+## Out of scope
+
+- Changing how Claude Code itself compacts or names conversations.
+- Populating `~/.amux/notes/` and `~/.amux/transcripts/`, which exist but are
+  unused; unrelated to this failure.
+- Any change to the `~/.amux/memory` global/session composition scheme beyond
+  adding one marked block.

--- a/tests/test_session_resume.py
+++ b/tests/test_session_resume.py
@@ -184,18 +184,6 @@ def test_missing_project_dir_returns_empty(amux_server, tmp_path, monkeypatch):
     assert amux_server._cc_session_id_for_name("Amux-gtm", "/no/such/dir") == ""
 
 
-def test_exists_in_project_sees_line_two_title(amux_server, project):
-    add, work_dir = project
-    add("aaaaaaaa-0000-0000-0000-000000000000", "Amux-gtm", time.time())
-    assert amux_server._cc_session_exists_in_project("Amux-gtm", work_dir) is True
-
-
-def test_exists_in_project_false_when_absent(amux_server, project):
-    add, work_dir = project
-    add("aaaaaaaa-0000-0000-0000-000000000000", "Other", time.time())
-    assert amux_server._cc_session_exists_in_project("Amux-gtm", work_dir) is False
-
-
 def test_candidates_are_ordered_newest_first(amux_server, project):
     add, work_dir = project
     now = time.time()
@@ -326,3 +314,233 @@ def test_resume_strategy_first_ever_start_nothing_to_clear(amux_server, project)
     assert flag == "--name Amux-gtm"
     assert cleared == []
     assert "no prior conversation" in msg
+
+
+def test_resume_strategy_migration_branch_rejects_snapshot_only(amux_server, project):
+    """Migration path (no usable title, bare uuid in meta): a snapshot-only
+    file is not resumable — `claude --resume` exits instantly on it — so the
+    uuid-only branch must apply the same has-messages guard as step 2 rather
+    than handing --resume a file it will bounce off."""
+    add, work_dir = project
+    add("dddddddd-0000-0000-0000-000000000000", "Whatever", time.time(),
+        with_messages=False)
+    # An invalid amux name forces the elif (migration) branch.
+    meta = {"cc_session_name": "!!bad!!",
+            "cc_conversation_id": "dddddddd-0000-0000-0000-000000000000"}
+    flag, _cleared, msg = amux_server._resume_strategy(meta, "!!also-bad!!", work_dir)
+    assert flag == "--name '!!also-bad!!'"
+    assert "stale uuid" in msg
+
+
+def test_resume_strategy_invalid_persisted_name_falls_back_to_amux_name(amux_server, project):
+    """A corrupt/illegal `cc_session_name` in meta must not permanently poison
+    resume for the session: fall back to the derived amux name, which is what
+    Claude was actually launched with."""
+    add, work_dir = project
+    add("aaaaaaaa-0000-0000-0000-000000000000", "Amux-gtm", time.time())
+    meta = {"cc_session_name": "!! not a valid name !!"}
+    flag, cleared, _ = amux_server._resume_strategy(meta, "Amux-gtm", work_dir)
+    assert flag == "--resume aaaaaaaa-0000-0000-0000-000000000000"
+    assert cleared == []
+
+
+# ── the reset escape hatch: cc_fresh_after ───────────────────────────────────
+#
+# reset_session and PATCH /config {new_conversation:true} used to force a fresh
+# start by DELETING cc_session_name / cc_conversation_id from meta. That only
+# worked because the title lookup was dead. Now that the name is derived, the
+# absence of meta says nothing — the next start would title-match and resume
+# the very conversation just abandoned, while still reporting success. The
+# signal is therefore positive and a TIMESTAMP: conversations older than the
+# reset are excluded, conversations created after it are not.
+
+def test_candidates_drop_conversations_older_than_fresh_marker(amux_server, project):
+    add, work_dir = project
+    now = time.time()
+    add("11111111-0000-0000-0000-000000000000", "Amux-gtm", now - 500)
+    assert amux_server._cc_session_candidates(
+        "Amux-gtm", work_dir, fresh_after=now - 100) == []
+
+
+def test_candidates_keep_conversations_newer_than_fresh_marker(amux_server, project):
+    """The whole point of a timestamp rather than a flag: the conversation the
+    reset itself creates must be resumable on the NEXT restart."""
+    add, work_dir = project
+    now = time.time()
+    add("11111111-0000-0000-0000-000000000000", "Amux-gtm", now - 500)
+    add("22222222-0000-0000-0000-000000000000", "Amux-gtm", now)
+    got = [p.stem[:8] for p in amux_server._cc_session_candidates(
+        "Amux-gtm", work_dir, fresh_after=now - 100)]
+    assert got == ["22222222"]
+
+
+def test_resume_strategy_after_reset_starts_fresh(amux_server, project):
+    """Post-reset meta (keys popped, marker set) in a project that still holds
+    a matching conversation older than the reset. This is the gap that let the
+    bug through: without the marker this returns --resume and reset is a no-op
+    that reports success."""
+    add, work_dir = project
+    now = time.time()
+    add("aaaaaaaa-0000-0000-0000-000000000000", "Amux-gtm", now - 500)
+    meta = {"cc_fresh_after": int(now - 100)}
+    flag, cleared, msg = amux_server._resume_strategy(meta, "Amux-gtm", work_dir)
+    assert flag == "--name Amux-gtm"
+    assert cleared == []
+    assert "aaaaaaaa" not in msg
+
+
+def test_resume_strategy_resumes_conversation_created_after_reset(amux_server, project):
+    """One reset must not disable resume forever."""
+    add, work_dir = project
+    now = time.time()
+    add("aaaaaaaa-0000-0000-0000-000000000000", "Amux-gtm", now - 500)
+    add("bbbbbbbb-0000-0000-0000-000000000000", "Amux-gtm", now)
+    meta = {"cc_fresh_after": int(now - 100)}
+    flag, _cleared, _ = amux_server._resume_strategy(meta, "Amux-gtm", work_dir)
+    assert flag == "--resume bbbbbbbb-0000-0000-0000-000000000000"
+
+
+def test_resume_strategy_without_marker_is_unchanged(amux_server, project):
+    """No marker in meta → byte-identical behaviour to before the marker
+    existed. Every pre-existing session's meta is in this state."""
+    add, work_dir = project
+    now = time.time()
+    add("aaaaaaaa-0000-0000-0000-000000000000", "Amux-gtm", now - 500)
+    flag, cleared, _ = amux_server._resume_strategy({}, "Amux-gtm", work_dir)
+    assert flag == "--resume aaaaaaaa-0000-0000-0000-000000000000"
+    assert cleared == []
+
+
+def test_resume_strategy_marker_also_suppresses_conv_id_fallback(amux_server, project):
+    """A reset must not be quietly undone via the conv_id fallback: a stale
+    pointer to a pre-reset conversation is exactly what the reset dropped."""
+    add, work_dir = project
+    now = time.time()
+    add("bbbbbbbb-0000-0000-0000-000000000000", "Some-Other-Title", now - 500)
+    meta = {"cc_conversation_id": "bbbbbbbb-0000-0000-0000-000000000000",
+            "cc_fresh_after": int(now - 100)}
+    flag, cleared, _ = amux_server._resume_strategy(meta, "Amux-gtm", work_dir)
+    assert flag == "--name Amux-gtm"
+    assert set(cleared) == {"cc_conversation_id"}
+
+
+def test_reset_session_records_the_fresh_marker(amux_server, tmp_path, monkeypatch):
+    """The contract in reset_session's own docstring, pinned: after a reset the
+    next start must be a fresh conversation. Popping the keys no longer
+    achieves that on its own, so the marker must actually be written."""
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    (sessions / "Amux-gtm.env").write_text('CC_DIR="/Users/someone/Projects/demo"\n')
+    monkeypatch.setattr(amux_server, "CC_SESSIONS", sessions)
+    (sessions / "Amux-gtm.meta.json").write_text(json.dumps({
+        "cc_conversation_id": "aaaaaaaa-0000-0000-0000-000000000000",
+        "cc_session_name": "Amux-gtm",
+    }))
+    monkeypatch.setattr(amux_server, "_is_session_blocked", lambda n: False)
+    monkeypatch.setattr(amux_server, "is_running", lambda n: False)
+    monkeypatch.setattr(amux_server, "slog", lambda *a, **k: None)
+    monkeypatch.setattr(amux_server, "_ilog", lambda *a, **k: None)
+    monkeypatch.setattr(amux_server, "start_session", lambda n: (True, "started"))
+
+    before = int(time.time())
+    ok, _msg = amux_server.reset_session("Amux-gtm")
+    assert ok
+    meta = json.loads((sessions / "Amux-gtm.meta.json").read_text())
+    assert "cc_conversation_id" not in meta
+    assert "cc_session_name" not in meta
+    assert meta.get("cc_fresh_after", 0) >= before
+
+
+# ── ownership: never adopt a neighbour's conversation ────────────────────────
+
+@pytest.fixture
+def sessions_dir(amux_server, tmp_path, monkeypatch):
+    d = tmp_path / "sessions"
+    d.mkdir()
+    monkeypatch.setattr(amux_server, "CC_SESSIONS", d)
+    return d
+
+
+def test_candidates_exclude_conversation_owned_by_another_session(
+        amux_server, project, sessions_dir):
+    """AMUX-1730: two amux sessions collided onto one conversation (shared
+    CC_DIR + a borrowed id) and each pane mirrored the other. Title matching
+    can reproduce that collision, so a conversation another session's meta
+    already claims is not a candidate."""
+    add, work_dir = project
+    now = time.time()
+    add("aaaaaaaa-0000-0000-0000-000000000000", "Amux-gtm", now - 10)
+    add("bbbbbbbb-0000-0000-0000-000000000000", "Amux-gtm", now)
+    (sessions_dir / "neighbour.meta.json").write_text(json.dumps(
+        {"cc_conversation_id": "bbbbbbbb-0000-0000-0000-000000000000"}))
+    got = [p.stem[:8] for p in amux_server._cc_session_candidates(
+        "Amux-gtm", work_dir, this_session="Amux-gtm")]
+    assert got == ["aaaaaaaa"]
+
+
+def test_candidates_keep_conversation_owned_by_this_session(
+        amux_server, project, sessions_dir):
+    """Our own claim is not a collision."""
+    add, work_dir = project
+    add("bbbbbbbb-0000-0000-0000-000000000000", "Amux-gtm", time.time())
+    (sessions_dir / "Amux-gtm.meta.json").write_text(json.dumps(
+        {"cc_conversation_id": "bbbbbbbb-0000-0000-0000-000000000000"}))
+    got = [p.stem[:8] for p in amux_server._cc_session_candidates(
+        "Amux-gtm", work_dir, this_session="Amux-gtm")]
+    assert got == ["bbbbbbbb"]
+
+
+def test_resume_strategy_skips_a_neighbours_conversation(
+        amux_server, project, sessions_dir):
+    add, work_dir = project
+    add("bbbbbbbb-0000-0000-0000-000000000000", "Amux-gtm", time.time())
+    (sessions_dir / "neighbour.meta.json").write_text(json.dumps(
+        {"cc_conversation_id": "bbbbbbbb-0000-0000-0000-000000000000"}))
+    flag, _cleared, _ = amux_server._resume_strategy({}, "Amux-gtm", work_dir)
+    assert flag == "--name Amux-gtm"
+
+
+def test_candidates_survive_unreadable_sessions_dir(
+        amux_server, project, sessions_dir, monkeypatch):
+    """The ownership guard must keep the function total — it may never raise
+    into session startup."""
+    add, work_dir = project
+    add("bbbbbbbb-0000-0000-0000-000000000000", "Amux-gtm", time.time())
+
+    def boom(*a, **k):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(amux_server, "_conversation_owned_by_other", boom)
+    got = [p.stem[:8] for p in amux_server._cc_session_candidates(
+        "Amux-gtm", work_dir, this_session="Amux-gtm")]
+    assert got == ["bbbbbbbb"]
+
+
+def test_candidates_tie_break_is_deterministic(amux_server, project):
+    """Identical mtimes previously fell back to glob (filesystem) order, so the
+    resume target could differ between runs on the same data."""
+    add, work_dir = project
+    same = time.time() - 60
+    add("22222222-0000-0000-0000-000000000000", "S", same)
+    add("11111111-0000-0000-0000-000000000000", "S", same)
+    add("33333333-0000-0000-0000-000000000000", "S", same)
+    got = [p.stem[:8] for p in amux_server._cc_session_candidates("S", work_dir)]
+    assert got == ["11111111", "22222222", "33333333"]
+
+
+# ── peek transcript resolution (the second title lookup) ─────────────────────
+
+def test_peek_path_matches_title_recorded_on_line_two(
+        amux_server, project, sessions_dir):
+    """`_session_jsonl_path_uncached` had its own hand-rolled line-1-only title
+    read — the exact bug this branch exists to fix, in a second place. With it
+    broken the title branch never matched and peek fell through to the
+    ambiguity guard, rendering live-only or a sibling's transcript."""
+    add, work_dir = project
+    now = time.time()
+    add("aaaaaaaa-0000-0000-0000-000000000000", "mine", now - 100)
+    add("bbbbbbbb-0000-0000-0000-000000000000", "neighbour", now)
+    for n in ("mine", "neighbour"):
+        (sessions_dir / f"{n}.env").write_text(f'CC_DIR="{work_dir}"\n')
+    got = amux_server._session_jsonl_path_uncached("mine")
+    assert got is not None and got.stem == "aaaaaaaa-0000-0000-0000-000000000000"

--- a/tests/test_session_resume.py
+++ b/tests/test_session_resume.py
@@ -1,0 +1,120 @@
+"""Unit tests for amux session resume — the path that decides whether a
+restarting session resumes its conversation or wakes up blank.
+
+Three defects made this dead code on every install. These tests pin all three:
+the title lives on line 2 and the lookup only read line 1; the lookup demanded
+a unique name match while every fresh start added another identically-named
+conversation; and the name was only persisted on graceful stop.
+
+Loaded via importlib like tests/test_shell_quote_flags.py so no drift is possible.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+SERVER_PATH = REPO_ROOT / "amux-server.py"
+
+
+@pytest.fixture(scope="module")
+def amux_server():
+    spec = importlib.util.spec_from_file_location("amux_server", SERVER_PATH)
+    assert spec is not None and spec.loader is not None, f"could not load {SERVER_PATH}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["amux_server"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_jsonl(path: Path, entries):
+    path.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+
+
+def _header(title):
+    """The header block Claude Code writes: custom-title is NOT line 1."""
+    return [
+        {"type": "last-prompt", "leafUuid": "abc"},
+        {"type": "custom-title", "customTitle": title, "sessionId": "x"},
+    ]
+
+
+def _msg(role="user"):
+    return {"type": role, "message": {"role": role, "content": "hi"}}
+
+
+# ── _cc_session_title ────────────────────────────────────────────────────────
+
+def test_title_on_line_two_is_found(amux_server, tmp_path):
+    """The regression: Claude Code writes custom-title on line 2, and the old
+    lookup read only line 1, so it matched nothing on any install."""
+    f = tmp_path / "conv.jsonl"
+    _write_jsonl(f, _header("Amux-gtm") + [_msg()])
+    assert amux_server._cc_session_title(f) == "Amux-gtm"
+
+
+def test_title_on_line_one_is_found(amux_server, tmp_path):
+    f = tmp_path / "conv.jsonl"
+    _write_jsonl(f, [{"type": "custom-title", "customTitle": "Solo"}])
+    assert amux_server._cc_session_title(f) == "Solo"
+
+
+def test_session_name_key_is_accepted(amux_server, tmp_path):
+    f = tmp_path / "conv.jsonl"
+    _write_jsonl(f, [{"type": "meta"}, {"sessionName": "Legacy"}])
+    assert amux_server._cc_session_title(f) == "Legacy"
+
+
+def test_title_absent_returns_empty(amux_server, tmp_path):
+    f = tmp_path / "conv.jsonl"
+    _write_jsonl(f, [_msg(), _msg("assistant")])
+    assert amux_server._cc_session_title(f) == ""
+
+
+def test_title_scan_is_bounded(amux_server, tmp_path):
+    """A title past the scan window is not found — the read must stay bounded
+    because this runs on every session-list refresh."""
+    f = tmp_path / "conv.jsonl"
+    _write_jsonl(f, [_msg()] * 40 + [{"type": "custom-title", "customTitle": "TooLate"}])
+    assert amux_server._cc_session_title(f, max_lines=30) == ""
+
+
+def test_malformed_lines_are_skipped(amux_server, tmp_path):
+    f = tmp_path / "conv.jsonl"
+    f.write_text("not json\n" + json.dumps({"customTitle": "Survivor"}) + "\n")
+    assert amux_server._cc_session_title(f) == "Survivor"
+
+
+def test_missing_file_returns_empty(amux_server, tmp_path):
+    assert amux_server._cc_session_title(tmp_path / "nope.jsonl") == ""
+
+
+def test_non_dict_json_line_is_skipped(amux_server, tmp_path):
+    f = tmp_path / "conv.jsonl"
+    f.write_text('["a list"]\n' + json.dumps({"customTitle": "Survivor"}) + "\n")
+    assert amux_server._cc_session_title(f) == "Survivor"
+
+
+# ── _jsonl_has_messages ─────────────────────────────────────────────────────
+
+def test_has_messages_true_for_real_conversation(amux_server, tmp_path):
+    f = tmp_path / "conv.jsonl"
+    _write_jsonl(f, _header("X") + [_msg("assistant")])
+    assert amux_server._jsonl_has_messages(f) is True
+
+
+def test_has_messages_false_for_snapshot_only(amux_server, tmp_path):
+    """claude --resume exits instantly on these, so resuming one is a fresh
+    start with extra steps."""
+    f = tmp_path / "conv.jsonl"
+    _write_jsonl(f, _header("X") + [{"type": "file-history-snapshot"}])
+    assert amux_server._jsonl_has_messages(f) is False
+
+
+def test_has_messages_false_for_missing_file(amux_server, tmp_path):
+    assert amux_server._jsonl_has_messages(tmp_path / "nope.jsonl") is False

--- a/tests/test_session_resume.py
+++ b/tests/test_session_resume.py
@@ -118,3 +118,88 @@ def test_has_messages_false_for_snapshot_only(amux_server, tmp_path):
 
 def test_has_messages_false_for_missing_file(amux_server, tmp_path):
     assert amux_server._jsonl_has_messages(tmp_path / "nope.jsonl") is False
+
+
+# ── name → conversation id ──────────────────────────────────────────────────
+
+@pytest.fixture
+def project(amux_server, tmp_path, monkeypatch):
+    """Build a fake ~/.claude/projects/<slug>/ and return a writer + work_dir."""
+    monkeypatch.setattr(amux_server, "CLAUDE_HOME", tmp_path)
+    work_dir = "/Users/someone/Projects/demo"
+    proj = tmp_path / "projects" / amux_server._project_name(work_dir)
+    proj.mkdir(parents=True)
+
+    def add(uuid, title, mtime, with_messages=True):
+        f = proj / f"{uuid}.jsonl"
+        entries = _header(title) + ([_msg()] if with_messages else
+                                    [{"type": "file-history-snapshot"}])
+        _write_jsonl(f, entries)
+        os.utime(f, (mtime, mtime))
+        return f
+
+    return add, work_dir
+
+
+def test_resolves_title_recorded_on_line_two(amux_server, project):
+    """End-to-end for the line-1 bug: nothing resolved before this."""
+    add, work_dir = project
+    add("aaaaaaaa-0000-0000-0000-000000000000", "Amux-gtm", time.time())
+    assert amux_server._cc_session_id_for_name("Amux-gtm", work_dir) == \
+        "aaaaaaaa-0000-0000-0000-000000000000"
+
+
+def test_many_same_named_sessions_resolve_to_newest(amux_server, project):
+    """The death spiral: each fresh start added another 'Amux-gtm' conversation,
+    and the old code required exactly one match — so once it had failed twice it
+    could never succeed again. Newest wins instead."""
+    add, work_dir = project
+    now = time.time()
+    add("11111111-0000-0000-0000-000000000000", "Amux-gtm", now - 500_000)
+    add("22222222-0000-0000-0000-000000000000", "Amux-gtm", now - 100_000)
+    add("33333333-0000-0000-0000-000000000000", "Amux-gtm", now - 10)
+    add("44444444-0000-0000-0000-000000000000", "Amux-gtm", now - 200_000)
+    assert amux_server._cc_session_id_for_name("Amux-gtm", work_dir) == \
+        "33333333-0000-0000-0000-000000000000"
+
+
+def test_snapshot_only_files_are_not_resume_targets(amux_server, project):
+    """A newer snapshot-only file must not beat an older real conversation."""
+    add, work_dir = project
+    now = time.time()
+    add("aaaaaaaa-0000-0000-0000-000000000000", "Amux-gtm", now - 1000)
+    add("bbbbbbbb-0000-0000-0000-000000000000", "Amux-gtm", now, with_messages=False)
+    assert amux_server._cc_session_id_for_name("Amux-gtm", work_dir) == \
+        "aaaaaaaa-0000-0000-0000-000000000000"
+
+
+def test_no_match_returns_empty(amux_server, project):
+    add, work_dir = project
+    add("aaaaaaaa-0000-0000-0000-000000000000", "Other-Session", time.time())
+    assert amux_server._cc_session_id_for_name("Amux-gtm", work_dir) == ""
+
+
+def test_missing_project_dir_returns_empty(amux_server, tmp_path, monkeypatch):
+    monkeypatch.setattr(amux_server, "CLAUDE_HOME", tmp_path)
+    assert amux_server._cc_session_id_for_name("Amux-gtm", "/no/such/dir") == ""
+
+
+def test_exists_in_project_sees_line_two_title(amux_server, project):
+    add, work_dir = project
+    add("aaaaaaaa-0000-0000-0000-000000000000", "Amux-gtm", time.time())
+    assert amux_server._cc_session_exists_in_project("Amux-gtm", work_dir) is True
+
+
+def test_exists_in_project_false_when_absent(amux_server, project):
+    add, work_dir = project
+    add("aaaaaaaa-0000-0000-0000-000000000000", "Other", time.time())
+    assert amux_server._cc_session_exists_in_project("Amux-gtm", work_dir) is False
+
+
+def test_candidates_are_ordered_newest_first(amux_server, project):
+    add, work_dir = project
+    now = time.time()
+    add("11111111-0000-0000-0000-000000000000", "S", now - 300)
+    add("22222222-0000-0000-0000-000000000000", "S", now - 100)
+    got = [p.stem[:8] for p in amux_server._cc_session_candidates("S", work_dir)]
+    assert got == ["22222222", "11111111"]

--- a/tests/test_session_resume.py
+++ b/tests/test_session_resume.py
@@ -262,3 +262,67 @@ def test_derived_name_resolves_to_a_conversation(amux_server, project):
     resolved = amux_server._resolve_cc_session_name({}, "Amux-gtm")
     assert amux_server._cc_session_id_for_name(resolved, work_dir) == \
         "aaaaaaaa-0000-0000-0000-000000000000"
+
+
+# ── _resume_strategy ─────────────────────────────────────────────────────────
+#
+# start_session is ~700 lines with tmux side effects and cannot be unit
+# tested directly, so the Claude-provider resume decision lives in this pure
+# helper: given (meta, name, work_dir), decide the tmux launch flag and which
+# meta keys (if any) should be cleared before the next start. start_session
+# applies the result — it does not re-decide anything.
+
+def test_resume_strategy_title_miss_falls_back_to_conv_id(amux_server, project):
+    """Title match misses (stale/renamed title) but the PostToolUse hook's
+    conv_id still points at a real, resumable conversation — the deterministic
+    pointer must win over giving up."""
+    add, work_dir = project
+    add("bbbbbbbb-0000-0000-0000-000000000000", "Some-Other-Title", time.time())
+    meta = {"cc_conversation_id": "bbbbbbbb-0000-0000-0000-000000000000"}
+    flag, cleared, _ = amux_server._resume_strategy(meta, "Amux-gtm", work_dir)
+    assert flag == "--resume bbbbbbbb-0000-0000-0000-000000000000"
+    assert cleared == []
+
+
+def test_resume_strategy_title_miss_conv_id_file_missing(amux_server, project):
+    """conv_id is set but no such file exists — nothing to resume, and the
+    stale pointer must be cleared so the next start doesn't re-check it."""
+    add, work_dir = project
+    meta = {"cc_conversation_id": "cccccccc-0000-0000-0000-000000000000"}
+    flag, cleared, _ = amux_server._resume_strategy(meta, "Amux-gtm", work_dir)
+    assert flag == "--name Amux-gtm"
+    assert set(cleared) == {"cc_conversation_id"}
+
+
+def test_resume_strategy_title_miss_conv_id_snapshot_only(amux_server, project):
+    """conv_id's file exists but has no real turns (claude --resume would exit
+    instantly on it) — treat it the same as missing: fresh start, cleared."""
+    add, work_dir = project
+    add("dddddddd-0000-0000-0000-000000000000", "Some-Other-Title", time.time(),
+        with_messages=False)
+    meta = {"cc_conversation_id": "dddddddd-0000-0000-0000-000000000000"}
+    flag, cleared, _ = amux_server._resume_strategy(meta, "Amux-gtm", work_dir)
+    assert flag == "--name Amux-gtm"
+    assert set(cleared) == {"cc_conversation_id"}
+
+
+def test_resume_strategy_title_hit_wins_and_conv_id_untouched(amux_server, project):
+    """The common case: title match succeeds. conv_id (even if present and
+    unrelated) is not consulted or cleared."""
+    add, work_dir = project
+    add("eeeeeeee-0000-0000-0000-000000000000", "Amux-gtm", time.time())
+    meta = {"cc_conversation_id": "ffffffff-0000-0000-0000-000000000000"}
+    flag, cleared, _ = amux_server._resume_strategy(meta, "Amux-gtm", work_dir)
+    assert flag == "--resume eeeeeeee-0000-0000-0000-000000000000"
+    assert cleared == []
+    assert meta == {"cc_conversation_id": "ffffffff-0000-0000-0000-000000000000"}
+
+
+def test_resume_strategy_first_ever_start_nothing_to_clear(amux_server, project):
+    """A genuine first-ever start (empty meta, no conversations anywhere) must
+    not be reported as a stale name, and there is nothing to clear or save."""
+    _add, work_dir = project
+    flag, cleared, msg = amux_server._resume_strategy({}, "Amux-gtm", work_dir)
+    assert flag == "--name Amux-gtm"
+    assert cleared == []
+    assert "no prior conversation" in msg

--- a/tests/test_session_resume.py
+++ b/tests/test_session_resume.py
@@ -203,3 +203,30 @@ def test_candidates_are_ordered_newest_first(amux_server, project):
     add("22222222-0000-0000-0000-000000000000", "S", now - 100)
     got = [p.stem[:8] for p in amux_server._cc_session_candidates("S", work_dir)]
     assert got == ["22222222", "11111111"]
+
+
+def test_candidates_empty_when_project_name_resolution_raises(amux_server, tmp_path, monkeypatch):
+    """A pathological work_dir (e.g. a symlink cycle, or a home directory that
+    can't be determined) can raise RuntimeError out of Path.expanduser()/
+    resolve() inside _project_name. That must not escape into session startup."""
+    monkeypatch.setattr(amux_server, "CLAUDE_HOME", tmp_path)
+
+    def boom(work_dir):
+        raise RuntimeError("symlink cycle")
+
+    monkeypatch.setattr(amux_server, "_project_name", boom)
+    assert amux_server._cc_session_candidates("Amux-gtm", "/some/dir") == []
+
+
+def test_candidates_empty_when_project_dir_cannot_be_listed(amux_server, project, monkeypatch):
+    """A project directory that exists but raises OSError on iteration (e.g.
+    permission denied) must not raise into session startup. Forced via
+    monkeypatch rather than chmod so this passes when run as root too."""
+    add, work_dir = project
+    add("aaaaaaaa-0000-0000-0000-000000000000", "Amux-gtm", time.time())
+
+    def boom(self, pattern):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "glob", boom)
+    assert amux_server._cc_session_candidates("Amux-gtm", work_dir) == []

--- a/tests/test_session_resume.py
+++ b/tests/test_session_resume.py
@@ -230,3 +230,35 @@ def test_candidates_empty_when_project_dir_cannot_be_listed(amux_server, project
 
     monkeypatch.setattr(Path, "glob", boom)
     assert amux_server._cc_session_candidates("Amux-gtm", work_dir) == []
+
+
+# ── name derivation ─────────────────────────────────────────────────────────
+
+def test_derives_amux_name_when_meta_is_empty(amux_server):
+    """The crash case. cc_session_name was written only in stop_session(), so
+    any ending that was not a graceful stop — crash, reboot, sleep, server
+    restart — left meta empty and forced a fresh start on a session that was
+    fully resumable. amux always launches with `--name <session name>`, so the
+    name was derivable the whole time."""
+    assert amux_server._resolve_cc_session_name({}, "Amux-gtm") == "Amux-gtm"
+
+
+def test_persisted_meta_name_wins(amux_server):
+    """A /rename inside Claude must still be honoured over the amux name."""
+    assert amux_server._resolve_cc_session_name(
+        {"cc_session_name": "Renamed-By-User"}, "Amux-gtm") == "Renamed-By-User"
+
+
+def test_blank_meta_name_falls_back_to_amux_name(amux_server):
+    """An empty string is not a rename — it is absence, and must not win."""
+    assert amux_server._resolve_cc_session_name(
+        {"cc_session_name": ""}, "Amux-gtm") == "Amux-gtm"
+
+
+def test_derived_name_resolves_to_a_conversation(amux_server, project):
+    """End to end: empty meta, as after a crash, still finds the conversation."""
+    add, work_dir = project
+    add("aaaaaaaa-0000-0000-0000-000000000000", "Amux-gtm", time.time())
+    resolved = amux_server._resolve_cc_session_name({}, "Amux-gtm")
+    assert amux_server._cc_session_id_for_name(resolved, work_dir) == \
+        "aaaaaaaa-0000-0000-0000-000000000000"


### PR DESCRIPTION
## The bug

Every amux session restarts with no memory of prior work. The recovery path — the peek UI's "Load log" button — tells the session to read `~/.amux/logs/.plain/<name>.log`, which for one session is **2.6 MB / 59,900 lines**. That does not fit in a context window, so recovery does not work.

But the log is a workaround for a door that was never supposed to be locked. `start_session` already has a resume path (`claude --resume <uuid>`). **It has never executed.** From `~/.amux/serve.log`, every session on this install:

```
[start] Amux-gtm: fresh start (new session)
[start] Amux: fresh start (new session)
[start] amux-helper: fresh start (new session)
... all 8
```

`Amux-gtm.meta.json` shows `start_count: 13` — thirteen restarts, thirteen blank slates.

## Three compounding bugs, each fatal alone

| # | Bug |
|---|---|
| 1 | `cc_session_name` was persisted **only in `stop_session()`**. Any ending that wasn't a graceful stop — crash, reboot, sleep, server restart — lost it. |
| 2 | The name lookup read **only line 1** of each conversation JSONL. Claude Code writes `custom-title` on **line 2**. Measured: 0 matches across all 26 files in the project. |
| 3 | The lookup required **exactly one** match. Six files share the title `Amux-gtm` — one per fresh start. |

Bug 3 is the death spiral: every blank start created another identically-named conversation, making the next lookup *more* ambiguous. It could never self-correct.

A fourth, latent: the old lookup returned a `sessionId` read from line 1 rather than the filename stem — wrong even when it matched.

## The fix

- **Derive the name instead of storing it.** amux always launches with `--name <session name>`, so it was knowable all along. Removes the crash window entirely and repairs existing sessions with no migration.
- **Scan the JSONL header block** (bounded, 30 lines) instead of line 1.
- **Newest match wins**, with snapshot-only files filtered out (`--resume` exits on those) and a deterministic `(-mtime, stem)` tie-break.
- The decision now lives in a pure `_resume_strategy(meta, name, work_dir)` helper, because `start_session` is ~700 lines with tmux side effects and none of this was testable before.

## Two regressions this fix would have caused, caught in review and fixed here

- **`reset_session` and "New conversation" became silent no-ops.** Both worked by *deleting* meta keys — which only forced a fresh start while the lookup was dead. With the name derived, deletion accomplished nothing: the next start resumed the conversation the user had just abandoned, while reporting `"reset — fresh conversation, lane intact"`. Since `reset` exists for the out-of-context emergency, this removed the only remedy for the exact case it's for. Fixed with a positive `cc_fresh_after` watermark.
- **Title-matching pre-empted the hook-reported `cc_conversation_id`**, which `amux-server.py` documents as "the ONLY deterministic link from an amux session to its conversation JSONL" — and the not-found path *deleted* it. Now consulted before any fallback to a blank start.

Also fixed: `_session_jsonl_path_uncached` had the identical line-1 bug, so peek transcript resolution silently fell through every time.

## Evidence

Replaying the fixed decision against all 8 real sessions:

```
AI---Work-Course                     RESUME  uuid=54970364-…
Amux-gtm                             RESUME  uuid=642f49e4-…
Amux-inspector                       RESUME  uuid=5a2ede61-…
Amux                                 RESUME  uuid=126a7189-…
Family-Command-and-Control-Center    RESUME  uuid=4f89a0e2-…
Kids-Daily-Prep                      RESUME  uuid=529d8af9-…
amux-helper                          RESUME  uuid=d5baa440-…
windsor-suits-rebuild                fresh   (malformed CC_DIR — a file:// URL, pre-existing)
duplicates: none
```

**7/8 resume; 0/8 did before. No two sessions resolve to the same conversation.**

Tests: **236 passing** (178 before this branch), 30 new in `tests/test_session_resume.py` pinning each named regression — line-2 titles, the ambiguity spiral, newer-snapshot-must-not-beat-older-real-conversation, post-reset freshness, and cross-session ownership.

## Known limitation

The `int(time.time())` reset watermark assumes sub-second filesystem mtime granularity (true on APFS and ext4). On a 1-second-granularity filesystem it can cost one spurious extra fresh start immediately after a reset, self-healing on the next restart. Truncating down with `<=` is deliberate: it errs toward an extra fresh start rather than resuming an abandoned conversation.

## Scope

Part A of `docs/superpowers/specs/2026-07-31-session-context-recovery-design.md`. Part B (a compact resume brief for `/clear` and compaction) and Part C (retiering the Load log prompt) are deferred.

**Not yet done: live acceptance.** This needs deploying to a running server and restarting a session to confirm `serve.log` reports `resume=` instead of `fresh start`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iNkfTyW4TdD5pbwLMGibZ