### PR TITLE
fix(autofix): log a skipped du path once per run, naming it, not once per attempt

### DIFF
--- a/crates/amux-server/src/runtime_jobs/autofix.rs
+++ b/crates/amux-server/src/runtime_jobs/autofix.rs
@@ -1371,7 +1371,11 @@ fn du_one(p: &std::path::Path, deadline: std::time::Instant) -> Option<u64> {
                     // very FDs the neighbouring FdPressure detector counts.
                     let _ = child.kill();
                     let _ = child.wait();
-                    tracing::warn!(path = %p.display(), "disk: du timed out — path skipped in the size ranking");
+                    // debug, not warn: `du_top` reports every skip ONCE per run and
+                    // names the paths. This line fired per attempt on the same
+                    // unchanging path (~/Library/Caches), which made it 78% of the
+                    // server log in a 30-minute window and buried a per-minute panic.
+                    tracing::debug!(path = %p.display(), "disk: du timed out — path skipped in the size ranking");
                     return None;
                 }
                 std::thread::sleep(std::time::Duration::from_millis(50));
@@ -1407,23 +1411,31 @@ fn du_top(paths: &[std::path::PathBuf], limit: usize) -> Vec<(String, u64)> {
     let total_budget = std::time::Duration::from_secs_f64(du_total_timeout_s());
     let per_path = std::time::Duration::from_secs_f64(du_path_timeout_s());
     let mut sized: Vec<(String, u64)> = Vec::new();
-    let mut skipped = 0usize;
+    let mut skipped: Vec<String> = Vec::new();
     for p in paths.iter().filter(|p| p.exists()) {
         let remaining = total_budget.saturating_sub(started.elapsed());
         if remaining.is_zero() {
-            skipped += 1;
+            skipped.push(p.display().to_string());
             continue;
         }
         let deadline = std::time::Instant::now() + per_path.min(remaining);
         match du_one(p, deadline) {
             Some(bytes) => sized.push((p.display().to_string(), bytes)),
-            None => skipped += 1,
+            None => skipped.push(p.display().to_string()),
         }
     }
     // Rule 4: a truncated ranking that does not say it was truncated reads as a
     // complete one. Whoever acts on this report must see that paths are missing.
-    if skipped > 0 {
-        tracing::warn!(skipped, "disk: size ranking is INCOMPLETE — some paths exceeded the du budget");
+    if !skipped.is_empty() {
+        // Rule 4 still applies — a truncated ranking must say so. But it must say
+        // it ONCE per run, naming the paths, rather than once per attempt: the
+        // per-attempt spelling reported the same unchanging path thousands of
+        // times and drowned the log it shares with real faults.
+        tracing::warn!(
+            skipped = skipped.len(),
+            paths = %skipped.join(", "),
+            "disk: size ranking is INCOMPLETE — these paths exceeded the du budget"
+        );
     }
     sized.sort_by_key(|(_, bytes)| std::cmp::Reverse(*bytes));
     sized.truncate(limit);


### PR DESCRIPTION
## Measured, not estimated

30 minutes after a restart on a live server: **52 of 67 log lines — 78% — were these two warnings**, all for one unchanging path (`~/Library/Caches`).

In the previous sample they were 5,722 of 10,480 lines (55%), and they buried a rate-limit sweep panicking **every 60 seconds**.

## What this is not

The AMUX-35 budget fix is correct and stays untouched. This is purely its logging.

`du_one` warned on every timed-out *attempt*; `du_top` then warned again with a count. The same path times out every run, so the volume is unbounded in time while carrying no new information after the first line.

## The change

- `du_one` → `debug!`
- `du_top` → exactly one `warn!` per run, **naming the skipped paths**

Strictly more information in strictly fewer lines. The old summary said only "some paths exceeded the du budget" — you could not tell *which* directory was missing from the ranking without grepping the per-attempt lines it was drowning in.

Rule 4 is preserved: a truncated ranking still announces itself. It announces itself once.

## Verification

`cargo test --workspace`: **0 failed.** The three `du_top` budget tests pass unchanged — they assert behaviour (bounded runtime, timed-out paths omitted rather than sized zero, walkable paths still measured), none of which this touches.

Found by the daily log review; recorded as LR-16 in that ledger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wh8jhGBHd1LjtYY4aVHLyH
