### PR TITLE
fix(dashboard): "Pull from remote" reported "Network error" for an HTTP 405 (AEAB-3)

### DIFF
--- a/crates/amux-dashboard/static/app.js
+++ b/crates/amux-dashboard/static/app.js
@@ -25742,19 +25742,42 @@ async function pullFromRemote(btn) {
   const el = document.getElementById('pull-status');
   btn.disabled = true; btn.textContent = '⏳ Pulling...';
   el.textContent = '';
+  // `r` is declared out here so the catch can tell a transport failure (no response
+  // at all) from a response we could not parse. The old code could not: it reported
+  // BOTH as 'Network error', so a 405 with an empty body — what a build without
+  // /api/pull actually returns — sent the reader to check their wifi.
+  let r = null;
   try {
-    const r = await fetch(API + '/api/pull', { method: 'POST' });
-    const d = await r.json();
-    el.textContent = d.output || (d.ok ? 'Up to date' : 'Failed');
-    el.style.color = d.ok ? 'var(--green)' : 'var(--red)';
-    if (d.ok && !d.output.includes('Already up to date')) {
-      setTimeout(() => forceUpdate(), 1500);
+    r = await fetch(API + '/api/pull', { method: 'POST' });
+    // Read as text first. r.json() throws on an empty body, and that throw is
+    // indistinguishable from a network fault once it reaches the catch.
+    const body = await r.text();
+    let d = null;
+    try { d = JSON.parse(body); } catch (_) { /* handled below, with the status */ }
+
+    if (d) {
+      el.textContent = d.output || (d.ok ? 'Up to date' : 'Failed');
+      el.style.color = d.ok ? 'var(--green)' : 'var(--red)';
+      if (d.ok && !(d.output || '').includes('Already up to date')) {
+        setTimeout(() => forceUpdate(), 1500);
+      }
+      return;
     }
-  } catch(e) {
-    el.textContent = 'Network error';
+
+    // Responded, but not with JSON. Say what actually came back.
+    const snippet = body.trim().slice(0, 200);
+    el.textContent = 'HTTP ' + r.status + (r.statusText ? ' ' + r.statusText : '') +
+      (snippet ? ': ' + snippet
+               : ' (empty body) — this build may not serve /api/pull');
     el.style.color = 'var(--red)';
+  } catch (e) {
+    // Only a genuine transport failure can reach here now.
+    el.textContent = (r ? 'Failed reading response: ' : 'Network error: ') + e.message;
+    el.style.color = 'var(--red)';
+  } finally {
+    // finally, because the success path now returns early.
+    btn.disabled = false; btn.textContent = '⬇ Pull from remote';
   }
-  btn.disabled = false; btn.textContent = '⬇ Pull from remote';
 }
 
 // ── DevTools Panel ──────────────────────────────────────────────


### PR DESCRIPTION
## The report

Tapping **Pull from remote** in the About modal shows a red **"Network error"**. There is no network problem.

## What is actually happening

Measured against a live server:

```
POST /api/pull  ->  HTTP 405, empty body, no content-type
```

`fetch` resolves normally — a 405 is a real HTTP response, not a transport failure — so what throws is `r.json()` hitting an empty body. The old `catch` reported that, *and* a genuine network fault, with the same three words:

```js
} catch(e) {
  el.textContent = 'Network error';
```

It names the one cause that is not happening. This is ethos rule 4 — the instrument could not express the discriminator, and the single word it emitted pointed away from the fault. Diagnosing the dead route cost ~20 minutes that the status code would have answered instantly.

## The fix

Read the body as text, parse it separately, and report the real status when it is not JSON. `r` is hoisted out of the `try` so the `catch` can still distinguish **no response at all** from **a response I could not parse** — genuinely different failures, and the user needs to know which one they have. The success path returns early, so the button reset moves to `finally`.

## Verified against the measured specimen

Not a constructed one — the 405/empty-body response was taken from a live server:

| case | old | new |
|---|---|---|
| the real 405 | `Network error` | `HTTP 405 Method Not Allowed (empty body) — this build may not serve /api/pull` |
| success | `Already up to date.` | `Already up to date.` |
| an honest refusal | `refused: …` | `refused: would rewrite a shared checkout` |
| **a real network failure** | `Network error` | `Network error: Failed to fetch` |

That last row is the one that matters: the fix removes the false positive **without destroying the true one**. A message fix that stopped saying "network" when the network really was down would be a worse bug than the one being fixed.

```
node --check crates/amux-dashboard/static/app.js    passes
bash scripts/spa-lint.sh                            exit 0
```

Zero lint warnings inside the changed function; the 45 reported elsewhere are pre-existing on main.

## Two notes for the reviewer

- **Independent of #94.** That PR unblocks *running* main. This one only changes an error string's accuracy and can land in either order.
- **Unrelated drift spotted, deliberately not included here:** `crates/amux-dashboard/eslint.globals.generated.json` is stale on main — regenerating it adds `_RA_CAP` and `_RA_TTL_MS`, neither of which comes from this change. Left out to keep this PR focused; worth a separate regeneration commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wh8jhGBHd1LjtYY4aVHLyH
