### PR TITLE
fix(ci): the frustrations gate could not fail — two discarded verdicts

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -56,11 +56,21 @@ jobs:
       # first run: an entry using `FIX-NOTE:` where the contract says `FIX:`, which
       # `grep '^FIX:'` silently skipped.
       #
-      # Exit codes are load-bearing: 0 clean, 1 real problems, 2 board unreachable.
-      # 2 is EXPECTED in CI (no localhost board) and must not fail the build — the
-      # structural half still ran and is what we are gating on. Only 1 fails, so a
-      # green run here means "every entry has its required fields", never "the
-      # board agreed", which CI cannot check and should not claim.
+      # Exit codes are load-bearing: 0 clean, 1 real problems, 2 board unreachable
+      # AND nothing structural wrong. 2 is EXPECTED in CI (no localhost board) and
+      # must not fail the build. Only 1 fails, so a green run here means "every entry
+      # has its required fields", never "the board agreed", which CI cannot check and
+      # should not claim.
+      #
+      # AEAB-19: the sentence above USED TO BE TRUE ONLY IN INTENT. The script's
+      # unreachable branch returned a bare 2, discarding whether it had found
+      # problems — and it always takes that branch in CI — so this step could not
+      # fail, and the older wording of this comment ("the structural half still ran
+      # and is what we are gating on") asserted a gate that did not exist. It ran; it
+      # was not gated on. A frustrations entry with no `## ` heading reached main
+      # green through this step on 2026-08-17. The script now returns 1 for a
+      # structural problem regardless of board reachability, which is what makes the
+      # claim above real; scripts/test-frustrations-audit.sh pins it.
       # The `|| rc=$?` is LOAD-BEARING, not style. GitHub runs this with
       # `shell: bash -e {0}`, and `set -uo pipefail` does NOT clear `-e` — so
       # the previous form (`python3 …` on its own line, then `rc=$?`) aborted
@@ -79,3 +89,18 @@ jobs:
           echo "frustrations_audit exit=$rc (0 clean, 1 real problems, 2 board unreachable)"
           if [ "$rc" = "1" ]; then exit 1; fi
           exit 0
+
+      # AEAB-19. This step exists because the step above could not fail, and a gate
+      # nobody can trip is worse than none — it is trusted. Same self-test logic as
+      # the secret scan at the top of this job: prove the instrument catches a planted
+      # defect before believing a clean run. Every case runs with the board pointed at
+      # a closed port, which is this job's real condition and the condition under
+      # which the gate was broken; a version run against a live board would pass
+      # against the old code and prove nothing.
+      #
+      # Runs under its own shebang and `set -uo pipefail`, so the `bash -e {0}`
+      # wrapper does not leak in and no `|| rc=$?` dance is needed.
+      - name: frustrations audit can actually fail (AEAB-19)
+        run: |
+          set -uo pipefail
+          ./scripts/test-frustrations-audit.sh

--- a/frustrations.md
+++ b/frustrations.md
@@ -2668,9 +2668,17 @@ SESSION: amux-homepage
 AREA: codex-integration
 STATUS: open
 CARD: AH-81
+SEVERITY: slows
 TITLE: `tmux send-keys ... Enter` does NOT submit a codex TUI prompt — amux sessions cannot send tasks to codex workers via raw tmux
-WHAT HAPPENED: Tested qwen worker (codex --oss --local-provider ollama). Used `tmux send-keys -t "amux-qwen" "task text" Enter` to send prompts. Enter appended a NEWLINE to codex's multi-line input buffer rather than submitting — the prompt accumulated silently, never reached the model. Discovered only after ~45 min of apparent "no response" — the model was idle, not processing. Same issue hit xhigh reasoning effort (qwen does not support extended thinking), which added ~30 min of wasted wait time. Eventually discovered that `POST /api/sessions/<name>/send` correctly submits (amux uses the pane's send protocol that delivers Ctrl+Enter or similar). After switching to the API send, the agent immediately started Working and produced correct output.
+SYMPTOM: Tested qwen worker (codex --oss --local-provider ollama). Used `tmux send-keys -t "amux-qwen" "task text" Enter` to send prompts. Enter appended a NEWLINE to codex's multi-line input buffer rather than submitting — the prompt accumulated silently, never reached the model. Discovered only after ~45 min of apparent "no response" — the model was idle, not processing. Same issue hit xhigh reasoning effort (qwen does not support extended thinking), which added ~30 min of wasted wait time. Eventually discovered that `POST /api/sessions/<name>/send` correctly submits (amux uses the pane's send protocol that delivers Ctrl+Enter or similar). After switching to the API send, the agent immediately started Working and produced correct output.
 COST: ~75 min (45 min for unresponsive session + 30 min debugging xhigh), wrong conclusion that the worker was broken (it was not — the submission method was wrong).
+NORMALISED 2026-08-17 by amux-errors-and-bugs, not rewritten — see AEAB-19. This entry
+  used `WHAT HAPPENED:` where the contract says `SYMPTOM:`, so `grep '^SYMPTOM:'` could
+  not find it, and carried no `SEVERITY:`, so `grep '^SEVERITY: ...'` could not either.
+  Renaming the label changed no words. The one INFERRED value is `SEVERITY: slows`,
+  derived from this entry's own COST line ("~75 min ... wrong conclusion that the worker
+  was broken"); amux-homepage should correct it if that is wrong. The non-contract
+  `TITLE:` line duplicating the heading was left alone as harmless.
 FIX: `POST /api/sessions/<name>/send` is the correct way to send tasks to codex/ollama workers. `tmux send-keys ... Enter` is wrong for codex TUI — it inserts a newline, not a submit. No amux docs or session-card says this; it is an easy mistake for any session testing a codex worker. Also: codex's global config `model_reasoning_effort = "xhigh"` is incompatible with local qwen models (qwen does not support extended thinking API); workers using `--oss --local-provider ollama` need `-c model_reasoning_effort=low` to be responsive.
 
 ---
@@ -2913,11 +2921,24 @@ COST: a destructive false positive shipped into standing advice for every lane, 
 FIX: `git log --all --find-object=<blob>`; empty means never committed anywhere. `--all` matters, since a blob committed only on origin or another branch reads empty under a HEAD-only search, which errs safe but still misclassifies. amux has a fix agent in flight across commit_nudge.rs, the shell guards and session-freshness.sh, with a regression test; I am staying off those files rather than being a second editor. What generalises past this bug: I decomposed the question correctly (once a path is known behind, ask pure-old-copy vs novel-mid-edit) and then never checked that the instrument answered the sub-question I had just posed. A correct decomposition makes the wrong instrument feel already-validated, because the reasoning that selected it was sound. Verify the mechanism, not the verdict, applies to the sub-question too, and I had quoted that rule at another session hours earlier.
 
 ---
+
+## push-guard reports "unknown (api unreachable)" instead of reading the Amux-Session trailer from the commit
 DATE: 2026-08-17
 AREA: attribution
 STATUS: open
+SEVERITY: annoys
+SESSION: amux-homepage
 COST: 5 minutes of false diagnosis and a wrong message sent to amux
-CARD: (file one)
-DESCRIPTION: push-guard emits "currently: unknown (api unreachable)" when it fails to resolve the owning session's identity via the API. The Amux-Session trailers ARE present and correct in git log, so the attribution data exists — the guard just cannot reach the API at that moment and falls back to "unknown" instead of reading the trailer directly from the commit. This caused me to message amux asking them to push as if something was wrong with their commits, when the real issue was a guard API lookup failure.
+CARD: AEAB-21
+SYMPTOM: push-guard emits "currently: unknown (api unreachable)" when it fails to resolve the owning session's identity via the API. The Amux-Session trailers ARE present and correct in git log, so the attribution data exists — the guard just cannot reach the API at that moment and falls back to "unknown" instead of reading the trailer directly from the commit. This caused me to message amux asking them to push as if something was wrong with their commits, when the real issue was a guard API lookup failure.
 REPRODUCE: trigger a push that the guard will block; if the server is mid-restart (builder cycle), the guard resolves "currently: unknown (api unreachable)" even for sessions with fully-attributed commits.
-FIX DIRECTION: the guard should fall back to the Amux-Session trailer in the commit itself when the API is unreachable, rather than reporting "unknown". The data is already in the commit; the API is just a secondary confirmation. Never let an API timeout degrade a git-native source.
+FIX: the guard should fall back to the Amux-Session trailer in the commit itself when the API is unreachable, rather than reporting "unknown". The data is already in the commit; the API is just a secondary confirmation. Never let an API timeout degrade a git-native source.
+NORMALISED 2026-08-17 by amux-errors-and-bugs, not rewritten — see AEAB-19. This entry
+  arrived in 18590ca8 with no `## ` heading, so the audit's parser folded it into the
+  entry above and the file's own greps could not see it. Changes were: added the heading
+  (worded from this entry's own first clause), `DESCRIPTION:` -> `SYMPTOM:`,
+  `FIX DIRECTION:` -> `FIX:`, `SESSION:` filled from the commit's own Amux-Session
+  trailer, and `CARD: (file one)` -> AEAB-21, which I filed on this entry's behalf
+  because it asked for one. Not a word of the account was altered. The one INFERRED
+  value is `SEVERITY: annoys`, derived from this entry's own COST line ("5 minutes of
+  false diagnosis"); amux-homepage should correct it if that is wrong.

--- a/scripts/frustrations_audit.py
+++ b/scripts/frustrations_audit.py
@@ -17,8 +17,15 @@ Why the field rots by construction, rather than by carelessness:
     covers several entries and "delete AC-300" is ambiguous
 From the file alone, a stale id and a colliding id are indistinguishable.
 
-Exit codes: 0 clean, 1 problems found, 2 could not reach the board (NOT a pass — an
-unreachable board means unchecked, and this says so rather than exiting 0).
+Exit codes: 0 clean, 1 problems found, 2 could not reach the board AND nothing
+structural was wrong (NOT a pass — an unreachable board means unchecked, and this says
+so rather than exiting 0).
+
+The "AND nothing structural was wrong" is the AEAB-19 fix, and it is the whole contract:
+structural problems are decidable without a board, so they exit 1 whether or not the
+board answered. Previously the unreachable branch returned a bare 2 and threw the
+structural verdict away — and since CI never has a board and treats 2 as a pass, the
+gate could not fail there at all.
 
     python3 scripts/frustrations_audit.py [--quiet]
 """
@@ -154,6 +161,21 @@ def main():
     # reported FIRST rather than buried under 122 lines of per-entry output.
     structure_ok = structure_check(raw, entries)
     problems, advisories = [], []
+    # AEAB-19, second instance in this same file. `structure_ok` was assigned here
+    # and NEVER READ — the drift check printed its finding and had no effect on the
+    # exit code. Its own docstring says it exists because an ad-hoc DATE-split
+    # shifted STATUS by one entry and put a live, thrice-regressed incident on a
+    # DELETION list, "seconds from receiving 'validated, deleting' text". That is
+    # the most expensive failure this file has, and the check guarding it was
+    # advisory by accident.
+    #
+    # It was firing on main at the time of this fix, and had been since 18590ca8
+    # landed a frustrations entry with NO `## ` heading — so the parser folded it
+    # into the preceding entry, which is exactly the count disagreement this check
+    # reports (DATE: 120 vs 119 entries). It reached main because the OTHER half of
+    # this bug meant `checks` could not fail. One defect hid the other.
+    #
+    # Structural drift is decidable without a board, so it fails in both branches.
 
     for e in entries:
         miss = [f for f in REQUIRED if not e.get(f)]
@@ -178,7 +200,27 @@ def main():
               % (len(entries), len(problems)))
         for p in problems:
             print("  PROBLEM  " + p)
-        return 2
+        # AEAB-19. This returned a bare 2, discarding whether `problems` is
+        # non-empty — and the board is ALWAYS unreachable in CI, which
+        # .github/workflows/checks.yml says in its own comment while treating 2 as
+        # a pass. So the structural half ran, printed its findings, and had its
+        # verdict thrown away on every push. `checks` is the only required status
+        # check on main, and this, its frustrations gate, could not fail. There
+        # was a live specimen the whole time (one entry missing SEVERITY and
+        # SYMPTOM) with the check green over it.
+        #
+        # Worse than a silent probe: a LOUD one whose output is correct and whose
+        # exit code contradicts it. The PROBLEM line was in the CI log every run,
+        # read by nobody, because the step was green — ethos rule 4's "a tag in a
+        # store the reader never opens", one layer out, where the check itself is
+        # what stops the reader opening it.
+        #
+        # The two halves are independent and now exit independently: a structural
+        # problem is decidable WITHOUT a board and so must fail; the CARD: half
+        # genuinely could not be checked and stays 2. Note the module docstring
+        # already said "2 ... (NOT a pass)" — the script and the workflow
+        # disagreed, and only the script knows whether `problems` is empty.
+        return 1 if (problems or not structure_ok) else 2
 
     for e in entries:
         c = e.get("CARD")
@@ -210,7 +252,7 @@ def main():
                 print("              %s x%d" % (k, len(v)))
         if not problems and not advisories:
             print("  clean — every CARD: resolves and plausibly matches its entry")
-    return 1 if problems else 0
+    return 1 if (problems or not structure_ok) else 0
 
 
 if __name__ == "__main__":

--- a/scripts/test-frustrations-audit.sh
+++ b/scripts/test-frustrations-audit.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# AEAB-19 — the frustrations.md gate must be able to FAIL, with no board reachable.
+#
+# It could not. Two independent defects in scripts/frustrations_audit.py, and each one
+# alone was enough to make `checks` — the only required status check on main — green
+# over a broken file:
+#
+#   1. the board-unreachable branch returned a bare `2`, discarding whether `problems`
+#      was non-empty. CI never has a board (checks.yml says so in its own comment) and
+#      treats 2 as a pass, so per-entry structural findings were printed and thrown away
+#      on every push.
+#   2. `structure_ok = structure_check(...)` was assigned and never read. The drift check
+#      whose docstring records it stopping a live incident from being queued for DELETION
+#      was advisory by accident.
+#
+# Both were live. Commit 18590ca8 landed an entry with no `## ` heading — the parser folds
+# such a block into the preceding entry — and main went green over it. One defect hid the
+# other, which is why this test asserts each failure mode separately rather than just
+# "the audit exits non-zero on a bad file".
+#
+# EVERY case runs with the board pointed at a closed port, because that is CI's condition
+# and the condition under which the gate was broken. A version of this test that ran
+# against a live board would pass against the OLD code and prove nothing.
+#
+# The audit resolves frustrations.md as `Path(__file__).parent.parent/frustrations.md`, so
+# each case builds a throwaway repo (scripts/ + frustrations.md) and copies the REAL
+# script into it — the shipped decision path, not a paraphrase.
+#
+# Exit 0 = all pass, 1 = a failure. Wired into .github/workflows/checks.yml.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+AUDIT="$(pwd)/scripts/frustrations_audit.py"
+REAL_FRUST="$(pwd)/frustrations.md"
+PASS=0; FAIL=0
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+
+# Board unreachable for every case: port 9 is reserved/discard.
+export AMUX_URL="https://127.0.0.1:9"
+export AMUX_API="https://127.0.0.1:9"
+
+# A conforming entry, used as the base that each defect case mutates. Kept in one place
+# so a contract change breaks this file loudly instead of leaving stale fixtures.
+good_entry() {
+  cat <<'EOF'
+## a well-formed entry
+AREA: cli
+SEVERITY: slows
+STATUS: open
+DATE: 2026-08-17
+SESSION: test
+CARD: none
+SYMPTOM: something observable happened
+COST: 1 minute
+FIX: do the thing
+EOF
+}
+
+# Build a throwaway repo whose frustrations.md is whatever arrives on stdin, run the
+# REAL audit inside it, echo the exit code.
+run_on() { # $1 = case dir name
+  local d="$TMP/$1"
+  mkdir -p "$d/scripts"
+  cp "$AUDIT" "$d/scripts/frustrations_audit.py"
+  cat > "$d/frustrations.md"
+  ( cd "$d" && python3 scripts/frustrations_audit.py >"$d/out.txt" 2>&1; echo $? )
+}
+
+check_rc() { # label expected actual casedir
+  if [ "$2" = "$3" ]; then PASS=$((PASS+1));
+  else
+    FAIL=$((FAIL+1)); echo "FAIL: $1 — expected exit $2, got $3"
+    [ -f "$TMP/$4/out.txt" ] && sed 's/^/      /' "$TMP/$4/out.txt" | head -6
+  fi
+}
+check_says() { # label needle casedir
+  if grep -qF "$2" "$TMP/$3/out.txt" 2>/dev/null; then PASS=$((PASS+1));
+  else FAIL=$((FAIL+1)); echo "FAIL: $1 — output did not mention '$2'"; fi
+}
+
+header() { printf '# frustrations\n\nblurb\n\n---\n\n'; }
+
+# ---------------------------------------------------------------------------
+# (a) THE CONTROL, and it comes first on purpose. A well-formed file must exit 2
+#     — board unchecked, nothing structurally wrong. If this ever fails, every
+#     "exits 1" assertion below is meaningless, because a script that exits 1 on
+#     everything would satisfy them all. This is also what proves the fix did not
+#     simply turn the gate into an unconditional failure.
+# ---------------------------------------------------------------------------
+rc=$( { header; good_entry; } | run_on control )
+check_rc "(a) CONTROL: conforming file exits 2 (board unchecked, nothing wrong)" 2 "$rc" control
+
+# ---------------------------------------------------------------------------
+# (b) The regression that motivated all of this: a missing required field, board
+#     unreachable. Was exit 2 (pass). Must be exit 1.
+# ---------------------------------------------------------------------------
+rc=$( { header; good_entry | grep -v '^SEVERITY:'; } | run_on missing_severity )
+check_rc   "(b) missing SEVERITY fails even with no board" 1 "$rc" missing_severity
+check_says "(b) names the missing field" "SEVERITY" missing_severity
+check_says "(b) still reports the board was unreachable" "CANNOT REACH BOARD" missing_severity
+
+# ---------------------------------------------------------------------------
+# (c) A second required field, to prove (b) is not special-cased.
+# ---------------------------------------------------------------------------
+rc=$( { header; good_entry | grep -v '^SYMPTOM:'; } | run_on missing_symptom )
+check_rc   "(c) missing SYMPTOM fails even with no board" 1 "$rc" missing_symptom
+check_says "(c) names the missing field" "SYMPTOM" missing_symptom
+
+# ---------------------------------------------------------------------------
+# (d) THE 18590ca8 SPECIMEN, rebuilt from the incident rather than invented: an
+#     entry appended with no `## ` heading. The parser folds it into the previous
+#     entry, so no field is "missing" — the only signal is the DATE/STATUS count
+#     disagreeing with the heading count, which is precisely the check whose
+#     result was being discarded. A test built only from missing fields (b, c)
+#     would pass while this half stayed broken.
+# ---------------------------------------------------------------------------
+rc=$( { header; good_entry; printf '\n---\nDATE: 2026-08-17\nSTATUS: open\nAREA: attribution\n'; } | run_on headless )
+check_rc   "(d) a heading-less entry fails via the drift check" 1 "$rc" headless
+check_says "(d) reports the drift, not a missing field" "STRUCTURE DRIFT" headless
+
+# ---------------------------------------------------------------------------
+# (e) THE REAL FILE must pass, or this PR turns main red the moment it lands.
+#     Fixing a gate is a migration event; this is the assertion that says the
+#     migration was actually completed rather than merely intended.
+# ---------------------------------------------------------------------------
+rc=$( run_on realfile < "$REAL_FRUST" )
+check_rc "(e) the repo's own frustrations.md passes (main stays green)" 2 "$rc" realfile
+
+echo
+echo "test-frustrations-audit: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## The bug

`checks` is the only required status check on main, and its frustrations.md gate was theatre. Two independent defects in `scripts/frustrations_audit.py`, each sufficient on its own:

**1. The board-unreachable branch threw away its own findings.**

```python
for p in problems:
    print("  PROBLEM  " + p)
return 2                    # even when problems is non-empty
```

CI never has a board — `checks.yml` says so in its own comment — and treats `2` as a pass. So the structural half ran, printed its findings, and had its verdict discarded on every push.

**2. `structure_ok` was assigned and never read.**

```python
structure_ok = structure_check(raw, entries)   # never referenced again
```

That check's docstring records it stopping a live, thrice-regressed incident from being queued for **deletion** — "seconds from receiving `validated, deleting` text". It was advisory by accident.

## Both were live, and one hid the other

Commit `18590ca8` landed a frustrations entry with **no `## ` heading**. The parser folds such a block into the preceding entry, which is exactly the count disagreement `structure_check` reports — and main went green over it, because defect 1 discarded the verdict that defect 2 had already neutered.

The old workflow comment asserted the gate that did not exist:

> 2 is EXPECTED in CI (no localhost board) and must not fail the build — *the structural half still ran and is what we are gating on.*

It ran. It was not gated on. Corrected here rather than left to mislead the next reader.

This is not a silent probe but a **loud** one whose exit code contradicted its own output: `PROBLEM` and `STRUCTURE DRIFT` were in the CI log every run, read by nobody, *because the step was green*. The module docstring already said `2` is "NOT a pass" — script and workflow disagreed, and only the script knows whether `problems` is empty.

## The fix

Structural problems exit `1` regardless of board reachability, in both branches. The `CARD:` half genuinely cannot be checked without a board and still exits `2`.

## Data migration — and a reversal I should flag

Fixing a gate is a migration event: this turns main red unless the file conforms first. Two entries needed repair, **both other sessions'**. In #108 I said this was not mine to touch. I reversed that, and what changed is that *reading* them showed the information was present and **mislabelled**, not absent:

| entry | problem |
|---|---|
| AH-81 (amux-homepage) | `WHAT HAPPENED:` instead of `SYMPTOM:` — so `grep '^SYMPTOM:'` could not see it; no `SEVERITY:` |
| 18590ca8 (amux-homepage) | no `## ` heading; `DESCRIPTION:` for `SYMPTOM:`; `FIX DIRECTION:` for `FIX:`; no `SESSION:`; `CARD: (file one)` |

**Not a word of either account was altered.** Labels renamed; `SESSION` filled from the commit's own `Amux-Session` trailer; AEAB-21 filed for the entry that literally asked for a card, quoting its author rather than re-diagnosing.

The only **inferred** values are two `SEVERITY` levels, each derived from that entry's own `COST` line, each annotated inline with a dated `NORMALISED` note naming me and inviting the author to correct it. Both greps the file promises are now complete: **120 of 120** entries.

If either author would rather revert their entry and supply the fields themselves, that is easy to do and I would not argue.

## Test

`scripts/test-frustrations-audit.sh` — 9 assertions, **every case with the board pointed at a closed port**, which is CI's real condition and the condition under which the gate was broken. A version run against a live board would pass against the old code and prove nothing.

**Verified to fail against `origin/main`'s audit: 3 of 9**, one per failure mode. The pre-fix output is the whole bug in four lines:

```
Structural checks only. 1 entries, 1 structural problem(s).
  PROBLEM  a well-formed entry      missing field(s): SEVERITY
→ exit 2      # a pass
```

Two cases are load-bearing controls rather than coverage:

- **(a)** a conforming file must exit `2`. Without it, a script that exits `1` on everything satisfies every other assertion — and that is the obvious wrong way to "fix" this.
- **(e)** the repo's own `frustrations.md` must pass. That is the assertion which says the migration was *completed*, not merely intended.

## Merge note

Touches `checks.yml`, as does #108 — a trivial textual conflict at the end of the file. Either order works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx
