### PR TITLE
Make staleness announce itself — session freshness hook + push-guard false positive

### DIFF
--- a/.claude/session-freshness.sh
+++ b/.claude/session-freshness.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# SessionStart hook: say out loud, at the one moment it matters, whether this
+# session is about to build on something stale.
+#
+# Two DIFFERENT staleness axes bit in one session on 2026-08-05, which is why
+# this checks both:
+#
+#   1. The CHECKOUT was ~110 commits behind origin/main. Work got built on a
+#      stale base; one fix turned out to duplicate a fix upstream already had,
+#      and the rebase that followed conflicted twice.
+#   2. The INSTALLED CLI (~/.local/bin/amux) was a Jul-31 copy missing the
+#      `status-update` verb. It fell through to help and exited 0, so three of
+#      the owner's status requests were silently swallowed (AMUX-2140 shape).
+#
+# Design constraints, each one deliberate:
+#
+#   * It FETCHES, never pulls. This is a shared checkout — CLAUDE.md records a
+#     peer's `git pull --rebase` replaying another session's unpushed commit
+#     onto origin. A hook that rewrites the working tree can destroy in-flight
+#     work belonging to a session that is not even running right now. Report
+#     and recommend; the human decides (ethos rule 8).
+#   * It FAILS OPEN. Offline, no remote, detached HEAD, missing files — every
+#     failure path exits 0 silently. A freshness check that blocks a session is
+#     worse than the staleness it detects.
+#   * It is SILENT when everything is current, so the one time it speaks is
+#     signal rather than another banner to scroll past.
+set -uo pipefail
+
+[ "${AMUX_SKIP_FRESHNESS:-}" = "1" ] && exit 0
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/null && pwd -P)" || exit 0
+cd "$REPO" 2>/dev/null || exit 0
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+out=""
+
+# ── Axis 1: is the checkout behind its remote? ───────────────────────────────
+# Bounded: a hook that hangs on a slow network is a hook that gets deleted.
+if git remote get-url origin >/dev/null 2>&1; then
+  timeout 10 git fetch -q origin 2>/dev/null
+  base="$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo origin/main)"
+  if git rev-parse --verify -q "$base" >/dev/null 2>&1; then
+    behind="$(git rev-list --count "HEAD..$base" 2>/dev/null || echo 0)"
+    if [ "${behind:-0}" -gt 0 ]; then
+      # Name the files that actually matter here, not just a number: "110
+      # commits behind" reads as bookkeeping, "amux-server.py changed upstream"
+      # reads as "your edit is going to conflict".
+      hot="$(git diff --name-only "HEAD..$base" 2>/dev/null \
+             | grep -E '^(amux-server\.py|amux|CLAUDE\.md)$' | tr '\n' ' ')"
+      out+="  - checkout is ${behind} commit(s) behind ${base}"
+      [ -n "$hot" ] && out+=" — including: ${hot}"
+      out+=$'\n'
+      out+=$'    git pull --rebase origin main   (review first: this checkout is SHARED)\n'
+    fi
+  fi
+fi
+
+# ── Axis 2: does what is INSTALLED match this checkout? ──────────────────────
+# The repo copy is the source; install.sh copies it. Editing the repo alone
+# changes nothing that a session or the dashboard actually executes.
+live_cli="$(command -v amux 2>/dev/null || true)"
+if [ -n "$live_cli" ] && [ -f "$REPO/amux" ]; then
+  if ! diff -q "$REPO/amux" "$live_cli" >/dev/null 2>&1; then
+    out+="  - installed CLI differs from this checkout: ${live_cli}"$'\n'
+    out+="    an unknown verb there may print help and exit 0 — a silent no-op"$'\n'
+    out+="    cp \"$REPO/amux\" \"$live_cli\""$'\n'
+  fi
+fi
+
+# Compare against the server that is actually RUNNING, resolved from the
+# process itself rather than a hardcoded path — a hardcoded path matches on one
+# machine and silently checks nothing everywhere else (ethos rule 7).
+run_srv="$(ps -axo command= 2>/dev/null | grep -oE '[^ ]*/amux-server\.py' | head -1 || true)"
+if [ -n "$run_srv" ] && [ -f "$run_srv" ] && [ -f "$REPO/amux-server.py" ]; then
+  if ! diff -q "$REPO/amux-server.py" "$run_srv" >/dev/null 2>&1; then
+    out+="  - the RUNNING server is not this checkout: ${run_srv}"$'\n'
+    out+="    edits here are not live until installed + restarted"$'\n'
+    out+="    cp \"$REPO/amux-server.py\" \"$run_srv\" && launchctl kickstart -k gui/\$(id -u)/com.amux.serve"$'\n'
+  fi
+fi
+
+[ -z "$out" ] && exit 0
+
+printf 'amux freshness — this session may be building on something stale:\n\n%s\n' "$out"
+printf 'Reconcile before starting work, or say so in your first message if you are deliberately not.\n'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,18 @@
   "model": "claude-opus-4-6",
   "thinking": true,
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/session-freshness.sh",
+            "timeout": 20,
+            "statusMessage": "Checking amux freshness..."
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write|MultiEdit",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,23 @@ your task, not the platform.
 
 ## Workflow
 
+- **Staleness announces itself; nothing auto-pulls.** The `SessionStart` hook
+  (`.claude/session-freshness.sh`) fetches and reports two things a session cannot see
+  on its own: how far this checkout is behind `origin/main` (naming `amux-server.py` /
+  `amux` / `CLAUDE.md` when they are in the diff, because those are the conflicts you
+  are about to hit), and whether the INSTALLED CLI and the RUNNING server still match
+  this checkout. It is silent when everything is current.
+
+  **Do not "improve" it into a scheduled pull.** This is a shared checkout, and the
+  Deploy section below records a peer's `git pull --rebase` replaying another session's
+  unpushed commit onto origin. A background job that rewrites the working tree can
+  destroy in-flight work belonging to a session that is not even running. The hook
+  reports; the human decides. Set `AMUX_SKIP_FRESHNESS=1` to silence it.
+
+  Both axes are there because both bit on 2026-08-05: the checkout was ~110 commits
+  behind (a fix was written that upstream already had), and the installed CLI was a
+  Jul-31 copy whose missing verb printed help and exited 0, silently swallowing three
+  status requests.
 - **Commit after every completed task.** When you finish a piece of work (bug fix, feature, refactor), immediately `git add amux-server.py && git commit` with a concise message. Don't batch multiple tasks into one commit.
 - The server auto-restarts on file save (watches its own mtime) — but **it watches the
   file it is RUNNING, which is `~/.local/bin/amux-server.py`, not your repo checkout.**

--- a/amux-server.py
+++ b/amux-server.py
@@ -18665,9 +18665,25 @@ def main():
             local_sha, remote_sha = parts[1], parts[3]
             if local_sha.strip("0") == "":
                 continue                      # branch deletion
-            rng = local_sha if remote_sha == ZERO else remote_sha + ".." + local_sha
+            # A NEW branch has no remote counterpart, so remote_sha is all
+            # zeros. Walking `local_sha` alone then means "everything reachable"
+            # — the ENTIRE history — and the guard reported 1081 foreign commits
+            # for a branch that added exactly one, every other commit already
+            # sitting on origin and shipping nothing.
+            #
+            # That is worse than a missing check. The guard's whole value is
+            # that AMUX_ALLOW_FOREIGN=1 stays a deliberate act; one that cries
+            # wolf on every `git checkout -b` teaches the reflex of setting it
+            # blind, and then the one push that really does carry someone
+            # else's work sails through. Bound the walk by what origin ALREADY
+            # has, which is the question the guard actually means to ask.
+            if remote_sha == ZERO:
+                rng_args = [local_sha, "--not", "--remotes=origin"]
+            else:
+                rng_args = [remote_sha + ".." + local_sha]
             out = subprocess.run(
-                ["git", "log", "--format=%h%x1f%s%x1f%(trailers:key=Amux-Session,valueonly)", rng],
+                ["git", "log", "--format=%h%x1f%s%x1f%(trailers:key=Amux-Session,valueonly)"]
+                + rng_args,
                 capture_output=True, text=True, timeout=15).stdout
             for row in out.splitlines():
                 if not row.strip():


### PR DESCRIPTION
Two checks that could not do their job. Both surfaced while fixing AMUX-4.

---

## 1. `chore(hooks)` — announce staleness at session start

Two different staleness axes bit in one session, and neither was visible from inside it:

1. The **checkout** was ~110 commits behind `origin/main`. A CLI fix was written against that stale base that **upstream already had**, and the rebase to recover conflicted twice.
2. The **installed CLI** (`~/.local/bin/amux`) was a Jul-31 copy with no `status-update` verb. It fell through to help and **exited 0**, silently swallowing three of the owner's status requests — the AMUX-2140 shape, where following the sanctioned instruction exactly is what produces the failure.

**Why a hook and not a doc line.** A doc relies on the model choosing to check, and is exactly what gets skipped when a task looks small (ethos rule 1). The server *already* detects the CLI/PATH drift from AC-193 — but writes it to `slog`, which no session reads. A tag in a store the reader never opens is the same failure as no tag.

**Why not a scheduled pull.** Actively unsafe here. This is a shared checkout, and CLAUDE.md records a peer's `git pull --rebase` replaying another session's unpushed commit onto origin. A background job that rewrites the working tree can destroy in-flight work belonging to a session that is not even running. So: fetch and report; the human decides (ethos rule 8).

Behaviour: names `amux-server.py` / `amux` / `CLAUDE.md` when they are in the incoming diff (a number reads as bookkeeping, a filename reads as "your edit is about to conflict"); silent when current; fails open on offline / no remote / detached HEAD / missing files; resolves the running server from the process rather than a hardcoded path. `AMUX_SKIP_FRESHNESS=1` to silence.

| Injected condition | Result |
|---|---|
| installed CLI drifts | detected |
| running server != checkout | detected |
| checkout 4 commits behind (isolated worktree) | detected, named the 3 hot files |
| everything current | silent, exit 0 |

Pipe-tested exactly as Claude Code invokes it (`$CLAUDE_PROJECT_DIR`), JSON validated with `jq -e`, existing `PostToolUse` hook and all 20 permissions preserved.

---

## 2. `fix(push-guard)` — a new branch reported the entire history as foreign

Pushing the one-commit branch above printed:

> PUSH BLOCKED — this would ship **1081** commit(s) authored by another session

Every one of those was already on origin and shipped nothing. A new branch has no remote counterpart, so `remote_sha` is all zeros and the range fell back to bare `local_sha` — "everything reachable" — instead of "what this push adds".

This is worse than a missing check. The guard's value is that `AMUX_ALLOW_FOREIGN=1` stays a deliberate act taken with the facts in view. One that fires on every `git checkout -b` teaches the reflex of setting it blind — and then the push that really does carry another session's work sails through the escape hatch. The constraint-with-an-unwalkable-escape pattern, arriving from the other direction.

Fixed by bounding the walk with `--not --remotes=origin`. The existing-branch path is unchanged.

**Verified against the real hook, not the generator:** with the fix installed and the hook regenerated, this very branch pushed cleanly with **no override**. Before it, the same push was blocked citing 1081.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDuBnmfziM6uGvdxn2y3Lo