### PR TITLE
feat(peek): Workflow tab — a worker's setup derived from state, not from the prompt (AMUX-39)

### DIFF
--- a/crates/amux-dashboard/static/app.js
+++ b/crates/amux-dashboard/static/app.js
@@ -3789,6 +3789,7 @@ const PEEK_TABS = [
   { id: 'steering',   label: 'Steering' },
   { id: 'schedules',  label: 'Schedules' },
   { id: 'scope',      label: 'Scope' },
+  { id: 'workflow',   label: 'Workflow' },
   { id: 'messages',   label: 'Messages' },
   { id: 'dictation',  label: 'Dictation' },
   { id: 'issues',     label: 'Board' },
@@ -5673,6 +5674,61 @@ async function _scopeLoad(scope, targetId) {
   }
 }
 
+
+// ── Workflow tab (AMUX-39) ───────────────────────────────────────────────────
+// Renders the worker's CONFIGURED workflow, derived server-side from schedules /
+// env / board — never from the prose the user typed when setting the worker up.
+// A diagram drawn from that prose cannot disagree with it, which makes it a check
+// that cannot fail (ethos rule 7); the whole point of this tab is that it CAN
+// disagree. The flags are the feature, so they render above the diagram, not
+// under it.
+let _wfMermaidReady = false;
+async function _workflowLoad() {
+  const body = document.getElementById('peek-workflow-body');
+  const flagsEl = document.getElementById('peek-workflow-flags');
+  if (!body || !peekSession) return;
+  body.textContent = 'Loading…';
+  flagsEl.innerHTML = '';
+  let d;
+  try {
+    const r = await fetch('/api/sessions/' + encodeURIComponent(peekSession) + '/workflow');
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+    d = await r.json();
+  } catch (e) {
+    body.textContent = 'Could not load workflow: ' + e.message;
+    return;
+  }
+  const flags = d.flags || [];
+  if (flags.length) {
+    flagsEl.innerHTML = flags.map(f => {
+      const warn = f.level === 'warn';
+      return '<div style="padding:6px 8px;margin-bottom:4px;border-radius:4px;border-left:3px solid ' +
+        (warn ? '#ff9800' : 'var(--dim)') + ';background:' + (warn ? 'rgba(255,152,0,0.08)' : 'transparent') +
+        ';color:' + (warn ? '#ffcc80' : 'var(--dim)') + '">' +
+        (warn ? '⚠ ' : '') + esc(f.text) + '</div>';
+    }).join('');
+  }
+  // mermaid ships from the same CDN as the other 22 libs; if it did not load we
+  // show the source rather than an empty pane, because a blank tab is a silent
+  // failure on the one surface whose job is to show you something.
+  if (typeof mermaid === 'undefined') {
+    body.innerHTML = '<div style="color:var(--dim);margin-bottom:6px;">Diagram renderer unavailable — showing source:</div>' +
+      '<pre style="white-space:pre-wrap;font-size:0.75rem;">' + esc(d.mermaid || '') + '</pre>';
+    return;
+  }
+  if (!_wfMermaidReady) {
+    try { mermaid.initialize({ startOnLoad: false, theme: 'dark', securityLevel: 'strict' }); _wfMermaidReady = true; }
+    catch (e) { /* fall through to render attempt */ }
+  }
+  try {
+    const { svg } = await mermaid.render('wf-' + Date.now(), d.mermaid);
+    body.innerHTML = svg;
+  } catch (e) {
+    body.innerHTML = '<div style="color:#ff9800;margin-bottom:6px;">Diagram failed to render: ' + esc(e.message || String(e)) + '</div>' +
+      '<pre style="white-space:pre-wrap;font-size:0.75rem;">' + esc(d.mermaid || '') + '</pre>';
+  }
+}
+
 function setPeekTab(tab) {
   _peekTab = tab;
   // The notes tab is gone; this flushed its pending save and called
@@ -5694,6 +5750,10 @@ function setPeekTab(tab) {
   const scopePanel = document.getElementById('peek-scope-panel');
   if (tab === 'scope') { scopePanel.classList.add('active'); _scopeLoad(); }
   else { scopePanel.classList.remove('active'); }
+  document.getElementById('peek-tab-workflow').classList.toggle('active', tab === 'workflow');
+  const wfPanel = document.getElementById('peek-workflow-panel');
+  if (tab === 'workflow') { wfPanel.classList.add('active'); _workflowLoad(); }
+  else { wfPanel.classList.remove('active'); }
   document.getElementById('peek-tab-memory').classList.toggle('active', tab === 'memory');
   document.getElementById('peek-tab-git').classList.toggle('active', tab === 'git');
   document.getElementById('peek-tab-commits').classList.toggle('active', tab === 'commits');
@@ -7079,7 +7139,7 @@ async function saveGlobalMemory() {
   }
 }
 
-const APP_VER = '0.9.605';   // bump together with the sw.js CACHE version
+const APP_VER = '0.9.606';   // bump together with the sw.js CACHE version
 
 // ── No silent failures (Ethan, 2026-08-09: "make sure every action has some
 // kind of response in the ui — i just deleted a worker and nothing happened").

--- a/crates/amux-dashboard/static/index.html
+++ b/crates/amux-dashboard/static/index.html
@@ -1932,6 +1932,7 @@ setTimeout(function(){var f=document.getElementById('js-fallback');if(f&&f.style
     <button class="peek-tab" id="peek-tab-steering" onclick="setPeekTab('steering')"><span class="tab-ico">⇉</span><span class="tab-lbl">Steering</span><span class="peek-tab-count" id="peek-tab-steering-count"></span></button>
     <button class="peek-tab" id="peek-tab-schedules" onclick="setPeekTab('schedules')"><span class="tab-ico">⏱</span><span class="tab-lbl">Schedules</span><span class="peek-tab-count" id="peek-tab-schedules-count"></span></button>
     <button class="peek-tab" id="peek-tab-scope" onclick="setPeekTab('scope')" title="What this worker operates under, and which scope layer set it"><span class="tab-ico">&#9707;</span><span class="tab-lbl">Scope</span></button>
+    <button class="peek-tab" id="peek-tab-workflow" onclick="setPeekTab('workflow')" title="This worker's configured workflow, derived from its schedules, tools, board and scope"><span class="tab-ico">&#9783;</span><span class="tab-lbl">Workflow</span></button>
     <button class="peek-tab" id="peek-tab-messages" onclick="setPeekTab('messages')" title="Every message sent to this worker"><span class="tab-ico">✉</span><span class="tab-lbl">Messages</span><span class="peek-tab-count" id="peek-tab-messages-count"></span></button>
     <button class="peek-tab" id="peek-tab-dictation" onclick="setPeekTab('dictation')" title="Voice dictation — speak, get clean text"><span class="tab-ico">🎤</span><span class="tab-lbl">Dictation</span><span class="peek-tab-count" id="peek-tab-dictation-count"></span></button>
     <button class="peek-tab" id="peek-tab-issues" onclick="setPeekTab('issues')"><span class="tab-ico">☷</span><span class="tab-lbl">Board</span><span class="peek-tab-count" id="peek-tab-issues-count"></span></button>
@@ -2142,6 +2143,10 @@ setTimeout(function(){var f=document.getElementById('js-fallback');if(f&&f.style
     <div class="peek-tasks-list" id="peek-issues-list"></div>
   </div>
 
+  <div id="peek-workflow-panel" class="peek-tasks-panel" style="padding:10px;padding-bottom:max(10px, env(safe-area-inset-bottom));gap:0;overflow-y:auto;-webkit-overflow-scrolling:touch;">
+    <div id="peek-workflow-flags" style="font-size:0.82rem;margin-bottom:10px;"></div>
+    <div id="peek-workflow-body" style="font-size:0.82rem;color:var(--dim);">Loading&hellip;</div>
+  </div>
   <div id="peek-scope-panel" class="peek-tasks-panel" style="padding:10px;padding-bottom:max(10px, env(safe-area-inset-bottom));gap:0;overflow-y:auto;-webkit-overflow-scrolling:touch;">
     <div id="peek-scope-body" style="font-size:0.82rem;color:var(--dim);">Loading&hellip;</div>
   </div>
@@ -2699,6 +2704,7 @@ setTimeout(function(){var f=document.getElementById('js-fallback');if(f&&f.style
 <script src="https://cdn.jsdelivr.net/npm/motion@11.11.17/dist/motion.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/gridstack@7/dist/gridstack-all.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-web-links@0.11.0/lib/addon-web-links.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js" crossorigin="anonymous"></script>

--- a/crates/amux-dashboard/static/sw.js
+++ b/crates/amux-dashboard/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'amux-v0.9.605';
+const CACHE = 'amux-v0.9.606';
 const SHELL_URLS = ['/', '/manifest.json', '/icon.svg', '/icon.png', '/icon-192.png', '/icon-512.png'];
 
 // Install: pre-cache entire app shell

--- a/crates/amux-server/src/api/mod.rs
+++ b/crates/amux-server/src/api/mod.rs
@@ -57,6 +57,7 @@ pub mod lookup;
 pub mod config_iac;
 pub mod skin;
 pub mod commit_mentions;
+pub mod workflow;
 pub mod sessions_git;
 pub mod sessions_legacy;
 pub mod settings;
@@ -253,6 +254,10 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/api/board/commit-mentions",
             axum::routing::get(commit_mentions::commit_mentions),
+        )
+        .route(
+            "/api/sessions/{name}/workflow",
+            axum::routing::get(workflow::workflow),
         )
         // The shared-checkout staged-guard's endpoint. UNROUTED since the
         // rust cutover — 405, ~1,147 calls/hour, and the installed

--- a/crates/amux-server/src/api/workflow.rs
+++ b/crates/amux-server/src/api/workflow.rs
@@ -1,0 +1,336 @@
+//! `GET /api/sessions/{name}/workflow` — a worker's configured workflow, DERIVED.
+//!
+//! AMUX-39. The owner asked for a mermaid diagram that populates when you spin a
+//! worker up, "so the user can visualize spot check the workflow".
+//!
+//! # Why this reads state and not the prompt
+//!
+//! The obvious build is to render the prose the user typed when configuring the
+//! worker. That fails ethos rule 7: a picture drawn from the same sentence that
+//! configured the worker cannot disagree with it, so it is a check that cannot
+//! fail. Worse than useless — it renders a misconfiguration as a tidy diagram and
+//! CONFIRMS it, on the surface the user opened specifically to catch that.
+//!
+//! So every node here is derived from resolved state: `schedules` rows, the
+//! worker's env, the board. The diagram is allowed to disagree with what the user
+//! believed they set up, and that disagreement is the entire product.
+//!
+//! # The flags are the feature
+//!
+//! A diagram that only draws correctly-configured things is decoration. The
+//! `flags` array — and the `warn` class on the nodes it names — is what earns the
+//! tab. It fires today: measured on the author's machine, 6 session envs and 0
+//! containing `CC_MCP`, which is ethos rule 1's flagship failure (mcp.json shipped
+//! six servers; the launcher passed them only when `CC_MCP` was set, so 0 of 101
+//! sessions ever received them, invisibly, for months). A prose-derived diagram
+//! would have drawn the six servers the user described and shown nothing wrong.
+//!
+//! # No model call
+//!
+//! Nodes and edges are computed from rows (ethos rule 2). Spending a model call to
+//! draw boxes it can derive is the labelling-with-`claude -p` mistake again.
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde_json::{json, Value};
+
+use super::AppState;
+
+/// A schedule row, already narrowed to what the diagram shows.
+struct Sched {
+    id: String,
+    title: String,
+    enabled: bool,
+    sched_type: String,
+    recurrence: String,
+    next_run: String,
+    watch: bool,
+    trigger_on: String,
+}
+
+/// Mermaid label text. Quotes and newlines terminate a `["..."]` label early and
+/// produce a diagram that fails to parse — which would render as an empty tab,
+/// i.e. a silent failure on the surface whose whole job is to show you something.
+fn lbl(s: &str) -> String {
+    let s: String = s
+        .chars()
+        .map(|c| match c {
+            '"' => '\'',
+            '\n' | '\r' | '[' | ']' | '{' | '}' | '(' | ')' | '<' | '>' | '|' => ' ',
+            c => c,
+        })
+        .collect();
+    let t = s.trim();
+    if t.chars().count() > 60 {
+        let cut: String = t.chars().take(57).collect();
+        format!("{cut}...")
+    } else {
+        t.to_string()
+    }
+}
+
+fn schedules_for(conn: &rusqlite::Connection, session: &str) -> rusqlite::Result<Vec<Sched>> {
+    let mut st = conn.prepare(
+        "SELECT id, COALESCE(title,''), enabled, COALESCE(sched_type,''), \
+                COALESCE(recurrence,''), COALESCE(next_run,''), COALESCE(watch,0), \
+                COALESCE(trigger_on,'') \
+         FROM schedules WHERE session=?1 AND deleted IS NULL ORDER BY id",
+    )?;
+    let rows = st.query_map([session], |r| {
+        Ok(Sched {
+            id: r.get::<_, String>(0)?,
+            title: r.get::<_, String>(1)?,
+            enabled: r.get::<_, i64>(2)? != 0,
+            sched_type: r.get::<_, String>(3)?,
+            recurrence: r.get::<_, String>(4)?,
+            next_run: r.get::<_, String>(5)?,
+            watch: r.get::<_, i64>(6)? != 0,
+            trigger_on: r.get::<_, String>(7)?,
+        })
+    })?;
+    Ok(rows.flatten().collect())
+}
+
+/// Open-set board counts by status. Shares the board's own "open" predicate
+/// (not deleted, not archived) rather than re-deriving one — a view that
+/// disagrees with the mechanism it describes is worse than no view.
+fn board_counts(conn: &rusqlite::Connection, session: &str) -> rusqlite::Result<Vec<(String, i64)>> {
+    let mut st = conn.prepare(
+        "SELECT status, COUNT(*) FROM issues \
+         WHERE session=?1 AND deleted IS NULL AND COALESCE(archived,0)=0 \
+         GROUP BY status ORDER BY status",
+    )?;
+    let rows = st.query_map([session], |r| Ok((r.get::<_, String>(0)?, r.get::<_, i64>(1)?)))?;
+    Ok(rows.flatten().collect())
+}
+
+/// The emitter, split out from the handler so tests drive the REAL one.
+/// Returns (mermaid, flags).
+fn build_graph(
+    name: &str,
+    dir: &str,
+    mcp: &str,
+    groups: &[String],
+    scheds: &[Sched],
+    counts: &[(String, i64)],
+) -> (String, Vec<Value>) {
+    let mut flags: Vec<Value> = Vec::new();
+    let mut warn_nodes: Vec<String> = Vec::new();
+    let mut m = String::from("flowchart TD\n");
+
+    let where_ = if dir.is_empty() { "(no CC_DIR)" } else { dir };
+    // SEPARATOR, not `<br/>`. mermaid 11 strips <br/> from labels under
+    // securityLevel:'strict' — measured BR-LOST both with and without
+    // flowchart.htmlLabels — so the halves ran together: "amux" + "/Users/..."
+    // rendered as "amux/Users/...", and "orphan job" + "once" as "orphan jobonce".
+    // The fix is NOT to relax securityLevel: these labels carry schedule titles
+    // straight out of the DB, and strict sanitisation is what stands between that
+    // and the SVG. Guarded by no_html_line_breaks_are_emitted.
+    m.push_str(&format!("  W[\"worker: {}  \u{b7}  {}\"]\n", lbl(name), lbl(where_)));
+
+    m.push_str(&format!("  W --> SCH[\"Schedules ({})\"]\n", scheds.len()));
+    if scheds.is_empty() {
+        m.push_str("  SCH --> SCH_NONE[\"(none - this worker only runs when steered)\"]\n");
+        flags.push(json!({
+            "level": "info",
+            "text": "No schedules bound to this worker. It acts only when a human or another worker steers it."
+        }));
+    }
+    for (i, s) in scheds.iter().enumerate() {
+        let nid = format!("S{i}");
+        let when = if !s.recurrence.is_empty() {
+            s.recurrence.clone()
+        } else if !s.trigger_on.is_empty() {
+            format!("on: {}", s.trigger_on)
+        } else if !s.next_run.is_empty() {
+            format!("next {}", s.next_run)
+        } else {
+            s.sched_type.clone()
+        };
+        m.push_str(&format!("  SCH --> {nid}[\"{}  \u{b7}  {}\"]\n", lbl(&s.title), lbl(&when)));
+        // A disabled schedule is intent without effect — the most common silent
+        // misconfiguration, and invisible everywhere else in the UI.
+        if !s.enabled {
+            warn_nodes.push(nid.clone());
+            flags.push(json!({"level":"warn","text":
+                format!("Schedule '{}' ({}) is DISABLED - it is configured but will never fire.", s.title, s.id)}));
+        } else if s.next_run.is_empty() && s.trigger_on.is_empty() && !s.watch {
+            warn_nodes.push(nid.clone());
+            flags.push(json!({"level":"warn","text":
+                format!("Schedule '{}' ({}) is enabled but has no next run and no trigger - nothing will start it.", s.title, s.id)}));
+        }
+    }
+
+    m.push_str("  W --> TOOLS[\"Tools / MCP\"]\n");
+    if mcp.is_empty() {
+        m.push_str("  TOOLS --> T_NONE[\"(no MCP servers reach this worker)\"]\n");
+        warn_nodes.push("T_NONE".to_string());
+        flags.push(json!({"level":"warn","text":
+            "No MCP servers reach this worker (CC_MCP is unset). Servers configured in mcp.json are NOT passed unless CC_MCP is set - this is the failure that left 0 of 101 sessions with MCP for months."}));
+    } else {
+        for (i, t) in mcp.split(',').map(str::trim).filter(|t| !t.is_empty()).enumerate() {
+            m.push_str(&format!("  TOOLS --> T{i}[\"{}\"]\n", lbl(t)));
+        }
+    }
+
+    let total: i64 = counts.iter().map(|(_, n)| *n).sum();
+    m.push_str(&format!("  W --> BOARD[\"Board ({total} open)\"]\n"));
+    for (i, (st_, n)) in counts.iter().enumerate() {
+        m.push_str(&format!("  BOARD --> B{i}[\"{}: {n}\"]\n", lbl(st_)));
+    }
+
+    let scope_txt = if groups.is_empty() {
+        "untagged - sees only itself".to_string()
+    } else {
+        groups.join(", ")
+    };
+    m.push_str(&format!("  W --> SCOPE[\"Scope: {}\"]\n", lbl(&scope_txt)));
+
+    if !warn_nodes.is_empty() {
+        m.push_str("  classDef warn fill:#3b2300,stroke:#ff9800,color:#ffcc80;\n");
+        m.push_str(&format!("  class {} warn;\n", warn_nodes.join(",")));
+    }
+    (m, flags)
+}
+
+pub async fn workflow(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> (StatusCode, Json<Value>) {
+    let cfg = super::session_verbs::parse_env(&name);
+    let dir = cfg.get("CC_DIR").unwrap_or("").to_string();
+    let mcp = cfg.get("CC_MCP").unwrap_or("").trim().to_string();
+    let groups: Vec<String> = cfg
+        .get("CC_TAGS")
+        .unwrap_or("")
+        .split(',')
+        .map(|t| t.trim().to_lowercase())
+        .filter(|t| !t.is_empty())
+        .collect();
+
+    let (scheds, counts) = {
+        let conn = match state.store.read() {
+            Ok(c) => c,
+            Err(e) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({ "error": format!("store unreadable: {e}") })),
+                )
+            }
+        };
+        let s = schedules_for(&conn, &name).unwrap_or_default();
+        let c = board_counts(&conn, &name).unwrap_or_default();
+        (s, c)
+    };
+
+    let (m, flags) = build_graph(&name, &dir, &mcp, &groups, &scheds, &counts);
+    let total: i64 = counts.iter().map(|(_, n)| *n).sum();
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "session": name,
+            "mermaid": m,
+            "flags": flags,
+            "derived_from": {
+                "schedules": scheds.len(),
+                "board_open": total,
+                "mcp": mcp.is_empty() == false,
+                "groups": groups,
+                "dir": dir,
+            }
+        })),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_graph, lbl, Sched};
+
+    fn sched(id: &str, title: &str, enabled: bool, recurrence: &str, next_run: &str) -> Sched {
+        Sched {
+            id: id.into(),
+            title: title.into(),
+            enabled,
+            sched_type: "cron".into(),
+            recurrence: recurrence.into(),
+            next_run: next_run.into(),
+            watch: false,
+            trigger_on: String::new(),
+        }
+    }
+
+    #[test]
+    fn lbl_neutralises_mermaid_breakers() {
+        // A quote or bracket in a card/schedule title would terminate the label
+        // early and break the whole diagram — an empty tab is a silent failure on
+        // the one surface meant to show you something.
+        assert_eq!(lbl("say \"hi\""), "say 'hi'");
+        assert_eq!(lbl("a[b]c"), "a b c");
+        assert_eq!(lbl("one\ntwo"), "one two");
+    }
+
+    /// mermaid strips `<br/>` under securityLevel:'strict', so a label built with
+    /// it silently concatenates its two halves. Guard the whole emitter, not just
+    /// the two call sites, so a future node cannot reintroduce it.
+    #[test]
+    fn no_html_line_breaks_are_emitted() {
+        let (m, _) = build_graph(
+            "lane", "/w", "chrome", &[],
+            &[sched("S1", "nightly", true, "0 9 * * *", "2026-01-01")],
+            &[("todo".into(), 1)],
+        );
+        assert!(!m.contains("<br"), "mermaid drops <br/> under strict; got:\n{m}");
+        assert!(m.contains('\u{b7}'), "expected the separator instead; got:\n{m}");
+    }
+
+    /// The half that matters: a flagger that always fires is as broken as one that
+    /// never does. A correctly-configured worker must emit NOTHING — no flags, and
+    /// no `classDef warn`, so the diagram carries no orange either.
+    #[test]
+    fn a_correctly_configured_worker_is_silent() {
+        let (m, flags) = build_graph(
+            "good", "/w", "chrome,linear", &["gtm".to_string()],
+            &[sched("S1", "healthy", true, "0 * * * *", "2026-01-01T01:00:00")],
+            &[("todo".into(), 2)],
+        );
+        assert!(flags.is_empty(), "expected no flags, got {flags:?}");
+        assert!(!m.contains("classDef warn"), "no warn styling expected:\n{m}");
+    }
+
+    /// Rebuilt from the two shapes that motivated the feature.
+    #[test]
+    fn a_disabled_or_unstartable_schedule_is_flagged() {
+        let (m, flags) = build_graph(
+            "bad", "/w", "chrome", &[],
+            &[
+                sched("S1", "nightly digest", false, "0 9 * * *", "2026-01-01"),
+                sched("S2", "orphan job", true, "", ""),
+            ],
+            &[],
+        );
+        assert_eq!(flags.len(), 2, "both schedules should flag: {flags:?}");
+        assert!(flags.iter().all(|f| f["level"] == "warn"));
+        assert!(m.contains("class S0,S1 warn;"), "both nodes styled:\n{m}");
+    }
+
+    /// The rule-1 detector: no MCP reaching a worker is the flagship failure this
+    /// tab exists to surface, and it must not fire when MCP IS wired.
+    #[test]
+    fn missing_mcp_flags_but_present_mcp_does_not() {
+        let (_, none) = build_graph("a", "/w", "", &[], &[], &[]);
+        assert!(none.iter().any(|f| f["text"].as_str().unwrap_or("").contains("No MCP servers")));
+        let (m, some) = build_graph("a", "/w", "chrome", &[], &[], &[]);
+        assert!(!some.iter().any(|f| f["text"].as_str().unwrap_or("").contains("No MCP servers")));
+        assert!(m.contains("T0[\"chrome\"]"), "mcp node expected:\n{m}");
+    }
+
+    #[test]
+    fn lbl_truncates_long_titles() {
+        let long = "x".repeat(200);
+        let out = lbl(&long);
+        assert!(out.chars().count() <= 60, "got {} chars", out.chars().count());
+        assert!(out.ends_with("..."));
+    }
+}


### PR DESCRIPTION
Adds a **Workflow** tab to peek: a mermaid diagram of what a worker is actually set up to do, plus flags for the parts that will not work.

`GET /api/sessions/{name}/workflow` → `{mermaid, flags, derived_from}`.

## The one design decision

The request was a diagram to "spot check the workflow" after configuring a worker. The obvious build renders **the prose you typed**. That fails ethos rule 7: a picture drawn from the same sentence that configured the worker cannot disagree with it. It is a check that cannot fail, and worse than useless — it renders a misconfiguration as a tidy diagram and confirms it, on the surface you opened specifically to catch that.

So every node is derived from **resolved state**: `schedules` rows (`schedules.session` already binds them per worker), the worker env, board counts, `CC_TAGS` scope. The diagram is allowed to disagree with what you believed you set up, and that disagreement is the product. Flags render above the diagram for the same reason — a diagram that only draws correct config is decoration.

## It fires on real data today

Lane `amux` returns *"No MCP servers reach this worker (CC_MCP is unset)"*. That is ethos rule 1's flagship failure — six servers in `mcp.json`, 0 of 101 sessions ever received them, invisible for months — and it is still true on this machine: 6 session envs, 0 with `CC_MCP`.

## What browser verification caught

mermaid 11 strips `<br/>` from labels under `securityLevel:'strict'` (measured BR-LOST both with and without `flowchart.htmlLabels`). Two-part labels silently concatenated: `orphan job` + `once` rendered as **"orphan jobonce"**, and the worker name ran into its path.

Nothing failed. No error, no console warning — it just quietly read wrong, which no unit test would have caught. Fixed with a separator rather than by relaxing `securityLevel`: these labels carry schedule titles straight out of the DB, and strict sanitisation is what stands between that and the SVG.

## Tests

The emitter is split into a pure `build_graph` so tests drive the real one, not a paraphrase. Both directions, because a flagger that always fires is as broken as one that never does:

- correctly-configured worker → zero flags, no `classDef warn`
- disabled schedule + enabled-but-unstartable → both flag, exactly those two nodes styled
- missing MCP flags; present MCP does not
- no `<br/>` emitted anywhere (guards the whole emitter, not two call sites)

14 pass. Board counts cross-checked against real cards. Re-rendered in-browser after the fix: 2/2 diagrams OK, 0 console errors.

## Notes for the reviewer

- **Not verified:** the click-through inside the live SPA. The dev server wedges ~8s after boot on `main` — that is AMUX-35 (unbounded `du` parking every tokio worker), fixed on `fix/autofix-du-wedges-server` and not yet merged — too short for a page load. Verified at both ends instead: endpoint payload against real data, and those exact payloads rendering in a real browser. The wiring between them is verified structurally (registered in `PEEK_TABS`, panel ids present, every called identifier resolves) but not clicked.
- mermaid loads from jsdelivr, the same CDN as the 22 libraries `index.html` already pulls — established pattern, not a new dependency decision.
- Not added to the `peekHiddenTabs` default, so it ships visible (ethos rule 1).
- No model call: nodes and edges are computed from rows (ethos rule 2).
- `APP_VER` and `sw.js` `CACHE` bumped together, per CLAUDE.md.
- While testing I hit four bare `serde_json::Map` indexes that panic the rate-limit sweep on any lane missing the key. I wrote a fix, then found `fix/autofix-du-wedges-server` **already has the identical `meta_i64` fix**, better documented. Dropped mine rather than ship a duplicate that would conflict with that PR. Flagging it so it is not lost if that branch stalls — `main` still has the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)