### PR TITLE
fix(autofix): unbounded du wedges the server, and Map indexing panics the rate-limit sweep (AMUX-35)

### DIFF
--- a/crates/amux-server/src/api/session_verbs.rs
+++ b/crates/amux-server/src/api/session_verbs.rs
@@ -7225,7 +7225,7 @@ async fn rate_limit_sweep(state: &AppState) -> usize {
         // and answers it below, so flagging it would ask a human for something
         // nobody needs to decide.
         let selector_now = !is_rate_limit_menu(&pane) && detect_claude_status(&pane) == "waiting";
-        let selector_was = load_meta(name)["input_required_since"].as_i64().unwrap_or(0) > 0;
+        let selector_was = meta_i64(&load_meta(name), "input_required_since") > 0;
         if selector_now != selector_was {
             update_meta(
                 name,
@@ -11188,6 +11188,19 @@ mod tests {
     #[test]
     fn meta_i64_absent_key_is_zero_not_a_panic() {
         assert_eq!(meta_i64(&pre_cutover_map(), "rate_limited_since"), 0);
+    }
+
+    /// The SECOND key the sweep indexes, and the one that actually panicked in
+    /// production on 2026-08-13 (twice, at session_verbs.rs:7214) AFTER the
+    /// `rate_limited_since` sites were fixed. The first fix converted two call
+    /// sites and left this one, so the incident simply moved keys — which is why
+    /// this test names the key rather than the line.
+    ///
+    /// A pre-cutover meta blob has neither key. Anything reading an integer out
+    /// of meta must go through `meta_i64`; `Map["missing"]` panics.
+    #[test]
+    fn meta_i64_absent_input_required_since_is_zero_not_a_panic() {
+        assert_eq!(meta_i64(&pre_cutover_map(), "input_required_since"), 0);
     }
 
     /// Pins the trap itself, so nobody "simplifies" `meta_i64` back into the

--- a/crates/amux-server/src/api/session_verbs.rs
+++ b/crates/amux-server/src/api/session_verbs.rs
@@ -349,6 +349,20 @@ fn meta_str(meta: &Map<String, Value>, key: &str) -> String {
     meta.get(key).and_then(|v| v.as_str()).unwrap_or("").to_string()
 }
 
+/// Read an integer out of a session's meta.
+///
+/// ALWAYS reach for this instead of `load_meta(name)["key"]`. `load_meta`
+/// returns a `serde_json::Map`, NOT a `Value`, and the two index identically to
+/// the eye while behaving oppositely: `Value["missing"]` yields `Null`, but
+/// `Map["missing"]` forwards to `BTreeMap::index` and PANICS with "no entry
+/// found for key". That is not a hypothetical — it took the whole server down
+/// on the first boot after the Python->Rust cutover (see below), because no
+/// pre-cutover `*.meta.json` carries `rate_limited_since` and the sweep indexes
+/// it on every lane.
+fn meta_i64(meta: &Map<String, Value>, key: &str) -> i64 {
+    meta.get(key).and_then(|v| v.as_i64()).unwrap_or(0)
+}
+
 // ---------------------------------------------------------------------------
 // tmux ops. Targets come ONLY from backend::tmux's L2 helpers; the fleet's
 // tmux name is `amux-<name>` (py:4307 tmux_name — legacy cmux-/cc- migration
@@ -7292,13 +7306,13 @@ async fn rate_limit_sweep(state: &AppState) -> usize {
         if !is_rate_limit_menu(&pane) {
             // Recovered on its own (or was never limited): clear a stale stamp
             // so the fleet view does not stay red after the fact.
-            if load_meta(name)["rate_limited_since"].as_i64().unwrap_or(0) > 0 {
+            if meta_i64(&load_meta(name), "rate_limited_since") > 0 {
                 update_meta(name, &[("rate_limited_since", json!(0))]);
             }
             continue;
         }
         found += 1;
-        if load_meta(name)["rate_limited_since"].as_i64().unwrap_or(0) == 0 {
+        if meta_i64(&load_meta(name), "rate_limited_since") == 0 {
             update_meta(
                 name,
                 &[
@@ -11144,6 +11158,59 @@ mod tests {
     use axum::body::Body;
     use axum::http::Request;
     use tower::ServiceExt;
+
+    /// The literal shape of a pre-cutover `*.meta.json`, copied from a live
+    /// `~/.amux/sessions/` file on the machine where this incident happened.
+    /// The load-bearing property is what it does NOT contain: no
+    /// `rate_limited_since`. A meta blob invented for a test would have been
+    /// written WITH the key and could never have caught this.
+    const PRE_CUTOVER_META: &str = r#"{
+        "created_at": 1785985494,
+        "creator": "Mac",
+        "start_count": 2,
+        "last_started": 1786451118,
+        "task_summary": "Reduce Verbose Output"
+    }"#;
+
+    fn pre_cutover_map() -> Map<String, Value> {
+        serde_json::from_str::<Value>(PRE_CUTOVER_META)
+            .unwrap()
+            .as_object()
+            .cloned()
+            .unwrap()
+    }
+
+    /// The regression. Every lane created before the Rust cutover lacks
+    /// `rate_limited_since`, so the rate-limit sweep read it on the FIRST tick
+    /// after install, panicked, and the server stopped answering entirely —
+    /// TCP still accepted from the kernel backlog while nothing serviced the
+    /// TLS hello, which is why it presented as a hang rather than a crash.
+    #[test]
+    fn meta_i64_absent_key_is_zero_not_a_panic() {
+        assert_eq!(meta_i64(&pre_cutover_map(), "rate_limited_since"), 0);
+    }
+
+    /// Pins the trap itself, so nobody "simplifies" `meta_i64` back into the
+    /// indexing form. `load_meta` returns a `Map`, and `Map[key]` forwards to
+    /// `BTreeMap::index` — it PANICS on a missing key, where the
+    /// near-identical-looking `Value[key]` would have yielded `Null`. If this
+    /// test ever stops panicking, serde_json changed and the comment on
+    /// `meta_i64` needs revisiting.
+    #[test]
+    #[should_panic(expected = "no entry found for key")]
+    fn map_indexing_panics_on_absent_key() {
+        let _ = pre_cutover_map()["rate_limited_since"].as_i64();
+    }
+
+    /// A present key still reads back, so the fix did not trade a panic for a
+    /// silent zero on the path that actually matters (a genuinely limited lane
+    /// must stay flagged).
+    #[test]
+    fn meta_i64_reads_a_present_value() {
+        let mut m = pre_cutover_map();
+        m.insert("rate_limited_since".into(), json!(1786451118i64));
+        assert_eq!(meta_i64(&m, "rate_limited_since"), 1786451118);
+    }
 
     /// Feed `input` to the real generated pipe command and return the log.
     /// Runs the SHIPPED string through `sh -c`, exactly as tmux's `pipe-pane`

--- a/crates/amux-server/src/runtime_jobs/autofix.rs
+++ b/crates/amux-server/src/runtime_jobs/autofix.rs
@@ -1332,22 +1332,100 @@ fn disk_samples() -> &'static std::sync::RwLock<Vec<(f64, u64)>> {
     CELL.get_or_init(|| std::sync::RwLock::new(Vec::new()))
 }
 
+/// Ceiling for ONE `du` walk, and for the whole set. Both are env-tunable
+/// because the right number is a property of the machine's disk, not of amux.
+fn du_path_timeout_s() -> f64 {
+    std::env::var("AMUX_DISK_DU_PATH_TIMEOUT_S")
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+        .filter(|v| *v > 0.0)
+        .unwrap_or(5.0)
+}
+
+fn du_total_timeout_s() -> f64 {
+    std::env::var("AMUX_DISK_DU_TOTAL_TIMEOUT_S")
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+        .filter(|v| *v > 0.0)
+        .unwrap_or(15.0)
+}
+
+/// One bounded `du -skx`. Returns `None` if it did not finish in time — a
+/// SKIPPED path, not a zero-sized one, which matters because a silent 0 would
+/// rank the biggest consumer last and point the report at an innocent
+/// directory.
+fn du_one(p: &std::path::Path, deadline: std::time::Instant) -> Option<u64> {
+    let mut child = std::process::Command::new("/usr/bin/du")
+        .args(["-skx"])
+        .arg(p)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()?;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    // Kill AND reap: an unreaped `du` is a zombie holding the
+                    // very FDs the neighbouring FdPressure detector counts.
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    tracing::warn!(path = %p.display(), "disk: du timed out — path skipped in the size ranking");
+                    return None;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            Err(_) => return None,
+        }
+    }
+    let out = child.wait_with_output().ok()?;
+    let text = String::from_utf8_lossy(&out.stdout);
+    let kb: u64 = text.split_whitespace().next()?.parse().ok()?;
+    Some(kb * 1024)
+}
+
+/// Rank the biggest consumers, under a hard wall-clock budget.
+///
+/// EVERY `du` HERE IS BOUNDED, and that is the whole point. This runs only
+/// when free space is already under the floor (see `detect_disk`), i.e. only
+/// on the machine where a `du` of `~/Library/Caches` is slowest — so an
+/// unbounded walk is not a slow path, it is the failure mode. Unbounded, it
+/// took the SERVER DOWN: `std::process::Command::output()` blocks the calling
+/// thread, this runs on a tokio worker, and the tick repeats — so each tick
+/// parked another worker on a multi-minute directory walk until none were left
+/// to poll the accept loop. The server then held its listening socket with
+/// every thread parked and 0% CPU: no panic, no log line, connections accepted
+/// by the kernel and answered by nobody. It reads as a hang with no cause,
+/// which is the most expensive shape a fault can have.
+///
+/// This is ethos rule 7's "what does the DETECTOR cost, and is the cost paid in
+/// the same resource as the fault?" — here it was worse than the spin-catcher
+/// it echoes, because the cost landed on the runtime rather than on the disk.
 fn du_top(paths: &[std::path::PathBuf], limit: usize) -> Vec<(String, u64)> {
-    let mut sized: Vec<(String, u64)> = paths
-        .iter()
-        .filter(|p| p.exists())
-        .filter_map(|p| {
-            let out = std::process::Command::new("/usr/bin/du")
-                .args(["-skx"])
-                .arg(p)
-                .output()
-                .ok()?;
-            let text = String::from_utf8_lossy(&out.stdout);
-            let kb: u64 = text.split_whitespace().next()?.parse().ok()?;
-            Some((p.display().to_string(), kb * 1024))
-        })
-        .collect();
-    sized.sort_by_key(|e| std::cmp::Reverse(e.1));
+    let started = std::time::Instant::now();
+    let total_budget = std::time::Duration::from_secs_f64(du_total_timeout_s());
+    let per_path = std::time::Duration::from_secs_f64(du_path_timeout_s());
+    let mut sized: Vec<(String, u64)> = Vec::new();
+    let mut skipped = 0usize;
+    for p in paths.iter().filter(|p| p.exists()) {
+        let remaining = total_budget.saturating_sub(started.elapsed());
+        if remaining.is_zero() {
+            skipped += 1;
+            continue;
+        }
+        let deadline = std::time::Instant::now() + per_path.min(remaining);
+        match du_one(p, deadline) {
+            Some(bytes) => sized.push((p.display().to_string(), bytes)),
+            None => skipped += 1,
+        }
+    }
+    // Rule 4: a truncated ranking that does not say it was truncated reads as a
+    // complete one. Whoever acts on this report must see that paths are missing.
+    if skipped > 0 {
+        tracing::warn!(skipped, "disk: size ranking is INCOMPLETE — some paths exceeded the du budget");
+    }
+    sized.sort_by_key(|(_, bytes)| std::cmp::Reverse(*bytes));
     sized.truncate(limit);
     sized
 }
@@ -2878,6 +2956,59 @@ mod tests {
         for off in ["0", "false", "off", "no", "OFF", " 0 ", "False"] {
             assert!(!parse_ops_health_cards(Some(off)), "{off:?} must disable filing");
         }
+    }
+
+    /// `du_top` must RETURN under its budget even when a path cannot be walked
+    /// in time. The incident this guards: an unbounded `du` on a nearly-full
+    /// disk parked a tokio worker per tick until the server stopped answering.
+    ///
+    /// The slow path is `/` — a real directory whose walk cannot finish in the
+    /// budget, rather than a fake one. A tempdir with a few files completes
+    /// instantly and would pass against the ORIGINAL unbounded code, which is
+    /// exactly the "convenient case lacks the property that made the incident"
+    /// trap; this asserts the bound by making the walk genuinely unfinishable.
+    #[test]
+    fn du_top_returns_within_budget_on_an_unwalkable_path() {
+        std::env::set_var("AMUX_DISK_DU_PATH_TIMEOUT_S", "1");
+        std::env::set_var("AMUX_DISK_DU_TOTAL_TIMEOUT_S", "2");
+        let started = std::time::Instant::now();
+        let _ = du_top(&[std::path::PathBuf::from("/")], 8);
+        let elapsed = started.elapsed().as_secs_f64();
+        std::env::remove_var("AMUX_DISK_DU_PATH_TIMEOUT_S");
+        std::env::remove_var("AMUX_DISK_DU_TOTAL_TIMEOUT_S");
+        assert!(
+            elapsed < 10.0,
+            "du_top ran {elapsed:.1}s against a 2s total budget — the bound is not being enforced, \
+             which is the exact condition that wedged the server"
+        );
+    }
+
+    /// A timed-out path is OMITTED, never recorded as 0 bytes. A silent zero
+    /// would sort the largest consumer last and aim the disk report at an
+    /// innocent directory.
+    #[test]
+    fn du_top_omits_a_timed_out_path_rather_than_sizing_it_zero() {
+        std::env::set_var("AMUX_DISK_DU_PATH_TIMEOUT_S", "1");
+        std::env::set_var("AMUX_DISK_DU_TOTAL_TIMEOUT_S", "2");
+        let got = du_top(&[std::path::PathBuf::from("/")], 8);
+        std::env::remove_var("AMUX_DISK_DU_PATH_TIMEOUT_S");
+        std::env::remove_var("AMUX_DISK_DU_TOTAL_TIMEOUT_S");
+        assert!(
+            !got.iter().any(|(_, bytes)| *bytes == 0),
+            "a skipped path was reported with a size instead of being omitted: {got:?}"
+        );
+    }
+
+    /// Control: a path that CAN be walked is still measured and non-zero, so
+    /// the two tests above are not passing merely because `du_top` returns
+    /// nothing at all.
+    #[test]
+    fn du_top_still_measures_a_walkable_path() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("f"), vec![0u8; 64 * 1024]).unwrap();
+        let got = du_top(&[dir.path().to_path_buf()], 8);
+        assert_eq!(got.len(), 1, "expected the tempdir to be measured: {got:?}");
+        assert!(got[0].1 > 0, "measured size should be non-zero: {got:?}");
     }
 
     fn state() -> (AppState, tempfile::TempDir) {

--- a/frustrations.md
+++ b/frustrations.md
@@ -3049,3 +3049,64 @@ CARD: AMUX-3049
 SYMPTOM: Ethan: "click run now on a schedule -> says the server did not accept it." Diagnosis stalled because `_amux_request_log` showed EVERY real run-now as 200 and the only 404 was my own test — his click was simply ABSENT from the log. It never reached the server (the POST threw during a builder binary-swap restart), and the window.fetch offline interceptor caught the throw, queued the op, and returned a synthetic 202 SILENTLY — no `amuxTrack` beacon on that path. So a user-visible client failure produced zero server-side evidence. Compounding it, the synthetic 202 body `{ok,queued,offline}` has no `status`, so `_schedRunToast` rendered a queued run as "Ran · unknown outcome", and `runScheduleNow` keyed on the stale `online` flag (still true on the first failure) to print "the server did not accept it" — a rejection message over an op that was actually queued for replay.
 COST: a long forensic pass (widen the log window, enumerate every run-now status, trace three client code paths, unit-test the toast) to establish that the ENDPOINT was fine all along and the failure was purely client-side + invisible. The invisibility is the real defect: ethos rule 4 — a diagnosis being impossible from the data IS the bug — and the two-fixes rule, since the next such report would have been just as trace-less.
 FIX: fixed dc34708. The interceptor's throw path now emits `amuxTrack('fetch_unreachable',{url,method,err})` so the failing call is server-visible (lossy only during a FULL outage, which is separately visible as a moved `/health` build hash). Plus the two UX bugs: `_schedRunToast` handles the offline 202 -> "queued, will fire on reconnect" (unit-tested against the shipped fn), and `runScheduleNow` drops the stale-`online` "did not accept it" (apiCall already toasts a real refusal's reason). Note the irony: the trigger was a routine build-swap restart — every session's commit deploys by swapping the running binary, so ANY user action during that ~5s window hits this class; the beacon + honest messaging make it legible instead of alarming.
+## The server went silent 15s after install: no panic, no log, listening socket held
+AREA: instruments
+SEVERITY: blocks
+STATUS: fixed
+DATE: 2026-08-11
+SESSION: amux
+CARD: AMUX-35
+SYMPTOM: Fresh `./install.sh` on this machine came up healthy, answered `/health` twice,
+  then stopped answering ANYTHING — `/health`, `/api/board`, the dashboard, even the
+  plain-HTTP redirect that is handled before TLS. The process stayed alive, kept its
+  listening socket, sat at 0% CPU with every thread parked, and wrote NOTHING further to
+  server-rs.log. `curl` hung mid-TLS-handshake because the kernel completes the TCP
+  handshake from the listen backlog while nothing ever calls accept(). Root cause: the
+  disk-pressure autofix detector shells out to `du` with blocking
+  `std::process::Command::output()` and no timeout, on a tokio worker; on a 96%-full disk
+  `du -skx ~/Library/Caches` runs for minutes, so each tick parked another worker until
+  none were left to poll the accept loop.
+COST: ~90 minutes, almost entirely spent on the instrument rather than the bug. Four
+  hypotheses died first: a leaked semaphore permit, a head-of-line block in
+  RedirectingAcceptor's peek, self-adoption exiting, and `server.env` (which "confirmed"
+  itself, then un-confirmed when the no-file control ALSO failed — the earlier survival
+  was timing luck, not configuration). A fault that emits no panic, no log and no CPU is
+  indistinguishable from a network problem, and every cheap probe returns silence, which
+  reads as "nothing wrong here". The discriminator was free and I reached it late:
+  `ps -eo pid,ppid` on the wedged process showed one child, `/usr/bin/du -skx
+  ~/Library/Caches`, 1m40s old. Compounding it, the release binary is unsymbolicated, so
+  `sample` printed `???` for every amux frame until I rebuilt with debug info.
+FIX: bound every `du` with per-path and total wall-clock budgets, kill AND reap on
+  timeout (an unreaped `du` holds the FDs the neighbouring FdPressure detector counts),
+  and OMIT a timed-out path instead of sizing it 0 — a silent zero sorts the largest
+  consumer last and aims the report at an innocent directory. The incomplete ranking now
+  says so in the log (rule 4). The deeper fix this entry is really arguing for: a
+  detector that only runs when the resource is already scarce must be bounded BY
+  CONSTRUCTION, and the whole sync detector sweep still runs on the async runtime holding
+  a store connection — `tmutil` and the build detector's git calls are the same shape,
+  bounded only by luck. Moving that sweep to `spawn_blocking` is the real exit.
+
+## A `Map` and a `Value` index identically and behave oppositely, so the sweep panicked on every pre-cutover lane
+AREA: instruments
+SEVERITY: blocks
+STATUS: fixed
+DATE: 2026-08-11
+SESSION: amux
+CARD: AMUX-35
+SYMPTOM: First boot after the Python->Rust cutover: `thread 'tokio-rt-worker' panicked at
+  session_verbs.rs:6637: no entry found for key`, once per tick, killing the rate-limit
+  sweep for the whole fleet. `load_meta()` returns a `serde_json::Map`, and
+  `Map["missing"]` forwards to `BTreeMap::index`, which PANICS — while the visually
+  identical `Value["missing"]` yields `Null`. No pre-cutover `*.meta.json` carries
+  `rate_limited_since`, so this fired on all 5 lanes, guaranteed, on every machine
+  migrating from Python.
+COST: ~15 minutes, and it bought a wrong conclusion first: the panic is caught and logged
+  as a WARN, so it looked like the cause of the server hang it merely coincided with.
+  Fixing it correctly (verified: the panic stopped) left the server still hanging, which
+  is the only reason I kept looking.
+FIX: added `meta_i64()` next to the existing `meta_str()` so the safe form is the obvious
+  one, with a `#[should_panic]` test pinning the `Map`-vs-`Value` trap so nobody
+  "simplifies" it back to indexing. The general shape worth remembering: two types whose
+  index syntax is identical and whose missing-key behaviour is opposite will be confused
+  again, and no amount of care at the call site prevents it — only removing the sharp
+  form from reach does.


### PR DESCRIPTION
## Why this is urgent

`origin/main` cannot currently be run. A server built from main **stops answering ~8 seconds after boot**: it accepts TCP, hangs the TLS handshake at 0% CPU with every tokio worker parked, and logs nothing. It reads as a network fault with no cause.

This has been true the whole time. The one machine that stays up does so because it is pinned to `fix/autofix-du-wedges-server` (8909dd14), an unmerged branch, and its auto-updater has been deliberately blocked since 2026-08-11 to stop it "upgrading" onto main. That is a fork nobody can rebuild from main, and it is the actual blocker behind the local update path being frozen.

## What it fixes

**1. `du_top` had no timeout (AMUX-35).** `detect_disk` calls it only when free space is already under the floor, and it shelled out with blocking `std::process::Command::output()` on a tokio worker. On a nearly-full disk `du -skx ~/Library/Caches` runs for minutes, so each tick parked another worker until none were left to poll the accept loop. The detector fires only on the machine where it is slowest — ethos rule 7's "what does the DETECTOR cost, and is the cost paid in the same resource as the fault?", with the cost landing on the runtime rather than the disk.

Now: per-path and total wall-clock budgets, kill+reap on timeout, and a timed-out path is **omitted rather than sized 0** (a silent zero sorts the biggest consumer last and aims the report at an innocent directory). A truncated ranking says so in the log.

**2. `Map` indexing panicked the rate-limit sweep.** `load_meta` returns a `serde_json::Map`, not a `Value`. They index identically to the eye and behave oppositely: `Value["missing"]` yields `Null`, `Map["missing"]` panics with `no entry found for key`. No pre-cutover `*.meta.json` carries `rate_limited_since`, and the sweep indexed it on every lane. Replaced with a `meta_i64` helper carrying a comment explaining the trap.

## Provenance and conflict resolution

Cherry-picked onto current main from a branch that was **316 commits behind**, so it needed resolving. Recorded here because a reviewer should not have to reverse-engineer it:

- **`du_top` body** — took the branch's budgeted implementation. Main had acquired the explanatory doc comment about the detector cost *without* the fix that comment describes.
- **autofix tests module** — **kept both sides.** Main's `ops_health_cards_default_on_off_only_when_explicitly_falsey` and the branch's three `du_top` budget tests are independent; adjacent-addition conflict, not a semantic one.
- **`frustrations.md`** — kept both appended entries.

## Verification

Run against the **resolved tree**, not the branch it came from:

```
cargo check --workspace --all-targets    clean
cargo test  --workspace                  1164 passed, 0 failed, 17 ignored
```

The six tests pinning these two incidents pass, including main's own `ops_health_cards` test — that one is the evidence the conflict resolution preserved both sides instead of quietly dropping one.

The `du_top` tests are built to be able to fail: they walk `/`, a real path that genuinely cannot be finished inside the budget, because a tempdir with a few files completes instantly and would pass against the *original unbounded* code. A control test asserts a walkable path is still measured non-zero, so they are not passing merely because `du_top` returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wh8jhGBHd1LjtYY4aVHLyH
