### PR TITLE
fix(board): Ask Amux reported failure on every click, including success

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,22 @@ your task, not the platform.
 ## Workflow
 
 - **Commit after every completed task.** When you finish a piece of work (bug fix, feature, refactor), immediately `git add amux-server.py && git commit` with a concise message. Don't batch multiple tasks into one commit.
-- The server auto-restarts on file save (watches its own mtime), so changes are live immediately.
+- The server auto-restarts on file save (watches its own mtime) — but **it watches the
+  file it is RUNNING, which is `~/.local/bin/amux-server.py`, not your repo checkout.**
+  Editing `~/amux/amux-server.py` alone changes nothing that is live: `ps` the process
+  and you will see it running out of `~/.local/bin`. To see a change on
+  `https://localhost:8822`, install it, then confirm it actually took:
+  ```bash
+  cp amux-server.py ~/.local/bin/amux-server.py
+  launchctl kickstart -k gui/$(id -u)/com.amux.serve   # label is com.amux.serve
+  curl -sk https://localhost:8822/ | grep -c '<a line unique to your change>'
+  ```
+  Verify with a string your edit INTRODUCED, not one that already existed — grepping a
+  common idiom returns a happy non-zero count against the old build and tells you
+  nothing (this cost a wrong "it's live" call on AMUX-4).
+- Always verify Python syntax after edits: `python3 -c "import ast; ast.parse(open('amux-server.py').read())"`
+- **Client JS changes need `APP_VER` and the sw.js `CACHE` bumped together**, or a
+  browser holding the cached script never receives the fix.
 - Always verify Python syntax after edits: `python3 -c "import ast; ast.parse(open('amux-server.py').read())"`
 
 ## Deploy
@@ -121,7 +136,7 @@ S3 bucket config (on `ethan-personal`):
 - Bucket policy grants public `s3:GetObject` on `arn:aws:s3:::ethan-personal/amux/*.ics` (widened from the single `calendar.ics` key so cache-busting keys work). Bucket LISTING is denied (403), so a random key is not discoverable.
 - Current key: a **random token** (`amux/cal-<32hex>.ics`) that lives ONLY in `~/.amux/server.env` — **NEVER commit the actual key/URL to this repo: the repo is public, and a committed feed URL is how the old guessable key leaked.** Read it with `grep AMUX_S3_KEY ~/.amux/server.env`; the dashboard's Subscribe button shows the full URL.
 
-**Google caches ICS feeds by URL, hard.** There is no reliable way to force a refresh — Google refetches on its own cadence (hours). If you edit the feed's *content shape* and need Google to see it now, publish to a NEW random key and re-subscribe; the old URL keeps serving Google's stale cache. `AMUX_S3_KEY` is read at startup via `os.environ.setdefault`, and execv reloads inherit the env, so changing it needs a real restart: `launchctl kickstart -k gui/$(id -u)/com.amux.server`.
+**Google caches ICS feeds by URL, hard.** There is no reliable way to force a refresh — Google refetches on its own cadence (hours). If you edit the feed's *content shape* and need Google to see it now, publish to a NEW random key and re-subscribe; the old URL keeps serving Google's stale cache. `AMUX_S3_KEY` is read at startup via `os.environ.setdefault`, and execv reloads inherit the env, so changing it needs a real restart: `launchctl kickstart -k gui/$(id -u)/com.amux.serve`.
 
 The feed auto-uploads to S3 on every event write. The dashboard's calendar subscription button shows the S3 URL directly when configured.
 

--- a/amux
+++ b/amux
@@ -1538,8 +1538,21 @@ except ValueError:
 print(u) if u else sys.exit('tunnel not running')
 "
       ;;
+    help|-h|--help)
+      _tunnel_help
+      ;;
     *)
-      cat <<EOF
+      # Same exit-0-on-unknown trap as `amux board` had: fail loudly instead,
+      # so a caller can distinguish "ran" from "silently printed help".
+      echo "${RED}unknown tunnel subcommand:${RESET} $subcmd" >&2
+      _tunnel_help >&2
+      exit 2
+      ;;
+  esac
+}
+
+_tunnel_help() {
+  cat <<EOF
 ${BOLD}amux tunnel${RESET} — expose a local port at a public HTTPS URL
 
   amux tunnel status          Show tunnel state and public URL
@@ -1551,8 +1564,6 @@ Any localhost port works: ${BOLD}amux tunnel start 3000${RESET} publishes your d
 Requires an active amux cloud subscription; set AMUX_TUNNEL_TOKEN in
 ~/.amux/server.env, then \`touch amux-server.py\` to reload.
 EOF
-      ;;
-  esac
 }
 
 cmd_alert() {

--- a/amux-server.py
+++ b/amux-server.py
@@ -20872,10 +20872,16 @@ def send_text(name: str, text: str, _from_steering: bool = False, defer_if_busy:
                         # Steering must land at a real idle boundary, never type
                         # into a live turn — re-queue for the next tick.
                         return False, "session started generating — retry at next turn boundary"
-                else:
+                elif not _waiting:
                     # Close any picker left open by a previous attempt, so the C-u
                     # below actually reaches the input. Without this a retry appends
-                    # and the message is submitted twice ("msg msg").
+                    # and the message is submitted twice ("msg msg"). Skipped when
+                    # _waiting: there the pane IS a genuine, CURRENT live selector
+                    # (AskUserQuestion / tool approval / confirm dialog), not a
+                    # stale leftover — this same Escape REJECTS that pending tool
+                    # instead of closing an old popup (Terminal-tab composer
+                    # couldn't answer a picker, mobile app had to be used instead —
+                    # AI-3, 2026-08-02/03). Type straight into it instead.
                     subprocess.run(["tmux", "send-keys", "-t", t, "Escape"], capture_output=True, timeout=5)
                     _esc_at = time.monotonic()
                     time.sleep(0.05)

--- a/amux-server.py
+++ b/amux-server.py
@@ -32738,8 +32738,17 @@ async function _askCardStatus(id, sess) {
     const r = await apiCall(API + '/api/board/' + id + '/status-request', {
       method: 'POST', headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({}) });
-    if (r && r.delivered) showToast('Asked ' + sess + ' to post a status update');
-    else showToast((r && (r.reason || r.message)) || 'Could not reach ' + sess);
+    // apiCall resolves to the raw Response, NOT parsed JSON — and to null when
+    // it already toasted an HTTP error or queued the op offline. Reading
+    // .delivered straight off the Response made the success branch
+    // unreachable, so this said "Could not reach <sess>" on every click even
+    // though the request was delivered and written to the card log (AMUX-4).
+    // A toast that cannot report success is an instrument that cannot express
+    // the outcome it exists to report (ethos §4).
+    if (!r) return;
+    const d = await r.json().catch(() => ({}));
+    if (d && d.delivered) showToast('Asked ' + sess + ' to post a status update');
+    else showToast((d && (d.reason || d.message)) || 'Could not reach ' + sess);
   } catch (e) { showToast('Status request failed'); }
 }
 
@@ -35672,7 +35681,7 @@ async function saveGlobalMemory() {
   }
 }
 
-const APP_VER = '0.9.452';   // bump together with the sw.js CACHE version
+const APP_VER = '0.9.453';   // bump together with the sw.js CACHE version
 let _peekScrollLockY = 0;
 // Paint a cached peek entry (offline / instant-open). Returns false when the
 // cache has no real content — the caller then keeps 'Loading…'/reconnecting
@@ -57187,7 +57196,7 @@ PWA_MANIFEST = json.dumps({
 
 # Robust service worker: cache-first with localStorage fallback for multi-day offline
 SERVICE_WORKER = r"""
-const CACHE = 'amux-v0.9.452';
+const CACHE = 'amux-v0.9.453';
 const SHELL_URLS = ['/', '/manifest.json', '/icon.svg', '/icon.png', '/icon-192.png', '/icon-512.png'];
 
 // Install: pre-cache entire app shell

--- a/tests/test_ask_card_status.mjs
+++ b/tests/test_ask_card_status.mjs
@@ -1,0 +1,78 @@
+// Board "Ask Amux" status-request toast — regression test for AMUX-4.
+//
+// Ethan clicked Ask Amux three times and got "Could not reach Amux" every
+// time. All three had actually been DELIVERED (the card log recorded them and
+// the session received the prompts) — only the toast was wrong. apiCall()
+// resolves to the raw Response, not parsed JSON, so reading `.delivered` off
+// it was always undefined and the success branch was unreachable.
+//
+// Like tests/test_peek_parity.py, this loads the REAL function out of
+// amux-server.py instead of replicating it. That is the whole point: a
+// re-typed paraphrase of _askCardStatus would have passed against the broken
+// client, because the bug was in the shipped text, not in the logic as
+// imagined (ethos §7 — test the shipped code path, not a paraphrase).
+//
+// Run:  node tests/test_ask_card_status.mjs
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const SERVER = join(dirname(fileURLToPath(import.meta.url)), '..', 'amux-server.py');
+const src = readFileSync(SERVER, 'utf8');
+
+const m = src.match(/async function _askCardStatus\(id, sess\) \{[\s\S]*?\n\}/);
+if (!m) {
+  console.error('FAIL: could not extract _askCardStatus from amux-server.py '
+    + '(renamed or reshaped? update this test rather than deleting it)');
+  process.exit(1);
+}
+const fnSrc = m[0];
+
+let toasts = [];
+
+// Stubs mirroring the real client environment. apiCall returns the raw
+// Response — that IS the contract, and the bug was forgetting it.
+function makeApiCall(payload, { httpOk = true } = {}) {
+  return async () => {
+    if (!httpOk) return null;   // apiCall already toasted / queued offline
+    return new Response(JSON.stringify(payload), {
+      status: 200, headers: { 'Content-Type': 'application/json' },
+    });
+  };
+}
+
+async function check(label, payload, expectSubstr, opts) {
+  toasts = [];
+  // Evaluating source read from our own repo file, same trust model as the
+  // ast/exec loading in the Python tests next door.
+  const fn = new Function('API', 'apiCall', 'showToast',
+    fnSrc + '; return _askCardStatus;')(
+    'https://localhost:8822', makeApiCall(payload, opts), (t) => toasts.push(t));
+  await fn('AMUX-4', 'Amux');
+  const got = toasts[0] === undefined ? '(no toast)' : toasts[0];
+  const pass = expectSubstr === null ? toasts.length === 0 : got.includes(expectSubstr);
+  console.log(`${pass ? 'PASS' : 'FAIL'}  ${label}\n      toast: ${got}`);
+  return pass;
+}
+
+const results = [];
+
+// The exact case Ethan hit: the server delivered it, so the UI must say so.
+results.push(await check('delivered:true -> success toast',
+  { ok: true, delivered: true, session: 'Amux', message: 'asked Amux to post a status update' },
+  'Asked Amux to post a status update'));
+
+// The server's honest offline path must reach the human verbatim, not be
+// flattened into a generic failure.
+results.push(await check('delivered:false -> server reason shown',
+  { ok: false, delivered: false, reason: "session 'Amux' is not running" },
+  'is not running'));
+
+// apiCall already showed 'Error: NNN' or queued the op — a second toast here
+// would be a false claim about reachability.
+results.push(await check('apiCall returned null -> no second toast',
+  null, null, { httpOk: false }));
+
+const failed = results.filter((r) => !r).length;
+console.log(failed ? `\n${failed} test(s) FAILED` : '\nAll tests passed');
+process.exit(failed ? 1 : 0);

--- a/tests/test_send_text_picker_escape.py
+++ b/tests/test_send_text_picker_escape.py
@@ -1,0 +1,131 @@
+"""Regression test: a deliberate human send at a live picker must not send a
+pre-emptive Escape.
+
+Bug (amux board AI-3 / user report, 2026-08-02..03): the Terminal tab's
+composer can't answer an AskUserQuestion / tool-approval / confirm-dialog
+picker. `send_text()`'s cleanup step ("close any picker left open by a
+previous attempt") sends Escape unconditionally whenever the session is not
+mid-turn -- including when `_waiting` is True, i.e. the pane IS a genuine,
+CURRENT live selector, not a stale leftover. That Escape REJECTS the pending
+tool ("[Request interrupted by user]" -- the same contention documented
+in-code for the gtm-engine incident, 2026-07-15) before the typed answer ever
+reaches it. The quick-action chips (arrow keys via send_keys) never hit this
+path and work correctly today, which is the tell.
+
+Loads the REAL send_text out of amux-server.py via AST (same technique as
+test_steering_delivery.py) and stubs every I/O boundary (tmux, disk, locks)
+so the escape-guard LOGIC runs unmodified against a fake clock/pane.
+"""
+import ast, os, re, threading
+
+SERVER = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                      "amux-server.py")
+
+# ── recorded tmux calls ───────────────────────────────────────────────────────
+CALLS = []
+
+class _FakeSubprocess:
+    class CalledProcessError(Exception):
+        pass
+    class TimeoutExpired(Exception):
+        pass
+
+    @staticmethod
+    def run(args, **kwargs):
+        CALLS.append(list(args))
+        class _R:
+            returncode = 0
+            stdout = b""
+            stderr = b""
+        return _R()
+
+
+# ── controllable fake state ──────────────────────────────────────────────────
+STATUS = "waiting"          # what _detect_claude_status should report
+PANE_TEXT = "some pane text without the interrupt hint"   # raw capture text
+
+
+def _fake_tmux_capture(name, lines=500):
+    return PANE_TEXT
+
+
+def _fake_detect_status(raw):
+    return STATUS
+
+
+ns = {
+    "subprocess": _FakeSubprocess,
+    "threading": threading,
+    "time": __import__("time"),
+    "re": re,
+    "tempfile": __import__("tempfile"),
+    "os": os,
+    # I/O boundary stubs — none of these paths are under test here.
+    "_session_iterm2_id": lambda name: None,
+    "_iterm2_send": lambda *a, **k: (True, "ok"),
+    "_session_auto_actions": {},
+    "_load_meta": lambda name: {"last_started": 0},
+    "tmux_capture": _fake_tmux_capture,
+    "_at_resume_picker": lambda out: False,
+    "_at_shell_prompt": lambda out: False,
+    "is_running": lambda name: True,
+    "_get_send_lock": lambda name: threading.Lock(),
+    "tmux_name": lambda name: name,
+    "tmux_target": lambda name: name,
+    "_detect_claude_status": _fake_detect_status,
+    "_steer_enqueue": lambda name, text, guard="": "queued",
+    "_verify_submitted": lambda name, target, text, esc_at=0.0, sent_at=0.0: True,
+    "_send_after_ready": lambda *a, **k: None,
+    "_auto_waking": set(),
+    "CC_SESSIONS": None,
+    "start_session": lambda name: (True, "ok"),
+}
+
+tree = ast.parse(open(SERVER, encoding="utf-8").read())
+_want_assign = {"_AT_PICKER_RE"}
+_want_func = {"send_text"}
+for node in tree.body:
+    if isinstance(node, ast.Assign) and isinstance(node.targets[0], ast.Name) \
+            and node.targets[0].id in _want_assign:
+        exec(compile(ast.Module(body=[node], type_ignores=[]), SERVER, "exec"), ns)
+    if isinstance(node, ast.FunctionDef) and node.name in _want_func:
+        exec(compile(ast.Module(body=[node], type_ignores=[]), SERVER, "exec"), ns)
+
+send_text = ns["send_text"]
+
+
+def _escape_calls():
+    return [c for c in CALLS if len(c) >= 5 and c[1] == "send-keys" and c[-1] == "Escape"]
+
+
+def _text_calls():
+    return [c for c in CALLS if len(c) >= 5 and c[1] == "send-keys" and "-l" in c]
+
+
+# ── T1: live picker (waiting) — a deliberate human send must NOT escape ───────
+CALLS.clear()
+STATUS = "waiting"
+PANE_TEXT = "❯ 1. Yes\n  2. No\n(Enter to select)"
+ok, msg = send_text("s1", "my answer")
+assert ok, f"T1: send_text failed: {msg}"
+assert _escape_calls() == [], (
+    f"T1: BUG — Escape sent while at a live selector (_waiting=True); "
+    f"this rejects the pending tool call instead of answering it. Calls: {CALLS}"
+)
+assert _text_calls(), f"T1: the answer text was never typed at all: {CALLS}"
+print("T1 ok — live selector: no pre-emptive Escape, answer typed directly")
+
+# ── T2: plain idle prompt — cleanup Escape should still fire as before ────────
+CALLS.clear()
+STATUS = "idle"
+PANE_TEXT = "some idle prompt, no selector here"
+ok, msg = send_text("s2", "a normal prompt")
+assert ok, f"T2: send_text failed: {msg}"
+assert _escape_calls(), (
+    f"T2: cleanup Escape regressed for the genuine stale-popup case (idle, not "
+    f"at a selector) — this Escape is needed there to close a leftover "
+    f"autocomplete popup so C-u actually reaches the input. Calls: {CALLS}"
+)
+print("T2 ok — plain idle prompt: cleanup Escape still fires (unchanged)")
+
+print("\nAll send_text picker-escape tests passed!")


### PR DESCRIPTION
## Why

Ethan clicked **Ask Amux** three times on AMUX-3 and got `Could not reach Amux` every time. All three had in fact been **delivered** — the card log recorded `status requested by Ethan (routed to Amux)` ×3 and the session received the prompts. Only the toast was wrong.

## Root cause

`apiCall()` resolves to the raw `Response`, not parsed JSON (and to `null` when it has already toasted an HTTP error or queued the op offline). `_askCardStatus` read `.delivered` straight off the Response, where it is `undefined` — so the **success branch was unreachable**. `.reason`/`.message` are undefined there too, so success, honest-offline, and HTTP error all collapsed into the same `'Could not reach ' + sess` string. It also double-toasted on top of `apiCall`'s own `Error: NNN`.

That is ethos §4: the instrument could not express the outcome it exists to report, so the human reached the only conclusion the UI supported and it was wrong.

A scan of all 63 `await apiCall(` sites found this was the **only** one misusing the Response as JSON.

## What's here

- **`fix(board)`** — parse the body with the house idiom, return early on `null`. `APP_VER` + sw.js `CACHE` bumped together (`0.9.453`), or a browser holding the cached script never receives the fix.
- **`test(board)`** — regression test that loads the **shipped** `_askCardStatus` out of `amux-server.py` rather than replicating it (same rationale as `tests/test_peek_parity.py`): the bug lived in the shipped text, so a re-typed paraphrase would have passed against the broken client. Covers all three outcomes the toast must tell apart. Mutation-checked — reintroducing the bug turns it red, restore turns it green.
- **`fix(cli)`** — `amux tunnel` unknown subcommands fell through to help and exited 0. (The identical `amux board` bug was fixed independently upstream while this was in flight; I dropped my version during rebase and kept upstream's.)
- **`docs`** — the restart command named `com.amux.server`; the real launchd label is `com.amux.serve`, so the documented command fails and sends you hunting a broken server instead of a typo. Also: "changes are live immediately" is only true of the file the server is *running* (`~/.local/bin/amux-server.py`) — editing the repo checkout changes nothing live, which reads exactly like "my fix didn't work".

## How this was found

The status-request notification instructed me to run `amux board status-update <id> "..."`. The installed CLI was a stale Jul-31 copy without that subcommand, so it printed help and **exited 0** — following the instruction exactly produced a success signal and posted nothing. That is the AMUX-2140 shape, and it is why three status requests vanished.

## Verification

- `python3 -c "import ast; ast.parse(...)"` and `bash -n ./amux` clean
- `node tests/test_ask_card_status.mjs` green; red when the bug is reintroduced
- Directly-runnable `tests/test_*.py` pass (pytest is not installed here, so the pytest-only files were not exercised)
- Live end-to-end: `POST /api/board/AMUX-4/status-request` returns `delivered: true` and the fixed client renders the success toast

## Note on scope

Includes `6ded032` (`fix(send)`, authored by session **Amux-inspector**) — it is the ancestor of this work in a shared checkout, so it cannot be separated without rewriting history. Ethan explicitly approved shipping it after being shown exactly this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDuBnmfziM6uGvdxn2y3Lo