### PR TITLE
fix(fs): retry EINTR in the Files browser instead of showing it to the user

### DIFF
--- a/crates/amux-server/src/api/fs.rs
+++ b/crates/amux-server/src/api/fs.rs
@@ -1199,7 +1199,7 @@ async fn list_dir(method: Method, RawQuery(q): RawQuery) -> Response {
             json!({"error": "not a directory — use /api/fs/read", "path": pystr(&target)}),
         );
     }
-    let rd = match std::fs::read_dir(&target) {
+    let rd = match retry_eintr(|| std::fs::read_dir(&target)) {
         Ok(rd) => rd,
         Err(e) => return j(500, json!({"error": e.to_string()})),
     };
@@ -1251,6 +1251,32 @@ async fn list_dir(method: Method, RawQuery(q): RawQuery) -> Response {
 // succeeds, is_dir fails), and there is no 1000-entry cap.
 // ---------------------------------------------------------------------------
 
+/// Retry a syscall that failed with `EINTR`.
+///
+/// `EINTR` is not a failure. It means a signal arrived while the call was
+/// blocked, and the only correct response is to try again — but neither
+/// `std::fs::read_dir` nor `std::fs::metadata` retries for you.
+///
+/// This matters here specifically because the server spawns child processes
+/// constantly (tmux, git, `du`), so `SIGCHLD` is routine, and listing a large
+/// directory is a wide enough window to catch one. When that happened, `ls`
+/// fell through to its catch-all arm and returned HTTP 500 carrying the raw
+/// `io::Error` string, so the Files browser told the user
+/// "Interrupted system call (os error 4)" — which reads as a broken directory
+/// rather than a retryable blip, and is not actionable by anyone who sees it.
+///
+/// Bounded rather than unbounded: a genuine repeated `EINTR` should surface,
+/// not spin.
+fn retry_eintr<T>(mut f: impl FnMut() -> std::io::Result<T>) -> std::io::Result<T> {
+    for _ in 0..4 {
+        match f() {
+            Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            other => return other,
+        }
+    }
+    f()
+}
+
 pub async fn ls(method: Method, RawQuery(q): RawQuery) -> Response {
     if method != Method::GET {
         return not_found().await;
@@ -1268,7 +1294,7 @@ pub async fn ls(method: Method, RawQuery(q): RawQuery) -> Response {
     if !p.is_dir() {
         return j(400, json!({"error": "not a directory"}));
     }
-    let rd = match std::fs::read_dir(&p) {
+    let rd = match retry_eintr(|| std::fs::read_dir(&p)) {
         Ok(rd) => rd,
         // Python: PermissionError on iterdir → 403.
         Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
@@ -1285,7 +1311,7 @@ pub async fn ls(method: Method, RawQuery(q): RawQuery) -> Response {
             }
             // Python: st = item.stat() inside try — a failing stat (broken
             // symlink) SKIPS the entry.
-            let meta = std::fs::metadata(e.path()).ok()?;
+            let meta = retry_eintr(|| std::fs::metadata(e.path())).ok()?;
             let is_dir = meta.is_dir();
             Some((!is_dir, name.to_lowercase(), name, meta))
         })
@@ -1339,7 +1365,7 @@ pub async fn autocomplete_dir(method: Method, RawQuery(q): RawQuery) -> Response
     if !parent.is_dir() {
         return j(200, json!([]));
     }
-    let rd = match std::fs::read_dir(&parent) {
+    let rd = match retry_eintr(|| std::fs::read_dir(&parent)) {
         Ok(rd) => rd,
         Err(_) => return j(200, json!([])), // PermissionError → []
     };
@@ -1408,6 +1434,57 @@ async fn delete_path(req: Request) -> Response {
 
 #[cfg(test)]
 mod tests {
+
+    use std::cell::Cell;
+    use std::io::{Error, ErrorKind};
+
+    /// A transient EINTR must be retried, not surfaced. This is the incident:
+    /// the Files browser showed "Interrupted system call (os error 4)" for a
+    /// directory that was perfectly readable a moment later.
+    #[test]
+    fn retry_eintr_retries_past_a_transient_interrupt() {
+        let calls = Cell::new(0);
+        let got = super::retry_eintr(|| {
+            calls.set(calls.get() + 1);
+            if calls.get() < 3 {
+                Err(Error::new(ErrorKind::Interrupted, "eintr"))
+            } else {
+                Ok(42)
+            }
+        });
+        assert_eq!(got.unwrap(), 42);
+        assert_eq!(calls.get(), 3, "should have retried until it succeeded");
+    }
+
+    /// CONTROL, and the one that makes the two tests around it mean anything:
+    /// a non-EINTR error must come straight back, un-retried. Without this, a
+    /// helper that blindly retried EVERY error would pass the other two — and
+    /// would turn a real PermissionDenied into four syscalls and the same
+    /// error, hiding a genuine fault behind a retry loop.
+    #[test]
+    fn retry_eintr_does_not_retry_other_errors() {
+        let calls = Cell::new(0);
+        let got: std::io::Result<u8> = super::retry_eintr(|| {
+            calls.set(calls.get() + 1);
+            Err(Error::new(ErrorKind::PermissionDenied, "nope"))
+        });
+        assert_eq!(got.unwrap_err().kind(), ErrorKind::PermissionDenied);
+        assert_eq!(calls.get(), 1, "a non-EINTR error must not be retried");
+    }
+
+    /// A PERSISTENT EINTR must still terminate and surface, rather than spin.
+    /// Bounded retry is the point; an unbounded one trades a visible error for
+    /// a hung request, which is strictly worse to diagnose.
+    #[test]
+    fn retry_eintr_surfaces_a_persistent_interrupt() {
+        let calls = Cell::new(0);
+        let got: std::io::Result<u8> = super::retry_eintr(|| {
+            calls.set(calls.get() + 1);
+            Err(Error::new(ErrorKind::Interrupted, "eintr"))
+        });
+        assert_eq!(got.unwrap_err().kind(), ErrorKind::Interrupted);
+        assert!(calls.get() <= 8, "retry must be bounded, got {} calls", calls.get());
+    }
     use super::*;
     use axum::body::Body;
     use tower::ServiceExt;


### PR DESCRIPTION
## The report

The Files browser showed **"Interrupted system call (os error 4)"** in place of a directory listing — for a directory that was perfectly readable a second later.

## Cause

`ls` calls `std::fs::read_dir`, and its catch-all arm stringifies any `io::Error` straight into a 500:

```rust
Err(e) => return j(500, json!({"error": e.to_string()})),
```

`EINTR` lands there. It is **not a failure** — it means a signal arrived while the call was blocked, and the only correct response is to try again. Neither `read_dir` nor `metadata` retries for you. This server spawns child processes constantly (tmux, git, `du`), so `SIGCHLD` is routine, and listing a large directory is a wide enough window to catch one.

The user is shown an error naming a cause they cannot act on, for a directory that is fine. Same shape as the `Network error` defect in #95: the message names a condition that is not the problem.

## Fix

Bounded retry (4 attempts) at all three `read_dir` sites plus the per-entry `metadata`.

**That last site matters more than it looks.** An `EINTR` there hits `.ok()?` and *silently drops the entry*, so the listing comes back short with **no error at all**. A quietly incomplete file listing is worse than a visible 500 — nothing prompts you to re-read it.

Bounded rather than unbounded on purpose: an unbounded retry trades a visible error for a hung request, which is strictly harder to diagnose.

## Tests, and proof they can fail

Three: a transient `EINTR` is retried; a persistent one still terminates and surfaces; and — the load-bearing one — **a non-`EINTR` error is returned un-retried**.

I sabotaged the helper to retry *every* error and re-ran:

```
retry_eintr_surfaces_a_persistent_interrupt ... ok
retry_eintr_retries_past_a_transient_interrupt ... ok
retry_eintr_does_not_retry_other_errors ... FAILED
```

The two obvious tests still passed. Only the control caught it. Without that control, a helper that retried everything would look correct while turning a real `PermissionDenied` into four syscalls and the same error.

## Correction to the commit message

The commit says "`cargo test --workspace` green." **That is not accurate and I am flagging it rather than force-pushing over it.**

The workspace run has one failure: `every_mounted_api_family_is_claimed_by_the_registry`, which `main` carries on its own (`/api/tts` missing from the boundary registry) and which **#96** fixes. This branch touches only `fs.rs`, so it cannot be the cause.

Worth naming why the wrong claim got written: the shell line I used to check printed "zero failures" *unconditionally*, regardless of what the grep actually found. A status line that cannot report failure is the same defect this PR fixes, one level up.

## Honest limitation

I could **not** reproduce this on demand — 40 consecutive `/api/ls` calls against the same path all succeeded. `EINTR` is timing-dependent by nature. The diagnosis rests on the error string being exactly Rust's `io::Error` Display for a raw OS error, on `EINTR` being the only way that string reaches this code path, and on there being no retry anywhere in `fs.rs`. The fix is correct regardless of reproduction: retrying `EINTR` is right, and the control test shows it does not paper over anything else.

Independent of #94/#95/#96 — merge in any order (though #96 first makes CI readable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wh8jhGBHd1LjtYY4aVHLyH
