### PR TITLE
fix(registry): claim /api/tts in NATIVE_FAMILIES — main's own CI is red without it

### DIFF
--- a/crates/amux-server/src/api/py_proxy.rs
+++ b/crates/amux-server/src/api/py_proxy.rs
@@ -148,6 +148,7 @@ pub const NATIVE_FAMILIES: &[(&str, &str)] = &[
     ("/api/push", "web push"),
     ("/api/dictation", "dictation history/dict CRUD + engine config (native whisper/gemini, api/dictation.rs)"),
     ("/api/dictate", "transcription — native whisper worker + gemini fallback (api/dictation.rs)"),
+    ("/api/tts", "read-aloud synth + voice list — POST /api/tts, GET /api/tts/voices (api/tts.rs)"),
     ("/api/torrents", "torrents"),
     ("/api/org", "org chart"),
     ("/api/gmail", "gmail oauth"),


### PR DESCRIPTION
## main is red, and it is red on its own

`origin/main` at 9442f772 fails its own `check` job:

```
every_mounted_api_family_is_claimed_by_the_registry ... FAILED
mod.rs mounts /api/tts but the boundary registry (py_proxy.rs
NATIVE_FAMILIES / PROXIED_FAMILIES) does not claim it — add the row
```

`/api/tts` was mounted in `api/mod.rs` (`tts::synth`) and added to request_log.rs's route table, but never added to the boundary registry. **The guard worked** — it named the exact file, the exact missing row, and what to do. It just was not acted on.

The cost of leaving it: every PR cut from main inherits a red build, so no PR can be judged on its own merits and a genuinely broken one would look identical to a clean one. It surfaced here because #94 and #95 both went red for a reason neither of them caused.

## The fix

One row, next to `/api/dictate` and `/api/dictation` — its audio siblings.

## Verified, with a control

Pre-existing rather than assumed: `/api/tts` appears in `mod.rs` at 9442f772 and **not** in `py_proxy.rs`, with `/api/habits` as the control confirming the same grep does find a claimed route. So the zero is a real absence, not a broken search.

```
cargo test -p amux-server --test proxy_composition   2 passed, 0 failed
cargo test --workspace                               green
```

## Suggested merge order

This one first — it turns main green, and then #94 and #95 can be evaluated honestly instead of inheriting someone else's failure.

- **#96** (this) — unblocks CI for everything
- **#94** — makes main *runnable* (a main-built server currently goes silent ~8s after boot)
- **#95** — error-text accuracy, independent of both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wh8jhGBHd1LjtYY4aVHLyH
