### PR TITLE
fix(peek): tab picker menu was trapped inside the scrolling tab strip

### DIFF
--- a/crates/amux-dashboard/static/app.js
+++ b/crates/amux-dashboard/static/app.js
@@ -7152,7 +7152,7 @@ async function saveGlobalMemory() {
   }
 }
 
-const APP_VER = '0.9.617';   // bump together with the sw.js CACHE version
+const APP_VER = '0.9.618';   // bump together with the sw.js CACHE version
 
 // ── No silent failures (Ethan, 2026-08-09: "make sure every action has some
 // kind of response in the ui — i just deleted a worker and nothing happened").

--- a/crates/amux-dashboard/static/index.html
+++ b/crates/amux-dashboard/static/index.html
@@ -1943,7 +1943,11 @@ setTimeout(function(){var f=document.getElementById('js-fallback');if(f&&f.style
     <button class="peek-tab" id="peek-tab-git" onclick="setPeekTab('git')"><span class="tab-ico">⎇</span><span class="tab-lbl">Worktree</span></button>
     <button class="peek-tab" id="peek-tab-logs" onclick="setPeekTab('logs')" title="HTTP request log for this worker"><span class="tab-ico">≡</span><span class="tab-lbl">Logs</span><span class="peek-tab-count" id="peek-tab-logs-count"></span></button>
     <button class="tab-customize-btn" id="peek-tab-customize" onclick="event.stopPropagation();togglePeekTabCustomizer()" title="Show/hide/reorder worker tabs" style="flex:0 0 auto;">&#x229E;</button>
-    <div class="tab-customizer-menu" id="peek-tab-customizer-menu" style="display:none;"></div>
+    <!-- The menu itself is NOT here on purpose — it is a direct child of the
+         document body, at the end of this file. `.peek-tabs` is a ~44px
+         horizontal scroller (overflow-x:auto; overflow-y:hidden;
+         -webkit-overflow-scrolling:touch) and a ~380px menu inside it is
+         clipped to nothing on mobile Safari. -->
   </div>
   <!-- Working directory bar -->
   <div class="peek-dir-bar">
@@ -2796,5 +2800,18 @@ setTimeout(function(){var f=document.getElementById('js-fallback');if(f&&f.style
     <div class="dt-log-area" id="dt-info-area"></div>
   </div>
 </div>
+<!-- Worker tab picker menu. Deliberately a direct child of the document body,
+     NOT of `.peek-tabs` where its button lives.
+     `.peek-tabs` is a horizontal scroller: overflow-x:auto, overflow-y:hidden,
+     -webkit-overflow-scrolling:touch, and about 44px tall. This menu renders
+     ~380px tall, so inside that box it is clipped to nothing on engines where a
+     position:fixed child does not escape a touch-scrolling ancestor — which is
+     what "the button next to Logs does nothing" was.
+     It is position:fixed and JS assigns top/left from the button's
+     getBoundingClientRect, so its placement never depended on where it sits in
+     the DOM — only its CLIPPING did. The main dashboard's equivalent
+     (#tab-customizer-menu) has always worked because it lives in
+     `.tab-customize-wrap`: position:relative, and not a scroller. -->
+<div class="tab-customizer-menu" id="peek-tab-customizer-menu" style="display:none;"></div>
 </body>
 </html>

--- a/crates/amux-dashboard/static/sw.js
+++ b/crates/amux-dashboard/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'amux-v0.9.617';
+const CACHE = 'amux-v0.9.618';
 const SHELL_URLS = ['/', '/manifest.json', '/icon.svg', '/icon.png', '/icon-192.png', '/icon-512.png'];
 
 // Install: pre-cache entire app shell


### PR DESCRIPTION
## The report

The **⊞** button at the end of the worker tab strip (next to Logs) does nothing on mobile — no menu appears.

The button, its handler, and the menu element all exist and are correctly wired. The menu was simply **invisible**.

## Cause

The menu lived **inside** `.peek-tabs`, which is a ~44px horizontal scroller:

```css
.peek-tabs { overflow-x: auto; overflow-y: hidden; -webkit-overflow-scrolling: touch; }
```

The menu renders ~380px tall. A `position: fixed` child normally escapes an overflow ancestor — but not on engines where a touch-scrolling container traps its fixed descendants, mobile Safari being the one that matters here. Clipped into a 44px box with `overflow-y: hidden`, it is invisible.

**The contrast inside this codebase is the diagnosis.** The main dashboard's identical control has always worked: `#tab-customizer-menu` lives in `.tab-customize-wrap`, which is `position: relative` and not a scroller. Same markup, same CSS class, same handler shape — different parent.

## Fix

Move the menu out to the document body. It is `position: fixed` and JS assigns `top`/`left` from the button's `getBoundingClientRect`, so its **placement** never depended on where it sat in the DOM — only its **clipping** did.

## The measurement corrected the fix mid-flight

Walking the ancestor chain with the real stylesheet applied shows **two** trapping ancestors, not one:

```
DIV.peek-tabs  overflowX=auto    overflowY=hidden
DIV.overlay    overflowX=hidden  overflowY=hidden
```

So moving the menu merely outside `.peek-tabs` would **not** have fixed it. Body level was necessary — and I only knew that because the check reported the whole chain instead of stopping at the first hit.

## Verification

The structural check discriminates:

| | clipping ancestors | verdict |
|---|---|---|
| current `main` | `.peek-tabs`, `.overlay` | **FAIL** |
| this branch | none | **PASS** |

A functional probe confirms no regression where it already worked: reparented to body, the menu opens with 13 items, lands on screen at 230×383, and receives taps. `scripts/spa-lint.sh` exits 0.

**Honest limitation:** I could not reproduce the invisibility in headless Chromium, where `position: fixed` escapes the scroller and the menu opens fine. The diagnosis rests on the ancestor chain above, the mobile-Safari behaviour of `-webkit-overflow-scrolling: touch`, and the working/broken contrast within this file. The fix removes the dependency on any of that being true.

## Cache

`APP_VER` and the `sw.js` `CACHE` are bumped together to **0.9.618**. This is a client change and the reporter is on a phone — without both, a browser holding the cached shell never receives the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wh8jhGBHd1LjtYY4aVHLyH
