### PR TITLE
feat(herdr): feed native agent lifecycle state into the status loop (#84)

### DIFF
--- a/amux-server.py
+++ b/amux-server.py
@@ -4611,6 +4611,42 @@ def _herdr_kill(name: str) -> None:
         pass
 
 
+_herdr_status_cache: dict = {"ts": 0.0, "by_name": {}}
+_herdr_status_lock = threading.Lock()
+
+
+def _herdr_agent_statuses(max_age_s: float = 5.0) -> dict:
+    """herdr agent name -> agent dict, from ONE `herdr agent list` (issue #84).
+
+    Cached for max_age_s so one scan tick reads the whole herdr fleet in a
+    single subprocess instead of one `agent get` per lane. A failed read
+    caches an EMPTY map for the same window — every consumer then falls back
+    to the scrape path, which is the pre-#84 behavior.
+    """
+    now = time.time()
+    with _herdr_status_lock:
+        if now - _herdr_status_cache["ts"] < max_age_s:
+            return _herdr_status_cache["by_name"]
+        d = _herdr_json(["agent", "list"], timeout=5)
+        agents = ((d or {}).get("result") or {}).get("agents") or []
+        by_name = {a["name"]: a for a in agents if a.get("name")}
+        _herdr_status_cache["ts"] = now
+        _herdr_status_cache["by_name"] = by_name
+        return by_name
+
+
+_HERDR_STATUS_MAP = {"working": "active", "blocked": "waiting",
+                     "idle": "idle", "done": "idle"}
+
+
+def _herdr_status_to_amux(agent_status) -> str:
+    """'' = no structured answer -> caller keeps the scrape result."""
+    return _HERDR_STATUS_MAP.get((agent_status or "").strip().lower(), "")
+
+
+_herdr_vs_scrape: dict = {}   # name -> last herdr/scrape/report disagreement (#84, ethos #4)
+
+
 def _log_path(session: str) -> Path:
     return CC_LOGS / f"{session}.log"
 
@@ -17762,6 +17798,9 @@ def list_sessions() -> list:
                 _herdr_names.add(f.stem)
         except Exception:
             pass
+    # One batched `herdr agent list` for the whole fleet (#84) instead of one
+    # `agent get` subprocess per herdr lane below.
+    _herdr_by_name = _herdr_agent_statuses() if _herdr_names else {}
     # Token cache is refreshed by background job (_refresh_token_cache via scheduler)
     # Last HUMAN message per session, batched in one query. "Last activity" is
     # dominated by schedulers and inter-session traffic, so a lane you have not
@@ -17816,8 +17855,9 @@ def list_sessions() -> list:
     for f in env_files:
         name = f.stem
         cfg = parse_env_file(f)
-        running = (tmux_name(name) in tmux_info
-                   or (name in _herdr_names and _herdr_agent_get(name) is not None))
+        _herdr_agent = (_herdr_by_name.get(_herdr_agent_name(name))
+                        if name in _herdr_names else None)
+        running = (tmux_name(name) in tmux_info or _herdr_agent is not None)
         preview = ""
         preview_lines = []
         status = ""
@@ -17864,6 +17904,21 @@ def list_sessions() -> list:
                         _scrape_vs_report[name] = {"scrape": status, "report": "idle",
                                                    "ts": time.time()}
                     status = _rep["state"]
+                # HERDR STRUCTURED STATE (#84): while the agent is alive, herdr's own
+                # lifecycle state outranks both the scrape AND the self-report — the
+                # report only changes at hook boundaries (UserPromptSubmit/Stop), so a
+                # fresh 'active' report would mask a mid-turn `blocked`, which is the
+                # exact state this override exists to surface. '' (unknown/agent-gone)
+                # keeps whatever the layers below concluded. Disagreements are recorded,
+                # not resolved silently (ethos #4).
+                if _herdr_agent is not None:
+                    _h_mapped = _herdr_status_to_amux(_herdr_agent.get("agent_status"))
+                    if _h_mapped and _h_mapped != status:
+                        _herdr_vs_scrape[name] = {"herdr": _h_mapped, "scrape": status,
+                                                  "report": (_rep or {}).get("state", ""),
+                                                  "ts": time.time()}
+                    if _h_mapped:
+                        status = _h_mapped
             # Detect session becoming idle → auto-complete board issue, then pick up next queued task
             prev = _session_prev_status.get(name)
             # Observable status transition → the event log (issue #48). Only on a
@@ -17871,6 +17926,18 @@ def list_sessions() -> list:
             if prev in ("active", "waiting", "idle") and status in ("active", "waiting", "idle") and status != prev:
                 _emit_event(name, "session." + ("working" if status == "active" else status),
                             {"prev": prev}, source="status-loop")
+            # waiting_since for herdr lanes (#84): the snapshot loop that stamps
+            # ac_waiting_since never visits herdr lanes (its tmux list-sessions gate),
+            # so derive the episode start from the durable event log — the same
+            # recovery the snapshot loop itself uses across restarts. Stamped into
+            # _session_auto_actions so the exporter below needs no branch.
+            if name in _herdr_names and running:
+                _h_actions = _session_auto_actions.setdefault(name, {})
+                if status == "waiting":
+                    if "ac_waiting_since" not in _h_actions:
+                        _h_actions["ac_waiting_since"] = _waiting_since_from_events(name, time.time())
+                else:
+                    _h_actions.pop("ac_waiting_since", None)
             if status == "idle" and prev in ("active", "waiting"):
                 # A worker finished a turn → emit a closed-loop event so any
                 # orchestrator schedule subscribed to 'session_idle' can wake.
@@ -66284,7 +66351,8 @@ class CCHandler(BaseHTTPRequestHandler):
                 "full_per_min": round(60.0 * _scan_stats["full"] / _up, 1),
                 "hooks_live_s": _HOOKS_LIVE_S, "hooks_live_idle_s": _HOOKS_LIVE_IDLE_S,
                 "demote_interval_s": _SCAN_DEMOTE_S,
-                "sessions": _rows})
+                "sessions": _rows,
+                "herdr_vs_scrape": _herdr_vs_scrape})
 
         if method == "GET" and path == "/api/debug/threads":
             import traceback as _tb

--- a/amux-server.py
+++ b/amux-server.py
@@ -4347,6 +4347,15 @@ def _herdr_capture(name: str, lines: int = 500) -> str:
                 "--lines", str(max(int(lines), 1)), "--format", "text"],
                timeout=8)
     if r is None or r.returncode != 0:
+        # herdr refuses recent-unwrapped while the agent is working/blocked
+        # (agent_not_idle: alternate-screen history is only scrollable at idle).
+        # The visible screen is exactly what preview + content classification
+        # need in those states — a blocked lane's picker IS its visible frame.
+        # Without this fallback a herdr lane goes status='' for the whole
+        # working/blocked episode (found by #84 E2E, 2026-08-07).
+        r = _herdr(["agent", "read", _herdr_agent_name(name),
+                    "--source", "visible", "--format", "text"], timeout=8)
+    if r is None or r.returncode != 0:
         return ""
     return r.stdout.strip()
 

--- a/amux-server.py
+++ b/amux-server.py
@@ -4620,28 +4620,35 @@ def _herdr_kill(name: str) -> None:
         pass
 
 
-_herdr_status_cache: dict = {"ts": 0.0, "by_name": {}}
+_herdr_status_cache: dict = {"ts": 0.0, "ok": True, "by_name": {}}
 _herdr_status_lock = threading.Lock()
 
 
 def _herdr_agent_statuses(max_age_s: float = 5.0) -> dict:
-    """herdr agent name -> agent dict, from ONE `herdr agent list` (issue #84).
+    """{"ok": bool, "by_name": {herdr agent name -> agent dict}} from ONE
+    `herdr agent list` (issue #84).
 
     Cached for max_age_s so one scan tick reads the whole herdr fleet in a
-    single subprocess instead of one `agent get` per lane. A failed read
-    caches an EMPTY map for the same window — every consumer then falls back
-    to the scrape path, which is the pre-#84 behavior.
+    single subprocess instead of one `agent get` per lane. `ok: False` means
+    the read itself failed — distinct from `ok: True` with an empty/partial
+    map, which means the fleet was queried successfully and those agents are
+    genuinely not there (PR #87 review: collapsing the two let a transient
+    `agent list` failure read as "every herdr lane stopped" and misfire board
+    auto-complete fleet-wide, ethos #4 — an instrument must express the
+    difference between "false" and "couldn't tell").
     """
     now = time.time()
     with _herdr_status_lock:
         if now - _herdr_status_cache["ts"] < max_age_s:
-            return _herdr_status_cache["by_name"]
+            return {"ok": _herdr_status_cache["ok"], "by_name": _herdr_status_cache["by_name"]}
         d = _herdr_json(["agent", "list"], timeout=5)
+        ok = d is not None
         agents = ((d or {}).get("result") or {}).get("agents") or []
         by_name = {a["name"]: a for a in agents if a.get("name")}
         _herdr_status_cache["ts"] = now
+        _herdr_status_cache["ok"] = ok
         _herdr_status_cache["by_name"] = by_name
-        return by_name
+        return {"ok": ok, "by_name": by_name}
 
 
 _HERDR_STATUS_MAP = {"working": "active", "blocked": "waiting",
@@ -17809,7 +17816,7 @@ def list_sessions() -> list:
             pass
     # One batched `herdr agent list` for the whole fleet (#84) instead of one
     # `agent get` subprocess per herdr lane below.
-    _herdr_by_name = _herdr_agent_statuses() if _herdr_names else {}
+    _herdr_batch = _herdr_agent_statuses() if _herdr_names else {"ok": True, "by_name": {}}
     # Token cache is refreshed by background job (_refresh_token_cache via scheduler)
     # Last HUMAN message per session, batched in one query. "Last activity" is
     # dominated by schedulers and inter-session traffic, so a lane you have not
@@ -17864,8 +17871,16 @@ def list_sessions() -> list:
     for f in env_files:
         name = f.stem
         cfg = parse_env_file(f)
-        _herdr_agent = (_herdr_by_name.get(_herdr_agent_name(name))
-                        if name in _herdr_names else None)
+        if name in _herdr_names:
+            _herdr_agent = _herdr_batch["by_name"].get(_herdr_agent_name(name))
+            if _herdr_agent is None and not _herdr_batch["ok"]:
+                # The batched read FAILED — a failed instrument must not read as
+                # "every herdr lane stopped" (that transition fires board
+                # auto-complete). Fall back to the pre-#84 per-lane probe, which
+                # confines a transient failure to the lane it actually touches.
+                _herdr_agent = _herdr_agent_get(name)
+        else:
+            _herdr_agent = None
         running = (tmux_name(name) in tmux_info or _herdr_agent is not None)
         preview = ""
         preview_lines = []

--- a/tests/test_herdr_status.py
+++ b/tests/test_herdr_status.py
@@ -1,0 +1,152 @@
+"""Unit tests for herdr agent_status -> status loop injection (mixpeek/amux#84).
+
+Covers the pure mapping function, the batched `agent list` -> by-name parse,
+and its tick cache. The override logic itself lives inline in list_sessions()
+(DB/tmux dependent) so it is not unit-tested directly; the mapping function's
+"" fallback behavior is the safety valve that keeps an unmapped/unknown herdr
+status from clobbering the scrape result, and that is what's pinned here.
+
+Imported from amux-server.py via importlib, same as test_herdr_backend.py, so
+no drift is possible. Mocks subprocess so these run with or without herdr
+installed.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+SERVER_PATH = REPO_ROOT / "amux-server.py"
+
+
+@pytest.fixture(scope="module")
+def amux_server():
+    spec = importlib.util.spec_from_file_location("amux_server", SERVER_PATH)
+    assert spec is not None and spec.loader is not None, f"could not load {SERVER_PATH}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["amux_server"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_status_cache(amux_server):
+    # Each test gets a cold cache so max_age_s timing from a prior test can't leak in.
+    amux_server._herdr_status_cache["ts"] = 0.0
+    amux_server._herdr_status_cache["by_name"] = {}
+    yield
+    amux_server._herdr_status_cache["ts"] = 0.0
+    amux_server._herdr_status_cache["by_name"] = {}
+
+
+class _FakeProc:
+    def __init__(self, stdout="", returncode=0):
+        self.stdout = stdout
+        self.returncode = returncode
+
+
+# ── Mapping ──────────────────────────────────────────────────────────────────
+
+def test_status_map_working_to_active(amux_server):
+    assert amux_server._herdr_status_to_amux("working") == "active"
+
+
+def test_status_map_blocked_to_waiting(amux_server):
+    assert amux_server._herdr_status_to_amux("blocked") == "waiting"
+
+
+def test_status_map_idle_to_idle(amux_server):
+    assert amux_server._herdr_status_to_amux("idle") == "idle"
+
+
+def test_status_map_done_to_idle(amux_server):
+    assert amux_server._herdr_status_to_amux("done") == "idle"
+
+
+def test_status_map_unknown_is_empty(amux_server):
+    assert amux_server._herdr_status_to_amux("unknown") == ""
+
+
+def test_status_map_none_is_empty(amux_server):
+    assert amux_server._herdr_status_to_amux(None) == ""
+
+
+def test_status_map_empty_string_is_empty(amux_server):
+    assert amux_server._herdr_status_to_amux("") == ""
+
+
+def test_status_map_uppercase_is_tolerated(amux_server):
+    assert amux_server._herdr_status_to_amux("WORKING") == "active"
+
+
+# ── Batched agent list parse ─────────────────────────────────────────────────
+
+def _agent_list_payload():
+    return {
+        "id": "cli:agent:list",
+        "result": {
+            "type": "agent_list",
+            "agents": [
+                {"agent": "claude", "name": "lane-one", "agent_status": "working",
+                 "pane_id": "w1:p1", "workspace_id": "w1"},
+                {"agent": "claude", "name": "lane-two", "agent_status": "blocked",
+                 "pane_id": "w2:p1", "workspace_id": "w2"},
+                # auto-recognized agent with no persisted name -> must be dropped
+                {"agent": "claude", "agent_status": "idle", "pane_id": "w3:p1",
+                 "workspace_id": "w3"},
+            ],
+        },
+    }
+
+
+def test_agent_statuses_parses_by_name(amux_server, monkeypatch):
+    monkeypatch.setattr(amux_server.subprocess, "run",
+                        lambda *a, **k: _FakeProc(json.dumps(_agent_list_payload()), 0))
+    by_name = amux_server._herdr_agent_statuses()
+    assert set(by_name.keys()) == {"lane-one", "lane-two"}
+    assert by_name["lane-one"]["agent_status"] == "working"
+    assert by_name["lane-two"]["agent_status"] == "blocked"
+
+
+def test_agent_statuses_drops_nameless_entries(amux_server, monkeypatch):
+    monkeypatch.setattr(amux_server.subprocess, "run",
+                        lambda *a, **k: _FakeProc(json.dumps(_agent_list_payload()), 0))
+    by_name = amux_server._herdr_agent_statuses()
+    assert all(v.get("pane_id") != "w3:p1" for v in by_name.values())
+
+
+def test_agent_statuses_failed_read_is_empty_map(amux_server, monkeypatch):
+    monkeypatch.setattr(amux_server.subprocess, "run",
+                        lambda *a, **k: _FakeProc("not json", 0))
+    assert amux_server._herdr_agent_statuses() == {}
+
+
+# ── Tick cache ───────────────────────────────────────────────────────────────
+
+def test_agent_statuses_cached_within_window(amux_server, monkeypatch):
+    calls = {"n": 0}
+
+    def fake_run(*a, **k):
+        calls["n"] += 1
+        return _FakeProc(json.dumps(_agent_list_payload()), 0)
+
+    monkeypatch.setattr(amux_server.subprocess, "run", fake_run)
+    amux_server._herdr_agent_statuses(max_age_s=5.0)
+    amux_server._herdr_agent_statuses(max_age_s=5.0)
+    assert calls["n"] == 1
+
+
+def test_agent_statuses_failed_read_also_cached(amux_server, monkeypatch):
+    calls = {"n": 0}
+
+    def fake_run(*a, **k):
+        calls["n"] += 1
+        return _FakeProc("not json", 0)
+
+    monkeypatch.setattr(amux_server.subprocess, "run", fake_run)
+    amux_server._herdr_agent_statuses(max_age_s=5.0)
+    amux_server._herdr_agent_statuses(max_age_s=5.0)
+    assert calls["n"] == 1

--- a/tests/test_herdr_status.py
+++ b/tests/test_herdr_status.py
@@ -36,9 +36,11 @@ def amux_server():
 def _reset_status_cache(amux_server):
     # Each test gets a cold cache so max_age_s timing from a prior test can't leak in.
     amux_server._herdr_status_cache["ts"] = 0.0
+    amux_server._herdr_status_cache["ok"] = True
     amux_server._herdr_status_cache["by_name"] = {}
     yield
     amux_server._herdr_status_cache["ts"] = 0.0
+    amux_server._herdr_status_cache["ok"] = True
     amux_server._herdr_status_cache["by_name"] = {}
 
 
@@ -105,7 +107,9 @@ def _agent_list_payload():
 def test_agent_statuses_parses_by_name(amux_server, monkeypatch):
     monkeypatch.setattr(amux_server.subprocess, "run",
                         lambda *a, **k: _FakeProc(json.dumps(_agent_list_payload()), 0))
-    by_name = amux_server._herdr_agent_statuses()
+    result = amux_server._herdr_agent_statuses()
+    by_name = result["by_name"]
+    assert result["ok"] is True
     assert set(by_name.keys()) == {"lane-one", "lane-two"}
     assert by_name["lane-one"]["agent_status"] == "working"
     assert by_name["lane-two"]["agent_status"] == "blocked"
@@ -114,14 +118,24 @@ def test_agent_statuses_parses_by_name(amux_server, monkeypatch):
 def test_agent_statuses_drops_nameless_entries(amux_server, monkeypatch):
     monkeypatch.setattr(amux_server.subprocess, "run",
                         lambda *a, **k: _FakeProc(json.dumps(_agent_list_payload()), 0))
-    by_name = amux_server._herdr_agent_statuses()
+    by_name = amux_server._herdr_agent_statuses()["by_name"]
     assert all(v.get("pane_id") != "w3:p1" for v in by_name.values())
 
 
-def test_agent_statuses_failed_read_is_empty_map(amux_server, monkeypatch):
+def test_agent_statuses_failed_read_is_ok_false_empty_map(amux_server, monkeypatch):
+    # §1e (PR #87 review): a failed read must NOT collapse into "fleet is
+    # empty" — the two are distinguished by `ok`, so a caller can tell a
+    # transient herdr failure apart from every agent genuinely being gone.
     monkeypatch.setattr(amux_server.subprocess, "run",
                         lambda *a, **k: _FakeProc("not json", 0))
-    assert amux_server._herdr_agent_statuses() == {}
+    assert amux_server._herdr_agent_statuses() == {"ok": False, "by_name": {}}
+
+
+def test_agent_statuses_success_with_no_agents_is_ok_true(amux_server, monkeypatch):
+    payload = {"id": "x", "result": {"type": "agent_list", "agents": []}}
+    monkeypatch.setattr(amux_server.subprocess, "run",
+                        lambda *a, **k: _FakeProc(json.dumps(payload), 0))
+    assert amux_server._herdr_agent_statuses() == {"ok": True, "by_name": {}}
 
 
 # ── Tick cache ───────────────────────────────────────────────────────────────

--- a/tests/test_herdr_status.py
+++ b/tests/test_herdr_status.py
@@ -150,3 +150,45 @@ def test_agent_statuses_failed_read_also_cached(amux_server, monkeypatch):
     amux_server._herdr_agent_statuses(max_age_s=5.0)
     amux_server._herdr_agent_statuses(max_age_s=5.0)
     assert calls["n"] == 1
+
+
+# ── _herdr_capture visible fallback (§1d, E2E-found: agent_not_idle) ─────────
+#
+# herdr rejects `--source recent-unwrapped` with agent_not_idle (exit 1) while
+# the agent is working/blocked, so a blocked lane's preview/status pipeline
+# went blind for the whole episode until this fallback (found 2026-08-07).
+
+def test_capture_falls_back_to_visible_on_agent_not_idle(amux_server, monkeypatch):
+    monkeypatch.setattr(amux_server, "_herdr_agent_name", lambda n: "w1")
+    seen_sources = []
+
+    def fake_run(cmd, **kw):
+        src = cmd[cmd.index("--source") + 1]
+        seen_sources.append(src)
+        if src == "recent-unwrapped":
+            return _FakeProc(json.dumps({"error": {"code": "agent_not_idle"}}), 1)
+        return _FakeProc("visible screen text", 0)
+
+    monkeypatch.setattr(amux_server.subprocess, "run", fake_run)
+    assert amux_server._herdr_capture("whatever") == "visible screen text"
+    assert seen_sources == ["recent-unwrapped", "visible"]
+
+
+def test_capture_no_fallback_needed_when_recent_unwrapped_succeeds(amux_server, monkeypatch):
+    monkeypatch.setattr(amux_server, "_herdr_agent_name", lambda n: "w1")
+    calls = {"n": 0}
+
+    def fake_run(cmd, **kw):
+        calls["n"] += 1
+        return _FakeProc("idle screen text", 0)
+
+    monkeypatch.setattr(amux_server.subprocess, "run", fake_run)
+    assert amux_server._herdr_capture("whatever") == "idle screen text"
+    assert calls["n"] == 1
+
+
+def test_capture_both_sources_failing_is_empty(amux_server, monkeypatch):
+    monkeypatch.setattr(amux_server, "_herdr_agent_name", lambda n: "w1")
+    monkeypatch.setattr(amux_server.subprocess, "run",
+                        lambda *a, **k: _FakeProc("", 1))
+    assert amux_server._herdr_capture("whatever") == ""


### PR DESCRIPTION
Closes #84. Feeds herdr's structured `agent_status` into the status loop for herdr lanes — D1's exit condition applied to a whole backend, in the shape #47/#48's `get_status` will absorb.

## What it does

Two commits, both additive, tmux paths untouched:

**1. `feat(herdr)`: batched agent-status read + status/waiting_since injection**

- `_herdr_agent_statuses()` — ONE `herdr agent list` per scan tick for the whole herdr fleet (5s cache, lock-protected single flight), replacing the per-lane `agent get` subprocess in `list_sessions`. Entries are keyed by agent `name`, matched via the existing `_herdr_agent_name()` (deterministic, `CC_HERDR_AGENT`-persisted), so no legacy fallback is needed. A failed read caches an empty map — every consumer then falls back to the scrape, which is the pre-#84 behavior.
- `_herdr_status_to_amux()` — `working → active`, `blocked → waiting`, `idle`/`done → idle`, anything else → `""` (keep the scrape's conclusion). `done` is real on herdr 0.8.0, so the `done ≡ idle` mapping is load-bearing.
- Precedence for herdr lanes: **herdr state > self-report > scrape** while the agent is alive. Both structured sources coexist on every herdr lane running Claude Code, and the self-report only changes at hook boundaries — a fresh `active` report would otherwise mask a mid-turn `blocked`, the exact state this exists to surface. Disagreements are recorded in `_herdr_vs_scrape`, exposed at `GET /api/debug/scan` (ethos #4), not resolved silently.
- `waiting_since` for herdr lanes is derived from the event log (`_waiting_since_from_events`) and stamped into `_session_auto_actions`, because the snapshot loop that stamps it for tmux lanes never visits herdr lanes (its `tmux list-sessions` gate). The exporter needs no branch; `session_idle` events and board completion light up unchanged off the same `status` field.

**2. `fix(herdr)`: visible-source fallback for blocked/working capture**

Found by the E2E pass, invisible to any mocked test: herdr 0.8.0 refuses `agent read --source recent-unwrapped` while the agent is `working`/`blocked` (`agent_not_idle` — alternate-screen history is only scrollable at idle). So `_herdr_capture()` returned `""` precisely in the states that matter, and the `if raw:` gate in `list_sessions` skipped scrape, self-report, herdr override, event transitions and waiting_since for the whole episode — a herdr lane sat at `status=''` while blocked. **This is a latent #79/#80 defect** (herdr lanes have had no status for every non-idle episode since the backend landed), and this PR's injection would have inherited the blindness. The fix falls back to `--source visible`, which answers during blocked/working and returns exactly the frame preview + content classification want — a blocked lane's picker IS its visible screen.

## What it deliberately does not do

- No tmux-side changes; no new scraper for herdr lanes.
- No auto-response to a blocked UI — what happens at a prompt stays the human's decision (D2's policy). The D2 rate-limit classifier currently never runs on herdr lanes (the auto-respond scan is tmux-gated); bringing it there is its own follow-up, noted so a `blocked` herdr lane is not assumed auto-answered.
- No `APP_VER`/`sw.js` bump — no client-side change.

## Tests

16 new mocked tests in `tests/test_herdr_status.py` (same importlib fixture style as `test_herdr_backend.py`): the mapping table including case/None/unknown fallbacks, the by-name parse against a real 0.8.0 `agent list` payload shape (nameless auto-recognized entries dropped), tick-cache behavior including failed-read caching, and the visible-source fallback chain. Suite: **240 passed** (224 existing + 16), collection clean — including `test_send_text_picker_escape.py`, the module that broke at collection during the #80 rebase.

Same CI-honesty note as #80: green CI proves the mapping, not the integration.

## E2E (herdr 0.8.0 + Claude Code, isolated server instance)

Full matrix on a live herdr lane, verified from the consumer's vantage (`/api/sessions`, `/api/debug/scan`, `session_events`):

- lane create → `CC_HERDR_AGENT` persisted by the batched path; `running`/`idle` injected via one `agent list` per tick
- AskUserQuestion picker → herdr `blocked` within ~3s → amux `waiting` with `waiting_since` stamped (event-log fallback to `now` verified for an episode with no prior `session.waiting` on record)
- approve (enter) → `working` → `idle`; `session.idle {"prev": "waiting"}` emitted by the status loop — the event board completion and orchestrator wakes subscribe to; earlier in the trail, `session.idle {"prev": "active"}` evidences the `working → active` mapping
- `herdr_vs_scrape` present at `/api/debug/scan`; empty during the picker episode because the scrape classified the visible frame as `waiting` too — the recorder only speaks when the sources disagree
- pre-fix, the same E2E showed herdr `blocked` / amux `status=''` — which is how commit 2 was found

The issue body (#84) was revised alongside: 0.8.0's `done`, the `name` matching key, the `waiting_since` consumer correction, and the defined precedence are all reflected there.
