### PR TITLE
fix(sweep): two Map-index panics survived the AMUX-35 merge and are live on main

### DIFF
--- a/crates/amux-server/src/api/session_verbs.rs
+++ b/crates/amux-server/src/api/session_verbs.rs
@@ -7225,7 +7225,7 @@ async fn rate_limit_sweep(state: &AppState) -> usize {
         // and answers it below, so flagging it would ask a human for something
         // nobody needs to decide.
         let selector_now = !is_rate_limit_menu(&pane) && detect_claude_status(&pane) == "waiting";
-        let selector_was = load_meta(name)["input_required_since"].as_i64().unwrap_or(0) > 0;
+        let selector_was = meta_i64(&load_meta(name), "input_required_since") > 0;
         if selector_now != selector_was {
             update_meta(
                 name,
@@ -7275,7 +7275,7 @@ async fn rate_limit_sweep(state: &AppState) -> usize {
             .flatten();
         let stuck_now = typed_pending.is_some();
         let meta_now = load_meta(name);
-        let stuck_was = meta_now["composer_stuck_since"].as_i64().unwrap_or(0) > 0;
+        let stuck_was = meta_i64(&meta_now, "composer_stuck_since") > 0;
         if stuck_now != stuck_was {
             let preview = typed_pending
                 .as_deref()


### PR DESCRIPTION
`meta_i64` landed in #98, but two of its four call sites came back as bare `serde_json::Map` indexes and are **live on main right now**:

```
session_verbs.rs:7228   load_meta(name)["input_required_since"]
session_verbs.rs:7278   meta_now["composer_stuck_since"]
```

`Map`'s `Index` panics with `no entry found for key`; `Value`'s yields `Null`. Any lane whose meta lacks the key kills the rate-limit sweep task on every pass.

## How it got there

I merged `origin/main` into the AMUX-35 branch and `session_verbs.rs` **auto-merged with no conflict**. Both sides had touched code near those lines, so git took main's version of them while keeping the new helper — textually clean, semantically wrong.

The fix therefore *looked* complete: the helper is present and two call sites use it. Nothing in a diff review would have shown the other two. Only the running server did, panicking twice within two minutes of the install.

## Measured, not inferred

After installing main `4698028b`, counting panics in `server-rs.log` since the restart line: **2, both at 7228.**

After this fix, the only remaining bare index in the file is line 8836 — a `serde_json::Value` from `from_str::<Value>`, which returns `Null` on a miss and is safe. Checked rather than assumed, since that distinction is exactly what makes the other two dangerous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)