### PR TITLE
feat(viewer): render Excel files as sheets instead of a binary placeholder (AMUX-44)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,7 @@ dependencies = [
  "axum",
  "axum-server",
  "base64",
+ "calamine",
  "chrono",
  "cron",
  "futures",
@@ -126,6 +127,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rusqlite",
+ "rust_xlsxwriter",
  "rustls",
  "rustls-pemfile",
  "serde",
@@ -241,6 +243,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "atoi_simd"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cdb3708a128e559a30fb830e8a77a5022ee6902806925c216658652b452a44"
+dependencies = [
+ "debug_unsafe",
+ "rustversion",
 ]
 
 [[package]]
@@ -434,6 +446,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "calamine"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa68281b1a76b54a62156474adb06bb380a67e07dd60656e3217152b42183f3"
+dependencies = [
+ "atoi_simd",
+ "byteorder",
+ "chrono",
+ "codepage",
+ "encoding_rs",
+ "fast-float2",
+ "log",
+ "quick-xml",
+ "serde",
+ "zip",
+]
+
+[[package]]
 name = "cc"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +575,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "codepage"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f68d061bc2828ae826206326e61251aca94c1e4a5305cf52d9138639c918b4"
+dependencies = [
+ "encoding_rs",
 ]
 
 [[package]]
@@ -674,6 +713,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
+name = "debug_unsafe"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +817,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,6 +852,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fast-float2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
 
 [[package]]
 name = "fastrand"
@@ -840,6 +900,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1772,6 +1833,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,6 +2197,15 @@ checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
 dependencies = [
  "sha2 0.11.0",
  "walkdir",
+]
+
+[[package]]
+name = "rust_xlsxwriter"
+version = "0.97.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "210c9bee5c2d1df2c3a4fa1fccf3647a37bea205a35d5775491731b271bff19b"
+dependencies = [
+ "zip",
 ]
 
 [[package]]
@@ -2885,6 +2965,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3442,7 +3528,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
+
+[[package]]
 name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/crates/amux-dashboard/static/app.css
+++ b/crates/amux-dashboard/static/app.css
@@ -4920,3 +4920,45 @@
   .sysjob-toggle { min-height: 44px; }
   .sysjob-detail { min-height: 44px; display: inline-flex; align-items: center; }
 }
+
+/* ── Spreadsheet viewer (AMUX-44) ───────────────────────────────────────────
+   Sticky header row + row-number gutter so a wide sheet stays readable while
+   scrolling in both axes. Tabs are 44px tall on mobile per the touch-target
+   rule; the strip scrolls horizontally rather than wrapping, because a
+   many-sheet workbook would otherwise push the table off screen. */
+.file-overlay-body.file-sheet { display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
+.sheet-tabs {
+  display: flex; gap: 4px; flex: 0 0 auto; overflow-x: auto; -webkit-overflow-scrolling: touch;
+  padding: 6px 4px; border-bottom: 1px solid var(--border, #30363d); scrollbar-width: thin;
+}
+.sheet-tab {
+  flex: 0 0 auto; padding: 6px 12px; min-height: 32px; border-radius: 5px;
+  border: 1px solid var(--border, #30363d); background: transparent;
+  color: var(--dim, #8b949e); font-size: 0.8rem; cursor: pointer; white-space: nowrap;
+}
+.sheet-tab.active { background: var(--accent-bg, #1f6feb22); color: var(--fg, #e6edf3); border-color: #1f6feb; }
+.sheet-truncated {
+  flex: 0 0 auto; margin: 6px 4px; padding: 6px 8px; border-radius: 4px; font-size: 0.78rem;
+  color: #ffcc80; background: rgba(255, 152, 0, 0.08); border-left: 3px solid #ff9800;
+}
+.sheet-msg { padding: 16px; font-size: 0.85rem; color: var(--dim, #8b949e); }
+.sheet-scroll { flex: 1 1 auto; min-height: 0; overflow: auto; -webkit-overflow-scrolling: touch; }
+.sheet-table { border-collapse: separate; border-spacing: 0; font-size: 0.78rem; font-variant-numeric: tabular-nums; }
+.sheet-table th, .sheet-table td {
+  border-right: 1px solid var(--border, #30363d); border-bottom: 1px solid var(--border, #30363d);
+  padding: 3px 8px; text-align: left; white-space: nowrap; max-width: 28em;
+  overflow: hidden; text-overflow: ellipsis;
+}
+.sheet-table thead th {
+  position: sticky; top: 0; z-index: 2; background: var(--bg-alt, #161b22);
+  color: var(--dim, #8b949e); font-weight: 600; text-align: center;
+}
+.sheet-table .sheet-rownum {
+  position: sticky; left: 0; z-index: 1; background: var(--bg-alt, #161b22);
+  color: var(--dim, #8b949e); font-weight: 400; text-align: right; min-width: 3em;
+}
+.sheet-table thead th:first-child { z-index: 3; }
+@media (max-width: 600px) {
+  .sheet-tab { min-height: 44px; padding: 10px 14px; }
+  .sheet-table th, .sheet-table td { max-width: 14em; padding: 6px 8px; }
+}

--- a/crates/amux-dashboard/static/app.js
+++ b/crates/amux-dashboard/static/app.js
@@ -7117,7 +7117,7 @@ async function saveGlobalMemory() {
   }
 }
 
-const APP_VER = '0.9.609';   // bump together with the sw.js CACHE version
+const APP_VER = '0.9.610';   // bump together with the sw.js CACHE version
 
 // ── No silent failures (Ethan, 2026-08-09: "make sure every action has some
 // kind of response in the ui — i just deleted a worker and nothing happened").
@@ -12927,6 +12927,16 @@ function _renderFileBody(data, mode) {
     body.innerHTML = `<embed src="${data.data_url}" type="application/pdf" style="width:100%;height:100%;min-height:520px;border-radius:4px;">`;
     return;
   }
+  // Spreadsheet (AMUX-44). The server has already parsed the workbook, so this
+  // only lays out rows — no parsing library ships to the phone.
+  //
+  // Placed ABOVE the is_binary branch on purpose: an xlsx is a zip and used to
+  // fall through to the "binary file" placeholder.
+  if (data.is_sheet) {
+    body.className = 'file-overlay-body file-sheet';
+    _renderSheet(body, data);
+    return;
+  }
   // Renderable ebook (EPUB/FB2/CBZ): server already inlined everything into a
   // self-contained HTML doc — render it in a sandboxed (no-script) iframe.
   if (data.is_ebook && data.content && !data.is_binary) {
@@ -13401,6 +13411,112 @@ function _filesUpdateSortHeaders() {
       el.appendChild(span);
     }
   });
+}
+
+
+// ── Spreadsheet viewer (AMUX-44) ─────────────────────────────────────────────
+// The server sends {sheet_names, sheets:[{name,rows,total_rows,total_cols,
+// truncated,error}]}. This renders it; it never parses a workbook.
+//
+// Column letters are generated (A..Z, AA..) rather than assuming row 0 is a
+// header: many real sheets start with a title row or blank rows, and promoting
+// an arbitrary first row to <th> silently relabels the data.
+function _sheetColName(n) {
+  let s = '';
+  n += 1;
+  while (n > 0) { const r = (n - 1) % 26; s = String.fromCharCode(65 + r) + s; n = Math.floor((n - 1) / 26); }
+  return s;
+}
+let _sheetActive = 0;
+function _renderSheet(body, data) {
+  const sheets = data.sheets || [];
+  body.innerHTML = '';
+  if (data.error) {
+    body.innerHTML = `<div class="sheet-msg">${esc(data.error)}</div>`;
+    return;
+  }
+  if (!sheets.length) {
+    body.innerHTML = '<div class="sheet-msg">This workbook has no sheets.</div>';
+    return;
+  }
+  if (_sheetActive >= sheets.length) _sheetActive = 0;
+
+  // Tab strip — EVERY sheet, including empty ones. A workbook that shows sheet 1
+  // and quietly omits sheet 4 is worse than one that renders nothing.
+  const tabs = document.createElement('div');
+  tabs.className = 'sheet-tabs';
+  sheets.forEach((sh, i) => {
+    const b = document.createElement('button');
+    b.className = 'sheet-tab' + (i === _sheetActive ? ' active' : '');
+    const n = sh.total_rows || 0;
+    b.textContent = sh.name + (n ? ` (${n})` : '');
+    b.title = sh.name + ' — ' + n + ' row' + (n === 1 ? '' : 's');
+    b.onclick = () => { _sheetActive = i; _renderSheet(body, data); };
+    tabs.appendChild(b);
+  });
+  body.appendChild(tabs);
+
+  const sh = sheets[_sheetActive];
+  if (sh.error) {
+    const d = document.createElement('div');
+    d.className = 'sheet-msg';
+    d.textContent = sh.error;
+    body.appendChild(d);
+    return;
+  }
+  const rows = sh.rows || [];
+  if (!rows.length) {
+    const d = document.createElement('div');
+    d.className = 'sheet-msg';
+    d.textContent = 'This sheet is empty.';
+    body.appendChild(d);
+    return;
+  }
+
+  // SAY WHAT IS NOT SHOWN. A table that stops at 2000 rows without saying so
+  // reads as the whole file, and the user decides off it.
+  if (sh.truncated) {
+    const w = document.createElement('div');
+    w.className = 'sheet-truncated';
+    const shownR = rows.length, shownC = rows[0] ? rows[0].length : 0;
+    w.textContent = `⚠ Showing ${shownR} of ${sh.total_rows} rows` +
+      (shownC < sh.total_cols ? ` and ${shownC} of ${sh.total_cols} columns` : '') +
+      ' — open the file directly for the rest.';
+    body.appendChild(w);
+  }
+
+  const wrap = document.createElement('div');
+  wrap.className = 'sheet-scroll';
+  const t = document.createElement('table');
+  t.className = 'sheet-table';
+  const nCols = rows.reduce((m, r) => Math.max(m, r.length), 0);
+  const thead = document.createElement('thead');
+  const hr = document.createElement('tr');
+  hr.appendChild(document.createElement('th'));           // row-number gutter
+  for (let c = 0; c < nCols; c++) {
+    const th = document.createElement('th');
+    th.textContent = _sheetColName(c);
+    hr.appendChild(th);
+  }
+  thead.appendChild(hr);
+  t.appendChild(thead);
+  const tb = document.createElement('tbody');
+  rows.forEach((r, ri) => {
+    const tr = document.createElement('tr');
+    const rh = document.createElement('th');
+    rh.className = 'sheet-rownum';
+    rh.textContent = String(ri + 1);
+    tr.appendChild(rh);
+    for (let c = 0; c < nCols; c++) {
+      const td = document.createElement('td');
+      td.textContent = r[c] == null ? '' : r[c];   // textContent, never innerHTML
+      tr.appendChild(td);
+    }
+    tb.appendChild(tr);
+  });
+  t.appendChild(tb);
+  wrap.appendChild(t);
+  body.appendChild(wrap);
 }
 
 function _fileTypeIcon(name, type) {

--- a/crates/amux-dashboard/static/sw.js
+++ b/crates/amux-dashboard/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'amux-v0.9.609';
+const CACHE = 'amux-v0.9.610';
 const SHELL_URLS = ['/', '/manifest.json', '/icon.svg', '/icon.png', '/icon-192.png', '/icon-512.png'];
 
 // Install: pre-cache entire app shell

--- a/crates/amux-server/Cargo.toml
+++ b/crates/amux-server/Cargo.toml
@@ -52,6 +52,8 @@ libc.workspace = true
 tempfile.workspace = true
 portable-pty = "0.9.0"
 serde_yaml = "0.9.34"
+calamine = { version = "0.36", default-features = false, features = ["dates"] }
 
 [dev-dependencies]
 proptest.workspace = true
+rust_xlsxwriter = "0.97.1"

--- a/crates/amux-server/src/api/file_viewer.rs
+++ b/crates/amux-server/src/api/file_viewer.rs
@@ -298,6 +298,19 @@ async fn view(req: Request) -> Response {
         );
     }
 
+    // Spreadsheets (AMUX-44). MUST sit above the binary sniff: an xlsx is a
+    // zip, so it sniffs binary and fell through to the "binary file"
+    // placeholder — the viewer showed nothing at all.
+    //
+    // Parsed HERE rather than in the client. The viewer already pre-processes
+    // per type server-side (image -> data_url, pdf -> base64), and amux is a
+    // mobile-first PWA: shipping a whole workbook to a phone to parse it there
+    // is the wrong place for the work. It is also the only place a cap can be
+    // applied honestly — see `truncated` below.
+    if matches!(ext.as_str(), ".xlsx" | ".xlsm" | ".xls" | ".xlsb" | ".ods") {
+        return sheet_payload(&p, &ext, meta.len());
+    }
+
     // Binary sniff: NUL byte in the first 8KB (py:68041).
     {
         use std::io::Read;
@@ -2225,5 +2238,194 @@ pub(crate) mod tests {
         // urllib.parse.quote("/a b/ü.png") == '/a%20b/%C3%BC.png'
         assert_eq!(py_quote("/a b/ü.png"), "/a%20b/%C3%BC.png");
         assert_eq!(py_quote("/plain/path.mp4"), "/plain/path.mp4");
+    }
+}
+
+
+// ---------------------------------------------------------------------------
+// Spreadsheet payload (AMUX-44)
+// ---------------------------------------------------------------------------
+
+/// Rows/cols kept per sheet. REPORTED when it bites, never silently applied: a
+/// table that stops at row 2000 with no indication reads as "this is the whole
+/// file", and the user makes decisions off it. Ethos rule 7 — a silent cap is a
+/// confident wrong answer.
+const SHEET_MAX_ROWS: usize = 2_000;
+const SHEET_MAX_COLS: usize = 100;
+
+/// One cell, flattened to what the browser should print.
+///
+/// Formulas are NOT evaluated: xlsx stores the last computed value alongside the
+/// formula and calamine hands us that value. Showing it is both what Excel shows
+/// on open and the only honest option without a formula engine.
+fn cell_text(d: &calamine::Data) -> String {
+    use calamine::Data;
+    match d {
+        Data::Empty => String::new(),
+        Data::String(s) => s.clone(),
+        // Whole floats print as integers — 3, not 3.0 — because a sheet of
+        // counts rendered as "3.0" reads as a different value than the file.
+        Data::Float(f) => {
+            if f.fract() == 0.0 && f.abs() < 1e15 {
+                format!("{}", *f as i64)
+            } else {
+                f.to_string()
+            }
+        }
+        Data::Int(i) => i.to_string(),
+        Data::Bool(b) => b.to_string(),
+        Data::Error(e) => format!("#{e:?}"),
+        Data::DateTime(dt) => dt
+            .as_datetime()
+            .map(|d| d.format("%Y-%m-%d %H:%M").to_string())
+            .unwrap_or_else(|| dt.to_string()),
+        Data::DateTimeIso(s) => s.clone(),
+        Data::DurationIso(s) => s.clone(),
+    }
+}
+
+fn sheet_payload(p: &Path, ext: &str, size: u64) -> Response {
+    use calamine::Reader;
+    let mut wb = match calamine::open_workbook_auto(p) {
+        Ok(w) => w,
+        // SAY SO. Falling back to the binary placeholder would report a
+        // readable-but-unparsed file as if it were opaque, which is the failure
+        // this change exists to remove.
+        Err(e) => {
+            return j(
+                200,
+                json!({
+                    "path": pystr(p), "is_sheet": true, "ext": ext, "size": size,
+                    "error": format!("could not read spreadsheet: {e}"),
+                    "sheet_names": Vec::<String>::new(),
+                    "sheets": Vec::<Value>::new(),
+                }),
+            )
+        }
+    };
+
+    let names = wb.sheet_names().to_vec();
+    let mut sheets: Vec<Value> = Vec::new();
+    for name in &names {
+        // EVERY sheet is emitted, including empty and unreadable ones. A
+        // workbook that renders sheet 1 and silently omits sheet 4 is worse
+        // than not rendering at all.
+        match wb.worksheet_range(name) {
+            Ok(range) => {
+                let (h, w) = (range.height(), range.width());
+                let keep_r = h.min(SHEET_MAX_ROWS);
+                let keep_c = w.min(SHEET_MAX_COLS);
+                let rows: Vec<Value> = range
+                    .rows()
+                    .take(keep_r)
+                    .map(|r| Value::Array(r.iter().take(keep_c).map(|c| json!(cell_text(c))).collect()))
+                    .collect();
+                sheets.push(json!({
+                    "name": name, "rows": rows,
+                    "total_rows": h, "total_cols": w,
+                    "truncated": h > keep_r || w > keep_c,
+                }));
+            }
+            Err(e) => sheets.push(json!({
+                "name": name, "rows": Vec::<Value>::new(),
+                "total_rows": 0, "total_cols": 0, "truncated": false,
+                "error": format!("sheet could not be read: {e}"),
+            })),
+        }
+    }
+
+    j(
+        200,
+        json!({
+            "path": pystr(p), "is_sheet": true, "ext": ext, "size": size,
+            "sheet_names": names, "sheets": sheets,
+            "max_rows": SHEET_MAX_ROWS, "max_cols": SHEET_MAX_COLS,
+        }),
+    )
+}
+
+#[cfg(test)]
+mod sheet_tests {
+    use super::*;
+
+    /// Build a real .xlsx IN RUST. The first version shelled out to python
+    /// openpyxl and skipped when it was missing — which is what happened: the
+    /// test reported `ok` while never running, the exact green-check-that-cannot-
+    /// fail this repo keeps finding. A dev-dependency has no such failure mode.
+    fn make_xlsx(path: &Path, sheets: &[(&str, usize, usize)]) {
+        use rust_xlsxwriter::Workbook;
+        let mut wb = Workbook::new();
+        for (name, nr, nc) in sheets {
+            let ws = wb.add_worksheet().set_name(*name).unwrap();
+            for i in 0..*nr {
+                for k in 0..*nc {
+                    ws.write_string(i as u32, k as u16, format!("r{i}c{k}")).unwrap();
+                }
+            }
+        }
+        wb.save(path).unwrap();
+    }
+
+    #[tokio::test]
+    async fn every_sheet_is_listed_and_truncation_is_reported() {
+        let dir = std::env::temp_dir().join(format!("amux-xlsx-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let f = dir.join("book.xlsx");
+        // sheet "big" exceeds SHEET_MAX_ROWS; "small" and "empty" do not.
+        make_xlsx(&f, &[("small", 3, 2), ("big", SHEET_MAX_ROWS + 25, 2), ("empty", 0, 0)]);
+        let resp = sheet_payload(&f, ".xlsx", 0);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: Value = serde_json::from_slice(&bytes).unwrap();
+
+        assert_eq!(v["is_sheet"], json!(true));
+        let names: Vec<String> = v["sheet_names"].as_array().unwrap().iter()
+            .map(|x| x.as_str().unwrap().to_string()).collect();
+        // EVERY sheet, including the empty one — a workbook that renders sheet 1
+        // and omits sheet 3 is worse than not rendering.
+        assert!(names.contains(&"small".to_string()), "{names:?}");
+        assert!(names.contains(&"big".to_string()), "{names:?}");
+        assert!(names.contains(&"empty".to_string()), "empty sheet dropped: {names:?}");
+
+        let sheets = v["sheets"].as_array().unwrap();
+        let get = |n: &str| sheets.iter().find(|s| s["name"] == json!(n)).unwrap();
+
+        // CONTROL: the small sheet must NOT claim truncation. A flag that is
+        // always true is as useless as one that is never set.
+        assert_eq!(get("small")["truncated"], json!(false), "small wrongly truncated");
+        assert_eq!(get("small")["rows"].as_array().unwrap().len(), 3);
+
+        // The big one must report it, and report the REAL total, not the capped one.
+        assert_eq!(get("big")["truncated"], json!(true), "cap applied silently");
+        assert_eq!(get("big")["rows"].as_array().unwrap().len(), SHEET_MAX_ROWS);
+        assert_eq!(get("big")["total_rows"], json!(SHEET_MAX_ROWS + 25));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A file that is not a workbook must say so, not fall back to "binary".
+    #[tokio::test]
+    async fn an_unreadable_workbook_reports_the_error() {
+        let dir = std::env::temp_dir().join(format!("amux-xlsx-bad-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let f = dir.join("not-really.xlsx");
+        std::fs::write(&f, b"this is not a zip").unwrap();
+        let resp = sheet_payload(&f, ".xlsx", 17);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(v["is_sheet"], json!(true), "must still claim the sheet branch");
+        assert!(v["error"].as_str().unwrap_or("").contains("could not read"),
+                "no error reported: {v}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn whole_floats_print_without_a_decimal_tail() {
+        use calamine::Data;
+        assert_eq!(cell_text(&Data::Float(3.0)), "3");
+        assert_eq!(cell_text(&Data::Float(3.5)), "3.5");
+        assert_eq!(cell_text(&Data::Empty), "");
+        assert_eq!(cell_text(&Data::Bool(true)), "true");
     }
 }


### PR DESCRIPTION
Owner: *"When I render files, when I render Excel files specifically, I want amux to render it in amux as an Excel file. In the file viewer."*

**Before:** an `.xlsx` is a zip, so it tripped the binary sniff and returned `{"is_binary":true}` — the viewer showed a placeholder. The only xlsx reference anywhere in the tree was an *icon colour* in `app.js`; nothing read the file.

## Parsed server-side, deliberately

The viewer already pre-processes per type (image → `data_url`, pdf → base64), so a sheet branch is the same shape. And amux is a mobile-first PWA — shipping a whole workbook to a phone to parse it there is the wrong place for the work. It's also the only place a cap can be applied honestly.

`calamine 0.36`, pure Rust, no system deps, reads xlsx/xlsm/xls/xlsb/ods. **No model call** — this is parsing, not judgment.

## The failure mode this is built against

A **plausible wrong table**. A renderer that drops a sheet or truncates rows silently produces something the user makes decisions from, with nothing prompting a recheck. So:

- **Every sheet is emitted and tabbed**, including empty and unreadable ones. A workbook that shows sheet 1 and quietly omits sheet 4 is worse than one that renders nothing.
- **Caps (2000 rows / 100 cols) are reported, never silent** — the payload carries `truncated` plus the *real* totals, and the UI prints "Showing 5 of 5000 rows".
- **A parse failure says so** rather than falling back to the binary placeholder, which would report a readable file as opaque.

## Verified end to end

Against a real 3-sheet workbook built from stdlib `zipfile`, so the fixture owes nothing to the code under test:

```
sheet_names = ['Q3 Revenue', 'Notes', 'Scratch']
  'Q3 Revenue'   rows=5 total=5x4 truncated=False
  'Notes'        rows=3 total=3x1 truncated=False
  'Scratch'      rows=0 total=0x0 truncated=False     ← empty sheet still listed
  ['EMEA', '12', '480000', 'Priya']                   ← whole float, not 480000.0
  ['APAC', '7',  '210000.5', 'Wei']                   ← fraction preserved
```

Then rendered in a real browser from that exact payload using the **shipped** `_renderSheet` and the **shipped** CSS: 3 tabs, 5 rows, truncation banner present when the flag is set.

Mobile measured at 375px, not assumed: `pageOverflow: false`, `tabHeight: 44`, tab strip scrolls horizontally instead of wrapping.

## The test nearly lied

The first fixture shelled out to python `openpyxl` and skipped when missing — which is what happened: it reported `ok` **while never running**. Rewritten with `rust_xlsxwriter` as a dev-dependency, so there is no skip path.

Then falsified deliberately: forcing `truncated: false` makes the test fail with *"cap applied silently"*, so the check can detect the bug it guards.

913 lib tests pass. `APP_VER` / `sw.js` `CACHE` bumped together per CLAUDE.md.

## Scope

Sheet tabs and cell values; formulas show their cached computed value (what xlsx stores, and what Excel shows on open). Out of scope and stated rather than implied: formatting, charts, pivot tables, conditional formatting, editing.

Note: this and #89/#90 all bump `APP_VER`, so whichever merges later needs a one-line bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)