### PR TITLE
fix(yolo): badge showed YOLO for lanes that still stop for approval

### DIFF
--- a/crates/amux-dashboard/static/app.js
+++ b/crates/amux-dashboard/static/app.js
@@ -2927,7 +2927,10 @@ function render() {
   function _renderSessionCard(s) {
     const isExp = expanded.has(s.name);
     const flags = s.flags || '';
-    const isYolo = flags.includes('--dangerously-skip-permissions') || flags.includes('--dangerously-bypass-approvals-and-sandbox') || flags.includes('--yolo') || !!s.auto_continue;
+    // Server verdict, not a re-derivation: see session_verbs::yolo_enabled.
+    // The old local form ORed in `s.auto_continue`, which is default-ON, so it
+    // badged lanes YOLO that would still stop and ask for approval.
+    const isYolo = !!s.yolo;
     const provider = sessionProvider(s);
     const model = sessionConfiguredModel(s);
     const effort = provider === 'claude' ? flagValue(flags, '--effort') : '';
@@ -4646,13 +4649,17 @@ async function toggleYolo(session) {
       const claudeFlag = '--dangerously-skip-permissions';
       const codexFlag = '--dangerously-bypass-approvals-and-sandbox';
       const geminiFlag = '--yolo';
-      const wasYolo = (s.flags || '').includes(claudeFlag) || (s.flags || '').includes(codexFlag) || (s.flags || '').includes(geminiFlag) || (s.flags || '').includes('--approval-mode=yolo') || (s.flags || '').includes('--approval-mode yolo') || !!s.auto_continue;
+      // Same server verdict the badge uses — the toggle must not disagree with
+      // what the card shows, or one tap appears to do nothing.
+      const wasYolo = !!s.yolo;
       if (wasYolo) {
         s.flags = stripProviderYoloFlags(s.flags || '');
         s.auto_continue = false;
+        s.yolo = false;   // the field the badge reads — the server will confirm
       } else {
         s.flags = ((s.flags || '') + ' ' + providerYoloFlag(s.provider)).trim();
         s.auto_continue = true;
+        s.yolo = true;
       }
       lastSessionsJSON = '';
       render();

--- a/crates/amux-server/src/api/session_verbs.rs
+++ b/crates/amux-server/src/api/session_verbs.rs
@@ -2145,7 +2145,24 @@ pub fn standing_orders_on_in(home: &std::path::Path, lane: &str, key: &str) -> b
     auto_continue_on(scoped_setting_in(home, lane, key).as_deref())
 }
 
-fn is_yolo_enabled(flags: &str, cfg: &EnvFile) -> bool {
+/// THE predicate for "is this lane in YOLO mode". Public so the sessions
+/// payload can serialize the very verdict the toggle acts on, instead of the
+/// SPA re-deriving it — a view that re-derives a predicate drifts from it the
+/// moment either side changes, and this one did.
+///
+/// The bug that made this public: the SPA computed its badge as
+/// `flags.includes(skipPermissions) || !!s.auto_continue`, and `auto_continue`
+/// in the payload is `standing_orders_on(...)`, which is DEFAULT-ON at every
+/// level. So a lane with no skip-permissions flag at all rendered a YOLO badge,
+/// and a worker sat blocked on "This command requires approval" for 11 hours
+/// while its card claimed it would never stop to ask.
+///
+/// Note the comment below already forbade exactly that, server-side, and was
+/// right: the default-on nudge must never imply skip-permissions. The client
+/// did it anyway, through a field carrying the default-on value. That is why
+/// the fix is to SHARE the predicate rather than to restate it correctly in a
+/// second place.
+pub fn yolo_enabled(flags: &str, cc_auto_continue: Option<&str>) -> bool {
     PROVIDER_YOLO_FLAGS.iter().any(|f| flags.contains(f))
         || flags.contains("--approval-mode=yolo")
         || flags.contains("--approval-mode yolo")
@@ -2154,7 +2171,11 @@ fn is_yolo_enabled(flags: &str, cfg: &EnvFile) -> bool {
         // implies skip-permissions. The DEFAULT-on nudge must not — routing
         // the default through here would flip the whole fleet to YOLO as a
         // side effect of a scheduling change.
-        || matches!(cfg.get("CC_AUTO_CONTINUE"), Some("1" | "true" | "yes"))
+        || matches!(cc_auto_continue, Some("1" | "true" | "yes"))
+}
+
+fn is_yolo_enabled(flags: &str, cfg: &EnvFile) -> bool {
+    yolo_enabled(flags, cfg.get("CC_AUTO_CONTINUE"))
 }
 
 fn default_model_for_provider(provider: &str) -> String {
@@ -11741,6 +11762,34 @@ mod tests {
 
     /// The file/DB-backed verbs, exercised through the full router shape on a
     /// hermetic fleet home — the same dispatch the live composition mounts.
+    /// THE INVARIANT the badge bug broke: the value the sessions payload ships
+    /// must be the value the toggle acts on. The SPA used to derive its own,
+    /// ORing in `auto_continue` — which the payload fills from
+    /// `standing_orders_on`, DEFAULT-ON at every level — so a lane with no
+    /// skip-permissions flag badged YOLO and then stopped to ask for approval.
+    ///
+    /// The control is the third case: default-on standing orders must NOT read
+    /// as YOLO. Without it this test passes against the very bug it exists for.
+    #[test]
+    fn yolo_verdict_ignores_default_on_standing_orders() {
+        use super::yolo_enabled;
+        // A real bypass flag is YOLO.
+        assert!(yolo_enabled("--model opus --dangerously-skip-permissions", None));
+        // An EXPLICIT CC_AUTO_CONTINUE=1 is YOLO — a worker that never stops
+        // implies skip-permissions, which is the documented intent.
+        assert!(yolo_enabled("--model opus", Some("1")));
+        // CONTROL — the reported bug. No flag, and auto-continue merely
+        // default-on (absent from the env, which is what default-on looks like
+        // to this function): NOT yolo.
+        assert!(
+            !yolo_enabled("--model opus", None),
+            "a lane with no bypass flag must not read as YOLO — this is the \
+             personal-planner case that sat blocked on an approval prompt for 11h"
+        );
+        // And an explicit off is not yolo either.
+        assert!(!yolo_enabled("--model opus", Some("0")));
+    }
+
     #[tokio::test]
     async fn file_backed_verbs_roundtrip_hermetically() {
         let home = tempfile::tempdir().unwrap();

--- a/crates/amux-server/src/api/sessions_legacy.rs
+++ b/crates/amux-server/src/api/sessions_legacy.rs
@@ -1542,6 +1542,17 @@ fn python_fleet_sessions(signals: &FleetSignals) -> Vec<serde_json::Value> {
             // flag) — a card without flags renders the wrong YOLO badge
             // (Ethan: "the lightning button isn't correct").
             "flags": flags,
+            // The YOLO badge's source of truth, computed by the SAME function the
+            // toggle acts on (`session_verbs::yolo_enabled`). The SPA previously
+            // derived this itself as `flags.includes(...) || !!s.auto_continue`,
+            // but `auto_continue` below is `standing_orders_on`, which is
+            // DEFAULT-ON — so lanes with no skip-permissions flag rendered a YOLO
+            // badge and users trusted a worker not to stop for approval when it
+            // would. Ship the verdict, not the ingredients.
+            "yolo": crate::api::session_verbs::yolo_enabled(
+                &flags,
+                env.get("CC_AUTO_CONTINUE").map(|v| v.as_str()),
+            ),
             "creator": env.get("CC_CREATOR").cloned().unwrap_or_default(),
             "backend": backend,
             // Same predicate as board_drive's nudge gate — the view must not


### PR DESCRIPTION
## The report

A worker card showed the **YOLO** badge while its terminal sat on *"This command requires approval — Do you want to proceed?"*. It had been **NEEDS INPUT for 11 hours**.

Measured on the live fleet: `personal-planner` has flags `--model opus`. **No skip-permissions flag at all** — and it was badged YOLO.

## Cause

The SPA derived the badge itself:

```js
isYolo = flags.includes('--dangerously-skip-permissions') || ... || !!s.auto_continue
```

`auto_continue` in the payload is `standing_orders_on(...)`, which is **DEFAULT-ON at every level** by design. So the badge was true for essentially any lane, whatever its actual permission mode.

**The server already knew better.** `is_yolo_enabled` counts `CC_AUTO_CONTINUE` only when *explicit*, with a comment stating exactly why:

> the DEFAULT-on nudge must not — routing the default through here would flip the whole fleet to YOLO as a side effect of a scheduling change

That is precisely what happened — in the client, through a field carrying the default-on value.

## Fix: share the predicate, don't restate it

`yolo_enabled(flags, cc_auto_continue)` is now public and is the single definition. `is_yolo_enabled` delegates to it. The sessions payload ships the **verdict** as `yolo`. The SPA reads `s.yolo` for both the badge and the toggle's before-state, and the optimistic update sets it too, so one tap doesn't appear to do nothing.

This is the same class the payload's own comments already record **twice** — *"the view must not disagree with the mechanism it describes"* (AMUX-2930) and *"a card without flags renders the wrong YOLO badge"*. Both were fixed by shipping better **ingredients** while the SPA kept re-deriving the verdict. Shipping the verdict is what stops it coming back a third time.

## Verification

The test names the invariant and, critically, its control: a bypass flag is YOLO; an explicit `CC_AUTO_CONTINUE=1` is YOLO; **default-on standing orders are not**.

I reintroduced the old conflation to check the control actually bites:

```
yolo_verdict_ignores_default_on_standing_orders ... FAILED
```

It is the only test that catches it.

```
cargo test --workspace     0 failed
scripts/spa-lint.sh        exit 0
```

## Deliberately not included

This fixes the **lie**, not `personal-planner`'s mode. That lane genuinely is not in YOLO, and switching it calls `restart_for_swap` — restarting an 11-hour-old task mid-flight is the owner's call, not mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wh8jhGBHd1LjtYY4aVHLyH
