### PR TITLE
fix: define _PLACEHOLDER_API_KEYS used by _is_placeholder_api_key

### DIFF
--- a/amux-server.py
+++ b/amux-server.py
@@ -70803,6 +70803,18 @@ def _watch_server_env():
 
 
 
+_PLACEHOLDER_API_KEYS = frozenset({
+    "changeme", "change-me", "change_me",
+    "your-api-key", "your_api_key", "your-key", "yourkey",
+    "your_key_here", "your-key-here", "your-api-key-here",
+    "placeholder", "dummy", "example", "sample",
+    "test", "test-key", "testkey",
+    "replace-me", "replace_me",
+    "xxx", "xxxx",
+    "sk-ant-xxx", "sk-ant-your-key", "sk-ant-example", "sk-ant-placeholder",
+})
+
+
 def _is_placeholder_api_key(val: str) -> bool:
     """Return True if ``val`` is an obvious placeholder/template, not a real key."""
     v = val.strip().strip('"').strip("'").lower()


### PR DESCRIPTION
## What & why

`_is_placeholder_api_key()` references `_PLACEHOLDER_API_KEYS`, but that constant was never defined on the Python side — only the client-side `_PLACEHOLDER_KEYS` exists. Every call raises `NameError`. The first caller to hit it is `GET /api/identity`: whenever `server.env` contains an `ANTHROPIC_API_KEY=` line, `has_key_in_env` crashes instead of reporting, so the dashboard's API-key state is wrong for every BYO-key install.

This adds the frozenset of obvious placeholder/template values the function's docstring already promises. Nothing else changes.

Closes nothing (no existing issue); happy to file one if preferred.

## Checklist

- [x] **One focused change** — one missing constant, defined immediately above its only consumer
- [x] **It still parses:** `python3 -c "import ast; ast.parse(open('amux-server.py').read())"`
- [x] **Client change?** server-only Python — no version bump needed
- [x] **Tested end-to-end** — reproduction below, plus unit behavior check
- [x] **Single-file rule respected** — no new files
- [x] Rebased on latest `main` (branch created from `40e6571`)

## How I tested

**Reproduce (before the fix):** with `ANTHROPIC_API_KEY=<anything>` in `~/.amux/server.env`, call `GET /api/identity` — the handler raises:

```
NameError: name '_PLACEHOLDER_API_KEYS' is not defined
```

at `return v in _PLACEHOLDER_API_KEYS` inside `_is_placeholder_api_key` (called from the `has_key_in_env` scan).

**After the fix**, unit-checked the extracted function: `"sk-ant-xxx"`, `"  CHANGE-ME "` and `"'your_key_here'"` all classify as placeholders; a real-looking key (`sk-ant-abc123realkey`) does not.

Full suite: **224 passed**.
