### PR TITLE
feat(herdr): feed native agent lifecycle state into the scan loop (#84)

### DIFF
--- a/crates/amux-server/src/backend/herdr.rs
+++ b/crates/amux-server/src/backend/herdr.rs
@@ -467,6 +467,19 @@ impl SessionBackend for HerdrBackend {
             _ => result,
         }
     }
+
+    /// #84: one `workspace list` for the whole fleet, returning
+    /// `(backend_ref, agent_status)` for every `amux-` workspace whose pane
+    /// herdr has recognized as a known agent (`idle`/`working`/`blocked`/
+    /// `done`; arbitrary commands read `unknown` and are omitted — the
+    /// scrape stays their voice). Verified live on herdr 0.7.5 (2026-08-15):
+    /// `pane run "claude"` is auto-recognized and the workspace carries
+    /// `agent_status: "idle"`; a `workspace list` already returns it, so no
+    /// per-lane probe is needed. A read failure is `Err`, NOT an empty map.
+    async fn agent_states(&self) -> Result<std::collections::BTreeMap<String, String>> {
+        let v = self.run_json(&["workspace", "list"], OP_TIMEOUT).await?;
+        Ok(parse_workspace_statuses(&v).into_iter().collect())
+    }
 }
 
 /// `{"error":{"code":..,"message":..}}` -> (code, message).
@@ -489,6 +502,29 @@ fn parse_workspaces(v: &Value) -> Vec<(String, String)> {
                         w["label"].as_str()?.to_string(),
                         w["workspace_id"].as_str()?.to_string(),
                     ))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// `workspace list` envelope -> [(label, agent_status)] for amux-owned
+/// workspaces whose pane herdr recognized as a known agent. `unknown`
+/// (arbitrary commands — GAP-ATTACH) and agentless entries are omitted:
+/// for them the scrape is the only voice, and an `unknown` key in the map
+/// would read as "herdr answered" to a caller that only checks presence.
+fn parse_workspace_statuses(v: &Value) -> Vec<(String, String)> {
+    v["result"]["workspaces"]
+        .as_array()
+        .map(|ws| {
+            ws.iter()
+                .filter_map(|w| {
+                    let label = w["label"].as_str()?;
+                    let status = w["agent_status"].as_str()?;
+                    if !label.starts_with("amux-") || status == "unknown" {
+                        return None;
+                    }
+                    Some((label.to_string(), status.to_string()))
                 })
                 .collect()
         })
@@ -547,6 +583,31 @@ mod tests {
             ]
         );
         assert!(envelope_error(&v).is_none());
+    }
+
+    #[test]
+    fn parses_native_agent_statuses() {
+        // Shape captured from a live herdr 0.7.5 probe (2026-08-15): a
+        // `pane run "claude"` lane reads `idle`, an arbitrary command reads
+        // `unknown`, and a foreign workspace is not ours to report.
+        let v: Value = serde_json::from_str(
+            r#"{"id":"cli:workspace:list","result":{"type":"workspace_list",
+                "workspaces":[
+                  {"agent_status":"unknown","label":"amux-wrk-spike","workspace_id":"w1"},
+                  {"agent_status":"idle","label":"amux-wrk-claude","workspace_id":"w2"},
+                  {"agent_status":"blocked","label":"amux-wrk-stuck","workspace_id":"w3"},
+                  {"agent_status":"done","label":"amux-wrk-finished","workspace_id":"w4"},
+                  {"agent_status":"idle","label":"scratch","workspace_id":"w9"}]}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            parse_workspace_statuses(&v),
+            vec![
+                ("amux-wrk-claude".to_string(), "idle".to_string()),
+                ("amux-wrk-stuck".to_string(), "blocked".to_string()),
+                ("amux-wrk-finished".to_string(), "done".to_string()),
+            ]
+        );
     }
 
     #[test]

--- a/crates/amux-server/src/backend/mod.rs
+++ b/crates/amux-server/src/backend/mod.rs
@@ -159,6 +159,15 @@ pub trait SessionBackend: Send + Sync {
     /// Capture recent visible output. This is a LIVENESS/diagnostic view,
     /// not the control plane (D1): structured state comes from OpenCode.
     async fn capture(&self, proc: &ProcessRef, lines: u32) -> Result<String>;
+    /// Native agent lifecycle states for everything this backend hosts,
+    /// keyed by backend ref, in ONE batched call for the whole fleet
+    /// (herdr: a single `workspace list`; #84 — the D1 exit applied to a
+    /// backend). Empty = no native signal (the tmux default); `Err` =
+    /// could not read. The two must stay distinguishable, or a transient
+    /// backend outage masquerades as a stopped fleet.
+    async fn agent_states(&self) -> Result<std::collections::BTreeMap<String, String>> {
+        Ok(std::collections::BTreeMap::new())
+    }
 }
 
 #[cfg(test)]

--- a/crates/amux-server/src/orchestrator/scan.rs
+++ b/crates/amux-server/src/orchestrator/scan.rs
@@ -591,7 +591,7 @@ mod tests {
             vec![Arc::new(ScriptedBackend {
                 name: "herdr",
                 frame: LIMIT_FRAME.into(),
-                native: native("amux-herdr-other", "idle"),
+                native: native("amux-herdr-unrelated", "idle"),
             })],
             Some(Arc::new(MockProtocol::new())),
         );

--- a/crates/amux-server/src/orchestrator/scan.rs
+++ b/crates/amux-server/src/orchestrator/scan.rs
@@ -130,6 +130,7 @@ impl ScanLoop {
             if let Some(status) = native
                 .get(&backend_name)
                 .and_then(|m| m.get(&backend_ref))
+                .filter(|status| matches!(status.as_str(), "working" | "blocked" | "idle" | "done"))
             {
                 report.demoted_native.push(wid_str.clone());
                 let event = {
@@ -591,7 +592,7 @@ mod tests {
             vec![Arc::new(ScriptedBackend {
                 name: "herdr",
                 frame: LIMIT_FRAME.into(),
-                native: native("amux-herdr-unrelated", "idle"),
+                native: native("amux-herdr-1", "unknown"),
             })],
             Some(Arc::new(MockProtocol::new())),
         );

--- a/crates/amux-server/src/orchestrator/scan.rs
+++ b/crates/amux-server/src/orchestrator/scan.rs
@@ -7,6 +7,13 @@
 //! workers with a live TERMINAL session and no protocol session get their
 //! panes captured and run through the TerminalAdapter.
 //!
+//! The same exit, applied to a whole backend (#84): a backend that can
+//! REPORT its hosted agents' lifecycle state (herdr `agent_status`) has
+//! that answer outrank the pane scrape too — one batched
+//! [`SessionBackend::agent_states`] read per pass, no per-lane probe.
+//! Precedence: the worker's own protocol voice (above) > the backend's
+//! native report > the scrape.
+//!
 //! Consecutive identical scan results are deduped by content hash — the
 //! Python system's two-scan persistence gate, done once here so every
 //! event consumer inherits it (a rate-limit banner sitting in scrollback
@@ -15,8 +22,11 @@
 use crate::backend::{ProcessRef, SessionBackend};
 use crate::db::SharedStore;
 use crate::opencode::AgentProtocol;
-use amux_core::ids::WorkerId;
+use amux_core::ids::{TurnId, WorkerId};
 use amux_core::provider::ProviderId;
+use amux_core::protocol::{WaitReason, WorkerEvent};
+use amux_core::worker::WorkerState;
+use rusqlite::{params, Connection, OptionalExtension};
 use sha2::Digest;
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -38,6 +48,13 @@ pub struct ScanLoop {
 pub struct ScanReport {
     pub scanned: Vec<String>,
     pub demoted_structured: Vec<String>,
+    /// Workers whose capture was skipped because the BACKEND reported their
+    /// agent state natively (#84: herdr `agent_status` via one batched
+    /// `workspace list`). Same trace discipline as `demoted_structured`.
+    pub demoted_native: Vec<String>,
+    /// Backends whose native-status read failed this pass; their lanes fell
+    /// back to the scrape, and the failure is named rather than silent.
+    pub native_status_failures: Vec<String>,
     pub events_applied: usize,
     pub capture_failures: Vec<String>,
 }
@@ -75,6 +92,24 @@ impl ScanLoop {
             rows.collect::<Result<_, _>>()?
         };
 
+        // #84: ONE batched native-status read per backend for the whole
+        // pass. An empty result (tmux, or a herdr session with no
+        // recognized agents) contributes nothing; a FAILED read is named in
+        // the report and that backend's lanes keep the scrape this tick —
+        // "cannot answer" must not read as "stopped".
+        let mut native: BTreeMap<String, BTreeMap<String, String>> = BTreeMap::new();
+        for backend in &self.backends {
+            match backend.agent_states().await {
+                Ok(states) if !states.is_empty() => {
+                    native.insert(backend.name().to_string(), states);
+                }
+                Ok(_) => {}
+                Err(e) => report
+                    .native_status_failures
+                    .push(format!("{}: {e}", backend.name())),
+            }
+        }
+
         for (wid_str, backend_name, backend_ref, provider) in targets {
             let Ok(worker) = WorkerId::parse(&wid_str) else { continue };
 
@@ -85,6 +120,48 @@ impl ScanLoop {
                     report.demoted_structured.push(wid_str.clone());
                     continue;
                 }
+            }
+
+            // NATIVE (#84): the backend reported this worker's agent state
+            // — capture is demoted and the state is applied as the event it
+            // already is in WorkerEvent terms. Stays BELOW the protocol
+            // demotion above: the worker's own voice outranks its host's
+            // observation of it.
+            if let Some(status) = native
+                .get(&backend_name)
+                .and_then(|m| m.get(&backend_ref))
+            {
+                report.demoted_native.push(wid_str.clone());
+                let event = {
+                    let conn = self.store.read()?;
+                    let prior = crate::db::queries::get_worker(&conn, &wid_str)
+                        .ok()
+                        .flatten()
+                        .map(|r| r.state);
+                    let open_turn = open_turn_id(&conn, &wid_str);
+                    native_status_event(prior.as_ref(), status, open_turn)
+                };
+                if let Some(ev) = event {
+                    let w = worker.clone();
+                    let applied = self
+                        .store
+                        .write_async(move |conn| {
+                            crate::orchestrator::events::apply_event(
+                                conn,
+                                &w,
+                                &ev,
+                                chrono::Utc::now(),
+                            )
+                        })
+                        .await;
+                    match applied {
+                        Ok(_) => report.events_applied += 1,
+                        Err(e) => {
+                            tracing::warn!(worker = %worker, error = %e, "native status event apply failed")
+                        }
+                    }
+                }
+                continue;
             }
 
             let Some(backend) = self.backends.iter().find(|b| b.name() == backend_name)
@@ -157,10 +234,16 @@ impl ScanLoop {
             interval.tick().await;
             crate::runtime_jobs::registry::tick(crate::runtime_jobs::registry::ids::SCAN);
             match self.scan_once().await {
-                Ok(r) if !r.scanned.is_empty() || !r.capture_failures.is_empty() => {
+                Ok(r) if !r.scanned.is_empty()
+                        || !r.capture_failures.is_empty()
+                        || !r.demoted_native.is_empty()
+                        || !r.native_status_failures.is_empty() =>
+                {
                     tracing::debug!(
                         scanned = r.scanned.len(),
                         demoted = r.demoted_structured.len(),
+                        demoted_native = r.demoted_native.len(),
+                        native_failures = r.native_status_failures.len(),
                         events = r.events_applied,
                         failures = r.capture_failures.len(),
                         "terminal scan pass"
@@ -170,6 +253,70 @@ impl ScanLoop {
                 Err(e) => tracing::warn!(error = %e, "terminal scan pass failed"),
             }
         }
+    }
+}
+
+/// The worker's open turn, if any — the id a native `idle`/`done` report
+/// must close to keep the turn ledger truthful. `None` means the native
+/// report saw the agent finish with no TurnStarted on record (e.g. the
+/// working phase happened while the server was down); the caller
+/// synthesizes one and `apply_event` names the miss in the log.
+fn open_turn_id(conn: &Connection, wid: &str) -> Option<TurnId> {
+    conn.query_row(
+        "SELECT id FROM _amux_turns WHERE worker_id = ?1 AND ended_at IS NULL
+         ORDER BY started_at DESC LIMIT 1",
+        params![wid],
+        |r| r.get::<_, String>(0),
+    )
+    .optional()
+    .ok()
+    .flatten()
+    .and_then(|t| TurnId::parse(&t).ok())
+}
+
+/// Map a backend-reported agent status (#84: herdr `working|blocked|idle|
+/// done`) onto the WorkerEvent that moves the store toward it, or `None`
+/// when it is already there. Pure so the mapping table is testable
+/// without a DB.
+///
+/// Equilibrium returns `None` on purpose: `write_state` writes
+/// unconditionally, so re-applying every tick would push a StatusChanged
+/// event per tick and bump the revision for no change (Invariant 37).
+/// `done ≡ idle`: herdr 0.8.0 surfaces `done` and amux has no state for
+/// "the agent process finished but the pane lives" — idle is the honest
+/// reading either way (#84 evidence).
+fn native_status_event(
+    prior: Option<&WorkerState>,
+    status: &str,
+    open_turn: Option<TurnId>,
+) -> Option<WorkerEvent> {
+    match status {
+        "working" => match prior {
+            Some(WorkerState::Active { .. }) => None,
+            _ => Some(WorkerEvent::TurnStarted {
+                turn_id: TurnId::from_ulid(ulid::Ulid::new()),
+            }),
+        },
+        "blocked" => match prior {
+            // WorkerState::Waiting carries the reason as a flat String
+            // (the WaitReason shape belongs to the event, not the state).
+            Some(WorkerState::Waiting { reason }) if reason == "herdr_agent_blocked" => None,
+            _ => Some(WorkerEvent::Waiting(WaitReason {
+                reason: "herdr_agent_blocked".into(),
+                detail: None,
+            })),
+        },
+        "idle" | "done" => match prior {
+            Some(WorkerState::Idle { .. }) => None,
+            _ => Some(WorkerEvent::TurnCompleted(amux_core::protocol::TurnResult {
+                turn_id: open_turn.unwrap_or_else(|| TurnId::from_ulid(ulid::Ulid::new())),
+                outcome: "herdr agent idle".into(),
+            })),
+        },
+        // `parse_workspace_statuses` never routes anything else here; a
+        // future herdr status word falls through to the scrape rather than
+        // being guessed at.
+        _ => None,
     }
 }
 
@@ -187,6 +334,9 @@ mod tests {
     struct ScriptedBackend {
         name: &'static str,
         frame: String,
+        /// Native agent states the backend reports (backend_ref -> status).
+        /// Empty = the tmux default (no native voice).
+        native: BTreeMap<String, String>,
     }
 
     #[async_trait]
@@ -212,6 +362,9 @@ mod tests {
         async fn capture(&self, _p: &ProcessRef, _l: u32) -> crate::backend::Result<String> {
             Ok(self.frame.clone())
         }
+        async fn agent_states(&self) -> crate::backend::Result<BTreeMap<String, String>> {
+            Ok(self.native.clone())
+        }
     }
 
     fn store() -> SharedStore {
@@ -226,7 +379,16 @@ mod tests {
     }
 
     fn seed_terminal_worker(store: &SharedStore, w: &WorkerId) {
+        seed_worker(store, w, "tmux", "amux-x");
+    }
+
+    fn seed_herdr_worker(store: &SharedStore, w: &WorkerId, backend_ref: &str) {
+        seed_worker(store, w, "herdr", backend_ref);
+    }
+
+    fn seed_worker(store: &SharedStore, w: &WorkerId, backend: &str, backend_ref: &str) {
         let (id, sid) = (w.to_string(), format!("ses_{w}"));
+        let (backend, backend_ref) = (backend.to_string(), backend_ref.to_string());
         store
             .write(move |conn| {
                 conn.execute(
@@ -236,12 +398,20 @@ mod tests {
                 )?;
                 conn.execute(
                     "INSERT INTO _amux_sessions (id, worker_id, backend, backend_ref, started_at)
-                     VALUES (?1, ?2, 'tmux', 'amux-x', 'now')",
-                    params![sid, id],
+                     VALUES (?1, ?2, ?3, ?4, 'now')",
+                    params![sid, id, backend, backend_ref],
                 )?;
                 Ok(WriteOutcome { applied: true, events: vec![] })
             })
             .unwrap();
+    }
+
+    fn worker_state(store: &SharedStore, w: &WorkerId) -> WorkerState {
+        let conn = store.read().unwrap();
+        crate::db::queries::get_worker(&conn, w.as_str())
+            .unwrap()
+            .expect("worker row")
+            .state
     }
 
     // A frame the Claude adapter flags: the weekly limit banner (fixture
@@ -257,7 +427,11 @@ mod tests {
         protocol.register(w.clone(), AgentState::Idle); // structured = live
         let scan = ScanLoop::new(
             store,
-            vec![Arc::new(ScriptedBackend { name: "tmux", frame: LIMIT_FRAME.into() })],
+            vec![Arc::new(ScriptedBackend {
+                name: "tmux",
+                frame: LIMIT_FRAME.into(),
+                native: BTreeMap::new(),
+            })],
             Some(protocol),
         );
         let r = scan.scan_once().await.unwrap();
@@ -273,7 +447,11 @@ mod tests {
         // No protocol session: the scraper is this worker's only voice.
         let scan = ScanLoop::new(
             store.clone(),
-            vec![Arc::new(ScriptedBackend { name: "tmux", frame: LIMIT_FRAME.into() })],
+            vec![Arc::new(ScriptedBackend {
+                name: "tmux",
+                frame: LIMIT_FRAME.into(),
+                native: BTreeMap::new(),
+            })],
             Some(Arc::new(MockProtocol::new())),
         );
         let r1 = scan.scan_once().await.unwrap();
@@ -312,5 +490,221 @@ mod tests {
         let r = scan.scan_once().await.unwrap();
         assert_eq!(r.capture_failures.len(), 1);
         assert!(r.capture_failures[0].contains("pane gone"));
+    }
+
+    // ---- native backend status (#84) ---------------------------------------
+
+    fn native(ref_: &str, status: &str) -> BTreeMap<String, String> {
+        BTreeMap::from([(ref_.to_string(), status.to_string())])
+    }
+
+    #[tokio::test]
+    async fn native_working_starts_turn_and_demotes_capture() {
+        let store = store();
+        let w = wid(10);
+        seed_herdr_worker(&store, &w, "amux-herdr-1");
+        let scan = ScanLoop::new(
+            store.clone(),
+            vec![Arc::new(ScriptedBackend {
+                name: "herdr",
+                frame: LIMIT_FRAME.into(),
+                native: native("amux-herdr-1", "working"),
+            })],
+            Some(Arc::new(MockProtocol::new())),
+        );
+        let r = scan.scan_once().await.unwrap();
+        assert_eq!(r.demoted_native, vec![w.to_string()]);
+        assert!(r.scanned.is_empty(), "native answer must demote the scrape");
+        assert_eq!(r.events_applied, 1, "TurnStarted: {r:?}");
+        assert!(matches!(worker_state(&store, &w), WorkerState::Active { .. }));
+    }
+
+    #[tokio::test]
+    async fn native_blocked_marks_waiting() {
+        let store = store();
+        let w = wid(11);
+        seed_herdr_worker(&store, &w, "amux-herdr-1");
+        let scan = ScanLoop::new(
+            store.clone(),
+            vec![Arc::new(ScriptedBackend {
+                name: "herdr",
+                frame: LIMIT_FRAME.into(),
+                native: native("amux-herdr-1", "blocked"),
+            })],
+            Some(Arc::new(MockProtocol::new())),
+        );
+        let r = scan.scan_once().await.unwrap();
+        assert_eq!(r.demoted_native.len(), 1);
+        assert!(matches!(
+            worker_state(&store, &w),
+            WorkerState::Waiting { ref reason } if reason == "herdr_agent_blocked"
+        ));
+    }
+
+    #[tokio::test]
+    async fn native_idle_completes_turn_and_equilibrium_applies_nothing() {
+        let store = store();
+        let w = wid(12);
+        seed_herdr_worker(&store, &w, "amux-herdr-1");
+        let scan = ScanLoop::new(
+            store.clone(),
+            vec![Arc::new(ScriptedBackend {
+                name: "herdr",
+                frame: LIMIT_FRAME.into(),
+                native: native("amux-herdr-1", "working"),
+            })],
+            Some(Arc::new(MockProtocol::new())),
+        );
+        let r1 = scan.scan_once().await.unwrap();
+        assert_eq!(r1.events_applied, 1, "working -> TurnStarted");
+        // Same working report again: equilibrium, no event, no revision churn.
+        let r2 = scan.scan_once().await.unwrap();
+        assert_eq!(r2.events_applied, 0, "equilibrium must apply nothing: {r2:?}");
+        // The backend now reports idle (a fresh backend answers the same
+        // lane — the store, not the loop, carries the prior state).
+        let scan = ScanLoop::new(
+            store.clone(),
+            vec![Arc::new(ScriptedBackend {
+                name: "herdr",
+                frame: LIMIT_FRAME.into(),
+                native: native("amux-herdr-1", "idle"),
+            })],
+            Some(Arc::new(MockProtocol::new())),
+        );
+        let r3 = scan.scan_once().await.unwrap();
+        assert_eq!(r3.events_applied, 1, "idle -> TurnCompleted");
+        assert!(matches!(worker_state(&store, &w), WorkerState::Idle { .. }));
+        // Idle again: nothing.
+        let r4 = scan.scan_once().await.unwrap();
+        assert_eq!(r4.events_applied, 0, "idle equilibrium must apply nothing");
+    }
+
+    #[tokio::test]
+    async fn native_unknown_or_absent_falls_back_to_scrape() {
+        let store = store();
+        let w = wid(13);
+        // `parse_workspace_statuses` omits `unknown` refs, so the map simply
+        // does not carry this lane — the scrape stays its only voice.
+        seed_herdr_worker(&store, &w, "amux-herdr-other");
+        let scan = ScanLoop::new(
+            store,
+            vec![Arc::new(ScriptedBackend {
+                name: "herdr",
+                frame: LIMIT_FRAME.into(),
+                native: native("amux-herdr-other", "idle"),
+            })],
+            Some(Arc::new(MockProtocol::new())),
+        );
+        let r = scan.scan_once().await.unwrap();
+        assert_eq!(r.scanned, vec![w.to_string()]);
+        assert!(r.demoted_native.is_empty());
+    }
+
+    #[tokio::test]
+    async fn native_read_failure_falls_back_and_is_named() {
+        struct FlakyNativeBackend;
+        #[async_trait]
+        impl SessionBackend for FlakyNativeBackend {
+            fn name(&self) -> &'static str { "herdr" }
+            async fn spawn(&self, _s: &SessionSpec) -> crate::backend::Result<ProcessRef> {
+                Err(BackendError::SpawnFailed("x".into()))
+            }
+            async fn terminate(&self, _p: &ProcessRef) -> crate::backend::Result<()> { Ok(()) }
+            async fn status(&self, _p: &ProcessRef) -> crate::backend::Result<BackendStatus> {
+                Ok(BackendStatus::Running)
+            }
+            async fn attach_info(&self, _p: &ProcessRef) -> crate::backend::Result<AttachInfo> {
+                Ok(AttachInfo { command: "true".into() })
+            }
+            async fn reconcile(&self) -> crate::backend::Result<Vec<BackendSession>> { Ok(vec![]) }
+            async fn capture(&self, _p: &ProcessRef, _l: u32) -> crate::backend::Result<String> {
+                Ok(LIMIT_FRAME.to_string())
+            }
+            async fn agent_states(&self) -> crate::backend::Result<BTreeMap<String, String>> {
+                Err(BackendError::CommandFailed(
+                    "server_not_running: herdr is down".into(),
+                ))
+            }
+        }
+        let store = store();
+        let w = wid(14);
+        seed_herdr_worker(&store, &w, "amux-herdr-1");
+        let scan = ScanLoop::new(store, vec![Arc::new(FlakyNativeBackend)], None);
+        let r = scan.scan_once().await.unwrap();
+        assert_eq!(r.scanned, vec![w.to_string()], "scrape is the fallback");
+        assert_eq!(r.native_status_failures.len(), 1);
+        assert!(r.native_status_failures[0].contains("server_not_running"));
+    }
+
+    #[tokio::test]
+    async fn protocol_voice_outranks_native_report() {
+        let store = store();
+        let w = wid(15);
+        seed_herdr_worker(&store, &w, "amux-herdr-1");
+        let protocol = Arc::new(MockProtocol::new());
+        protocol.register(w.clone(), AgentState::Idle);
+        let scan = ScanLoop::new(
+            store.clone(),
+            vec![Arc::new(ScriptedBackend {
+                name: "herdr",
+                frame: LIMIT_FRAME.into(),
+                native: native("amux-herdr-1", "working"),
+            })],
+            Some(protocol),
+        );
+        let r = scan.scan_once().await.unwrap();
+        assert_eq!(r.demoted_structured, vec![w.to_string()]);
+        assert!(r.demoted_native.is_empty());
+        assert_eq!(r.events_applied, 0, "the worker speaks for itself");
+        assert_eq!(worker_state(&store, &w), WorkerState::Stopped);
+    }
+
+    #[test]
+    fn native_status_event_mapping_table() {
+        let turn = || Some(TurnId::from_ulid(ulid::Ulid::from_parts(1, 1)));
+        let active = WorkerState::Active { turn: None };
+        let idle = WorkerState::Idle { since: chrono::Utc::now() };
+        let waiting = WorkerState::Waiting { reason: "herdr_agent_blocked".into() };
+
+        // Unknown status words never guess.
+        assert!(native_status_event(Some(&idle), "unknown", turn()).is_none());
+        assert!(native_status_event(Some(&idle), "somewhere-else", turn()).is_none());
+
+        // working: only from not-Active.
+        assert!(native_status_event(Some(&active), "working", turn()).is_none());
+        assert!(matches!(
+            native_status_event(Some(&idle), "working", turn()),
+            Some(WorkerEvent::TurnStarted { .. })
+        ));
+        assert!(matches!(
+            native_status_event(None, "working", turn()),
+            Some(WorkerEvent::TurnStarted { .. })
+        ));
+
+        // blocked: only from not-that-Waiting.
+        assert!(native_status_event(Some(&waiting), "blocked", turn()).is_none());
+        assert!(matches!(
+            native_status_event(Some(&active), "blocked", turn()),
+            Some(WorkerEvent::Waiting(_))
+        ));
+
+        // idle/done close an open turn; equilibrium applies nothing; the
+        // done≡idle mapping is the same branch.
+        assert!(native_status_event(Some(&idle), "idle", turn()).is_none());
+        assert!(native_status_event(Some(&idle), "done", turn()).is_none());
+        for st in ["idle", "done"] {
+            match native_status_event(Some(&active), st, turn()) {
+                Some(WorkerEvent::TurnCompleted(res)) => {
+                    assert_eq!(res.turn_id, turn().unwrap());
+                }
+                other => panic!("{st} from Active must complete the open turn, got {other:?}"),
+            }
+        }
+        // No open turn on record: a synthesized id still completes —
+        // apply_event names the missing TurnStarted in the log.
+        assert!(matches!(
+            native_status_event(Some(&active), "idle", None),
+            Some(WorkerEvent::TurnCompleted(_))
+        ));
     }
 }


### PR DESCRIPTION
Closes #84. Rust refile of #87 (closed unmerged in the Rust migration — this carries the same design across, translated to the crates/ architecture as invited in the close comment).

## What it does

Feeds herdr's native agent lifecycle state into the scan loop, in the shape the Rust status pipeline already speaks (`WorkerEvent` → `apply_event`), so herdr-hosted workers get status from the one party that knows it instead of a pane scrape — D1's exit condition applied to a whole backend.

**`SessionBackend::agent_states()` (trait default, backend/herdr.rs)** — one batched `workspace list` per scan pass returns `(backend_ref, agent_status)` for every `amux-` workspace herdr has recognized as a known agent. Keyed by workspace **label** (the backend ref), not agent name: the Rust herdr backend hosts one single-pane workspace per worker (RR-0031), and the workspace row already carries `agent_status` — no `agent list` name-matching, no per-lane `agent get` probe. Entries reading `unknown` (arbitrary commands — GAP-ATTACH) are omitted, so for them the scrape stays the only voice. A failed read is `Err`, never an empty map — "cannot answer" must not read as "stopped fleet" (the same `{ok, by_name}` lesson the Copilot review on #87 surfaced, kept by construction here).

**ScanLoop wiring (orchestrator/scan.rs)** — one batched read per backend per pass; for a lane whose backend reports `working|blocked|idle|done`:

- capture is **demoted** (skip + recorded in `ScanReport::demoted_native` — the existing "a skip that leaves no trace" discipline, new field alongside `demoted_structured`),
- the status maps to the `WorkerEvent` it already is (`working`→`TurnStarted`, `blocked`→`Waiting(herdr_agent_blocked)`, `idle`/`done`→`TurnCompleted` closing the open turn), applied through the existing `apply_event` — turn ledger, `WorkerState`, StatusChanged events, board completion and orchestrator wakes light up with zero per-consumer branches,
- equilibrium applies nothing (`write_state` writes unconditionally, so re-applying every tick would push a StatusChanged per tick and bump the revision for no change — Invariant 37).

**Precedence** — the worker's own structured protocol voice (`demoted_structured`, unchanged) still outranks the backend's native report; the native report outranks the scrape. This differs from #87's `herdr > self-report > scrape`, deliberately: in the Rust status pipeline the self-report is the worker speaking for itself through the AgentProtocol seam, which is exactly the thing D1 says outranks any observation of the worker.

Read failures land in `ScanReport::native_status_failures` and the lanes fall back to the scrape for that pass — named, not silent.

## Verified against herdr 0.7.5 (live, 2026-08-15)

- `workspace create --label amux-wrk-X` + `pane run "claude"` → herdr auto-recognizes the agent; the **workspace list row** carries `agent_status` (a `sleep 300` lane reads `unknown`). One subprocess answers the whole fleet.
- **Full cycle observed end-to-end on a live lane**: idle → (`send-text` + `enter`) → **working within 4s** → (turn end) → **idle**. The exact transition set this PR wires into `WorkerEvent`s.
- The mapping handles 0.8.0's `done` (`done ≡ idle`) — 0.7.5 never surfaces it, 0.8.0 does (#84 evidence); same branch either way.

## Verification status (CI-honesty)

- `cargo check --workspace --all-targets` and `cargo clippy --workspace --all-targets -- -D warnings` green locally (pinned toolchain 1.97.1).
- The mapping table and parser logic verified standalone (17 assertions: equilibrium no-ops, unknown-word rejection, `done≡idle`, open-turn closure, synthesized-turn fallback, unknown/foreign workspace omission).
- `cargo test -p amux-server --lib -j 4` passed locally after increasing the WSL allocation to 15 GiB RAM + 4 GiB swap: **944 passed, 0 failed, 7 ignored** (35.67s). The initial 4 GiB WSL allocation was insufficient for rustc's codegen peak; the test suite itself is now green locally.

## What it deliberately does not do

- No tmux-side changes: the default `agent_states()` is an empty map, tmux lanes never enter the native branch.
- No auto-response to a blocked lane — surfacing `waiting` summons a human; answering the prompt stays theirs (D2's policy, same boundary as #84/#87).
- The legacy fleet path (`sessions_legacy.rs` `derive_status`) is untouched: the Rust origin refuses to START herdr-backed `.env` lanes (named gap in `session_verbs.rs`), so a herdr lane can only exist through the modern `_amux_sessions` path this wires. Injecting there now would be dead code; when herdr lane-start lands on the fleet path, `FleetSignals` gains the same one-call read.
- No `waiting_since` derivation: `WorkerState::Waiting` carries no timestamp in the modern pipeline; that's a core-type question, not a herdr one.

## Tests

`orchestrator/scan.rs` (ScriptedBackend extended to answer `agent_states`): working→TurnStarted + capture demoted; blocked→Waiting; idle closes the open turn; equilibrium (working×2, idle×2) applies nothing; `unknown`/absent ref falls back to scrape; native read failure named + scrape fallback; protocol voice outranks native; plus a pure mapping-table test for `native_status_event` (including `done`, unknown words, no-open-turn completion). `backend/herdr.rs`: `parse_workspace_statuses` against the live-probed 0.7.5 envelope (idle/unknown/blocked/done mixed, foreign labels dropped).

Same CI-honesty note as #80/#87: green CI proves the mapping and the wiring against scripted backends, not the herdr integration — that's what the live 0.7.5 probe above is for, and what D6's README caveat already says.
