### PR TITLE
feat(create): Ollama provider + local model picker in the New worker dialog (AMUX-61)

### DIFF
--- a/crates/amux-dashboard/static/app.js
+++ b/crates/amux-dashboard/static/app.js
@@ -7619,7 +7619,7 @@ async function saveGlobalMemory() {
   }
 }
 
-const APP_VER = '0.9.649';   // bump together with the sw.js CACHE version
+const APP_VER = '0.9.650';   // bump together with the sw.js CACHE version
 
 // ── No silent failures (Ethan, 2026-08-09: "make sure every action has some
 // kind of response in the ui — i just deleted a worker and nothing happened").
@@ -15768,11 +15768,60 @@ let _createBranchEdited = false;  // track if user manually changed branch name
 let _createDirIsGit = false;     // track if current dir is a git repo
 
 let _createProvider = 'claude';
+
+// Populate the New-worker local-model picker from the machine's own Ollama.
+//
+// SAY WHICH EMPTY IT IS. "No models" and "cannot reach Ollama" need different
+// actions from the user — one is `ollama pull`, the other is `ollama serve` —
+// and collapsing them into one blank dropdown is the unactionable-message bug
+// this dashboard keeps producing (AMUX-43). The hint line carries the remedy.
+async function _loadLocalModels() {
+  const sel = document.getElementById('create-localmodel');
+  const hint = document.getElementById('create-localmodel-hint');
+  if (!sel) return;
+  sel.innerHTML = '<option value="">Loading local models…</option>';
+  if (hint) hint.textContent = '';
+  let d;
+  try {
+    const r = await fetch(API + '/api/ollama/models', { headers: _authHeaders() });
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+    d = await r.json();
+  } catch (e) {
+    sel.innerHTML = '<option value="">Could not reach Ollama</option>';
+    if (hint) hint.textContent = 'Is Ollama running? Start it with: ollama serve';
+    return;
+  }
+  const models = d.models || [];
+  sel.innerHTML = '';
+  if (!models.length) {
+    const o = document.createElement('option');
+    o.value = ''; o.textContent = 'No local models installed';
+    sel.appendChild(o);
+    if (hint) hint.textContent = 'Ollama is running but has no models. Pull one, e.g: ollama pull qwen3-coder:30b';
+    return;
+  }
+  models.forEach(name => {
+    const o = document.createElement('option');
+    o.value = name; o.textContent = name;
+    sel.appendChild(o);
+  });
+  if (hint) hint.textContent = models.length + ' local model' + (models.length === 1 ? '' : 's') + ' available';
+}
+
 function _selectProvider(p) {
   _createProvider = p;
   document.getElementById('create-provider-claude').classList.toggle('selected', p === 'claude');
   document.getElementById('create-provider-codex').classList.toggle('selected', p === 'codex');
   document.getElementById('create-provider-gemini').classList.toggle('selected', p === 'gemini');
+  const ollamaBtn = document.getElementById('create-provider-ollama');
+  if (ollamaBtn) ollamaBtn.classList.toggle('selected', p === 'ollama');
+  // Local model picker: Ollama only. Loaded on selection rather than on dialog
+  // open so a machine with no Ollama pays nothing for a provider it will not use.
+  const lmField = document.getElementById('create-localmodel-field');
+  if (lmField) {
+    lmField.style.display = p === 'ollama' ? '' : 'none';
+    if (p === 'ollama') _loadLocalModels();
+  }
   // Hide branch/template/session-name options for non-Claude providers since they use different mechanics
   const isClaude = p === 'claude';
   document.getElementById('create-branch-enabled').closest('.field-group').style.display = isClaude ? '' : 'none';
@@ -15781,6 +15830,10 @@ function _selectProvider(p) {
 }
 function openCreate() {
   _createProvider = 'claude';
+  const _ob = document.getElementById('create-provider-ollama');
+  if (_ob) _ob.classList.remove('selected');
+  const _lm = document.getElementById('create-localmodel-field');
+  if (_lm) _lm.style.display = 'none';
   document.getElementById('create-provider-claude').classList.add('selected');
   document.getElementById('create-provider-codex').classList.remove('selected');
   document.getElementById('create-provider-gemini').classList.remove('selected');
@@ -16034,6 +16087,11 @@ async function submitCreate() {
   // open to fix — apiCall would pop a generic "Error: 409" with the form gone.
   const createBody = { name, dir, creator: _getDeviceName() };
   if (_createProvider !== 'claude') createBody.provider = _createProvider;
+  if (_createProvider === 'ollama') {
+    const lm = document.getElementById('create-localmodel');
+    const chosen = lm && lm.value ? lm.value : '';
+    if (chosen) createBody.model = chosen;
+  }
   if (worktreeEnabled) createBody.worktree = true;
   let r;
   try {

--- a/crates/amux-dashboard/static/index.html
+++ b/crates/amux-dashboard/static/index.html
@@ -1811,7 +1811,16 @@ setTimeout(function(){var f=document.getElementById('js-fallback');if(f&&f.style
         <button type="button" id="create-provider-claude" class="btn provider-btn selected" onclick="_selectProvider('claude')">Claude Code</button>
         <button type="button" id="create-provider-codex" class="btn provider-btn" onclick="_selectProvider('codex')">Codex</button>
         <button type="button" id="create-provider-gemini" class="btn provider-btn" onclick="_selectProvider('gemini')">Gemini</button>
+        <button type="button" id="create-provider-ollama" class="btn provider-btn" onclick="_selectProvider('ollama')">Ollama</button>
       </div>
+    </div>
+    <!-- Local model: only for Ollama, and populated from the machine's own
+         `ollama list` via /api/ollama/models. Hidden for every other provider
+         because they pin their model through CC_FLAGS elsewhere. -->
+    <div class="field-group" id="create-localmodel-field" style="display:none;">
+      <label class="field-label">Local model</label>
+      <select id="create-localmodel"></select>
+      <div id="create-localmodel-hint" style="font-size:0.72rem;color:var(--dim);margin-top:4px;"></div>
     </div>
     <div class="field-group">
       <label class="field-label">Working directory</label>

--- a/crates/amux-dashboard/static/sw.js
+++ b/crates/amux-dashboard/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'amux-v0.9.649';
+const CACHE = 'amux-v0.9.650';
 const SHELL_URLS = ['/', '/manifest.json', '/icon.svg', '/icon.png', '/icon-192.png', '/icon-512.png'];
 
 // Install: pre-cache entire app shell


### PR DESCRIPTION
The New worker dialog offers Claude Code / Codex / Gemini. **Ollama was missing** — even though everything behind it already existed and was already used elsewhere:

- `/api/ollama/models` is live (returns 200)
- `app.js` already knows provider `ollama` — `_providerLabel`, `_normProvider`, its default model, its skip-permissions flag — and the **edit** dialog already lists local models from that endpoint
- `POST /api/sessions` already accepts `model` and turns it into `--model <m>` in `CC_FLAGS` (`sessions_legacy.rs:1408`)

So a worker could be switched *to* Ollama after creation but never created as one. Wired at both ends, unreachable from the surface people start at. **Client-only; no server change needed.**

## Two empty states, kept distinguishable

"No models installed" and "cannot reach Ollama" need different actions — `ollama pull` vs `ollama serve` — and both render as an empty dropdown if you let them. The hint line under the picker carries the remedy for each. Same lesson as AMUX-43: a refusal that names its cause but not its fix still leaves the user asking someone.

Models load on provider *selection*, not on dialog open, so a machine without Ollama pays nothing for a provider it won't use. `openCreate` resets the button and hides the field, or a reopened dialog keeps the previous provider's state.

## Verified

In a browser, against the **shipped** markup and **shipped** functions (lifted verbatim, not paraphrased):

| state | options | hint |
|---|---|---|
| A. models present | `qwen3-coder:30b`, `qwen2.5vl:7b` | "2 local models available" |
| B. running, 0 models | "No local models installed" | `ollama pull qwen3-coder:30b` |
| C. unreachable | "Could not reach Ollama" | `ollama serve` |
| D. switch to Claude | field hidden, button deselected | — |

**B is the reporting machine's actual state**: Ollama answers on `:11434` with zero models pulled, so the picker correctly reads "No local models installed" until one is.

`APP_VER` / `sw.js` `CACHE` bumped together per CLAUDE.md.

## Note on origin

This was reported as "why does Ethan's amux have this and mine doesn't". The button is **not on main** (`git show origin/main:...index.html | grep -c create-provider-ollama` → 0), so it appears to be unreleased locally on his machine. If a fuller version is already in flight, close this in favour of it — the useful part here may just be the two-empty-states distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)