### PR TITLE
fix(scheduler): Run Now overwrote the server's reason with a worse one (AMUX-43)

### DIFF
--- a/crates/amux-dashboard/static/app.js
+++ b/crates/amux-dashboard/static/app.js
@@ -1865,6 +1865,13 @@ async function _apiErrText(r) {
         // Gate refusals carry the exact command that WOULD work — that is the
         // most actionable thing in the whole response; surface it.
         if (msg && j.cli) msg += ' — try: ' + j.cli;
+        // Same idea, different key. The scheduler's shadow-mode 409 answers
+        // "what do I do about it" in `enable` (AMUX_RS_SCHEDULER=1), and only
+        // `cli` was being read — so the half of the body that was actionable
+        // was the half dropped. Any refusal that names its own remedy should
+        // carry it to the toast; a reason without a remedy still leaves the
+        // user asking someone.
+        if (msg && j.enable) msg += ' — set ' + j.enable;
       } catch (e) { msg = txt.slice(0, 200); }
     }
   } catch (e) { /* body already consumed or unreadable — status only */ }
@@ -7117,7 +7124,7 @@ async function saveGlobalMemory() {
   }
 }
 
-const APP_VER = '0.9.608';   // bump together with the sw.js CACHE version
+const APP_VER = '0.9.609';   // bump together with the sw.js CACHE version
 
 // ── No silent failures (Ethan, 2026-08-09: "make sure every action has some
 // kind of response in the ui — i just deleted a worker and nothing happened").
@@ -18635,12 +18642,20 @@ async function runScheduleNow(id) {
       renderSchedulerAudit();
       _peekRefreshSchedIfActive();
       if (typeof showToast === 'function') showToast(_schedRunToast(d));
-    } else if (typeof showToast === 'function') {
-      // apiCall returns null for BOTH "queued while offline" and "refused".
-      // Calling a queued run a failure would be its own wrong-message bug —
-      // the user would press again, which is the behaviour being fixed.
-      showToast(online ? 'Run failed — the server did not accept it'
-                       : 'Offline — run queued, will fire when reconnected');
+    } else if (!online && typeof showToast === 'function') {
+      // ONLY the offline case toasts here. apiCall returns null for BOTH
+      // "queued while offline" and "refused" — but on a refusal it has ALREADY
+      // shown the server's own sentence via _apiErrText, and showToast writes
+      // one shared element, so a second call here REPLACES it. That is how
+      // "409: rust scheduler is in shadow mode — set AMUX_RS_SCHEDULER=1"
+      // reached the screen as "Run failed — the server did not accept it", and
+      // the owner had to ask a session why (AMUX-43). The message was never
+      // swallowed in transit; it was overwritten at the last hop by a worse one.
+      //
+      // The offline branch stays: calling a queued run a failure would be its
+      // own wrong-message bug — the user would press again, which is the
+      // behaviour AMUX-2679 fixed.
+      showToast('Offline — run queued, will fire when reconnected');
     }
   } finally {
     if (btn && btn.tagName === 'BUTTON') { btn.disabled = false; }

--- a/crates/amux-dashboard/static/sw.js
+++ b/crates/amux-dashboard/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'amux-v0.9.608';
+const CACHE = 'amux-v0.9.609';
 const SHELL_URLS = ['/', '/manifest.json', '/icon.svg', '/icon.png', '/icon-192.png', '/icon-512.png'];
 
 // Install: pre-cache entire app shell


### PR DESCRIPTION
Pressing **Run Now** on a schedule showed *"Run failed — the server did not accept it"*. The server had actually said:

```
POST /api/schedules/SCHED-1/run  →  409
{"error":"rust scheduler is in shadow mode","enable":"AMUX_RS_SCHEDULER=1"}
```

## My first diagnosis was wrong

I filed this as `apiCall` discarding the body. **It does not.** `apiCall` already calls `showToast(await _apiErrText(r))`, and `_apiErrText` already parses `error`. The good message was produced and did reach the screen.

It was then **overwritten**. `showToast` writes one shared element (`el.textContent = msg`), and `runSchedule`'s else-branch fired a second toast immediately after — replacing the specific sentence with a generic one about 0ms later.

That distinction decides the fix: *"make apiCall surface the body"* would have changed nothing, because it already did.

## Two changes

1. **`runSchedule` only toasts when offline.** On a refusal, `apiCall` has already shown the server's own sentence, so this branch has nothing to add and everything to lose. The offline branch stays — calling a queued run a failure would be its own wrong-message bug, which is what AMUX-2679 fixed.

2. **`_apiErrText` reads `enable` alongside `cli`.** The 409 answers "what do I do about it" in `enable`, and only `cli` was read — so the half of the body that was actionable was exactly the half dropped. A reason without a remedy still leaves the user asking someone, which is how this got reported.

Toast now reads:

```
409: rust scheduler is in shadow mode — set AMUX_RS_SCHEDULER=1
```

## Verification

Extracted the **shipped** `_apiErrText` out of `app.js` and drove it with the real 409 body, not a paraphrase. Controls included, because a formatter that always appends a suffix is as wrong as one that never does:

| input | output |
|---|---|
| `{error, enable}` | `409: rust scheduler is in shadow mode — set AMUX_RS_SCHEDULER=1` |
| `{error}` only | `409: already holding doing` (no phantom suffix) |
| empty body | `Error: 500` |

Swept for the same shape elsewhere: this `else if (typeof showToast === 'function')` after an `apiCall` refusal is the only occurrence in `app.js`.

**Not verified:** the click itself in the live SPA. The dev server wedges ~8s after boot on `main` (AMUX-35, unmerged), shorter than a page load. Both halves are verified at the unit level against the real functions and the real payload.

## Notes

- `APP_VER`/`sw.js` `CACHE` bumped together per CLAUDE.md. Both this and #89 bump to `0.9.609` off `main`'s `0.9.608`, so whichever merges second needs a one-line bump — flagging so it is not a surprise.
- **This does not make the schedule run.** The 409 is correct: the Rust scheduler is in shadow mode because the code assumes "while Python owns firing", and Python was deleted in `792ce1f`. So nothing fires schedules at all — `SCHED-1` reads `never ×0`. The config fix is `AMUX_RS_SCHEDULER=1` in `~/.amux/server.env` (the cutover record, RR-0139, notes it was armed for exactly this reason). This PR only makes the failure legible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)