### PR TITLE
docs(frustrations): five entries from the 2026-08-17 log review

### DIFF
--- a/frustrations.md
+++ b/frustrations.md
@@ -2921,3 +2921,157 @@ CARD: (file one)
 DESCRIPTION: push-guard emits "currently: unknown (api unreachable)" when it fails to resolve the owning session's identity via the API. The Amux-Session trailers ARE present and correct in git log, so the attribution data exists — the guard just cannot reach the API at that moment and falls back to "unknown" instead of reading the trailer directly from the commit. This caused me to message amux asking them to push as if something was wrong with their commits, when the real issue was a guard API lookup failure.
 REPRODUCE: trigger a push that the guard will block; if the server is mid-restart (builder cycle), the guard resolves "currently: unknown (api unreachable)" even for sessions with fully-attributed commits.
 FIX DIRECTION: the guard should fall back to the Amux-Session trailer in the commit itself when the API is unreachable, rather than reporting "unknown". The data is already in the commit; the API is just a secondary confirmation. Never let an API timeout degrade a git-native source.
+## The verify nudge names `needs:you` as its escape and does not honour it
+AREA: board
+SEVERITY: slows
+STATUS: fixed
+DATE: 2026-08-17
+SESSION: amux (AEAB)
+CARD: AEAB-9
+SYMPTOM: The done-verification nudge closes with "Cards that genuinely cannot be
+  verified by you ... should be tagged `needs:you` so they surface in the owner digest
+  rather than sitting here indefinitely." AEAB-5 was tagged via `amux board needsyou`
+  on 08-14 — the sanctioned command, which succeeded — and the nudge fired on it again
+  on 08-17. `done_verify_candidates` / `done_card_count` filter on session, status,
+  deleted, archived, owner_type and type, and never join `issue_tags`.
+COST: Three nudge cycles spent re-deciding a card that was already correctly parked,
+  each one re-reading the card to reach the same verdict. Worse than the minutes: the
+  nudge is the mechanism that is supposed to make a stuck done card visible, so an
+  instruction it issues and then ignores trains the reader to discount it. It also
+  double-nags — `needsyou.renag` already chases the HUMAN on these cards every 3d, so
+  the same card asks both the party who owes the answer and the party who cannot give
+  one.
+FIX: PR #106 / a9aa7177 — exclusion factored into `needs_human_sql()` next to the
+  existing `unverifiable_types_sql()` and applied to BOTH queries (they feed the
+  "... and N more" arithmetic and the file already warns they must not drift). Same
+  `LIKE 'needs:you%'` form as `select_pickup`, so `needs:you:decision` cannot slip
+  past. Test verified to FAIL on the pre-fix code, listing all three tagged cards.
+  NOT A NEW DEFECT CLASS: this is AC-223 one consumer down. That card closed the
+  auto-pickup hole and its own FIX note said the tag-vs-status representation question
+  stayed open. Every query that reads `issues` without joining `issue_tags` is a
+  candidate for the same bug — worth a sweep rather than waiting to hit the next one.
+
+## `amux board add` folds every flag into the title, and `--help` files a card
+AREA: cli
+SEVERITY: blocks
+STATUS: open
+DATE: 2026-08-17
+SESSION: amux-errors-and-bugs
+CARD: AEAB-17
+SYMPTOM: `amux board add` takes only a positional title. Unknown flags are concatenated
+  into it, exit 0, no warning — proved with a control rather than inferred from missing
+  help: `amux board add "PROBE..." --totally-bogus-flag xyz` filed AEAB-16 with the flag
+  in the title. Separately, `amux board add --help` does not print help; it creates a
+  card titled `--help` (AEAB-15). The verbs that DO take flags are inconsistent with it:
+  `retitle` accepts `--stdin/--file/--desc-stdin` and `--type`, every status verb accepts
+  `--checked/--ack/--outcome-file`; `add`, the verb you reach first, accepts none.
+COST: All five cards filed in one log-review run (AEAB-9..AEAB-13) were created with
+  desc_len 0 or near-0 — every diagnosis written for them went nowhere — titles up to
+  259 chars carrying raw `--desc-file /private/tmp/claude-501/.../c26.md` paths that
+  will not exist tomorrow, and the wrong TYPE, so two cards about a production outage
+  and a dual-server fault were gated on "Implemented and merged" + "Tests / lint pass".
+  An empty card is worse than no card: it asserts the work is tracked. And the
+  discovery path is the polluting action, so the mistake is unlearnable in advance —
+  the AMUX-2140 shape (`amux board claim`) with a new verb.
+FIX: Cards repaired via the documented path (`retitle ... --desc-stdin`) and verified
+  from fresh reads; probe cards discarded after confirming they were mine. CLI not
+  fixed — not mine. Wanted: reject unknown flags, print help for `--help`, accept
+  `--type`/`--desc-file` on `add` like `retitle` does, and a title-length sanity check
+  (a 259-char title containing `/private/tmp/` is never intentional).
+MY OWN HALF, recorded because ethos.md predicted it verbatim: I verified `type` and
+  `status` on those cards from fresh reads and never checked `desc` — the exact
+  desc_append/AMUX-2161 failure rule 7 describes ("the habit gave the feeling of rigour
+  while pointing at the wrong field"). I had read that line earlier in the same session.
+  Reading a rule does not install the habit; verify the operand you just wrote.
+
+## The auto-builder ships any branch to the live fleet with no announcement
+AREA: deploy
+SEVERITY: blocks
+STATUS: open (the live deviation is fixed; the hazard is not)
+DATE: 2026-08-17
+SESSION: amux-errors-and-bugs
+CARD: AEAB-12
+SYMPTOM: `~/amux` is the BUILD SOURCE, and the builder rebuilds on any local HEAD move
+  regardless of branch; the server self-adopts in 5s. I committed a9aa7177 on a feature
+  branch there at 00:02; at 00:03:43 the builder installed it and it served the whole
+  fleet until 09:45 — 9h42m of an unreviewed, un-CI'd commit in production. The same
+  condition left the machine 29 commits behind origin/main, so SCHED-1 ("keep me on the
+  latest") fired at 09:00 and could not do its job.
+COST: 9h42m of unreviewed code live, plus the owner's standing "keep me on the latest"
+  request silently unmet while every indicator looked healthy. Diagnosing it took the
+  first ~30 minutes of a log review that was supposed to be about something else.
+FIX: Live deviation fixed — ~/amux back on main, fast-forwarded to 9d5aebf4, verified
+  by build-stamp change (663a3a84 -> ec3228af), store=ok, 0 panics/0 ERRORs since. The
+  hazard is NOT fixed and should not be fixed by refusing non-main HEADs: this machine
+  survived weeks deliberately pinned to an unmerged fix branch, so that is a supported
+  mode. The defect is that a deliberate pin and an accidental feature branch are
+  byte-identical to the builder and the accidental one is announced nowhere. Wanted:
+  one line in rust-auto-build.log naming the branch when the revision is off main, and
+  the same fact on /health or the dashboard. Workaround that works today and belongs in
+  CLAUDE.md: never develop in ~/amux — `git worktree add` and leave its HEAD on main.
+
+## Two amux servers on one SQLite DB, and endpoint.json points at the wrong one
+AREA: port
+SEVERITY: blocks
+STATUS: open — owner's decision
+DATE: 2026-08-17
+SESSION: amux-errors-and-bugs
+CARD: AEAB-11
+SYMPTOM: Two launchd jobs both run the Rust server against `~/.amux/amux.db` —
+  `com.amux.server-rs` (pid 22521, port 8824, last exit -9) and `com.amux.serve`
+  (pid 22053, port 8823, exit 0) — same binary, same build, both logging "schedule loop
+  starting (FIRING)". Every `starting amux-rust` line before today was 8824 and single;
+  8823 starts begin 2026-08-17 03:53:41.
+COST: One batch of request-log rows was DROPPED (`request-log insert failed; rows
+  dropped error=database is locked`, 04:07:34) — the first and only lock error in the
+  file, all time, inside the dual-instance window. `endpoint.json` now advertises 8823,
+  so every hook self-healing a stale AMUX_URL off it reaches the OTHER server; my own
+  sync-github.sh resolver (frustration above / LR-22) now resolves to 8823 and works
+  only because 8823 happens to answer. And it doubled the log: both instances tick the
+  same 5s stall loop, so those warnings appear twice ~200ms apart, which is 77% of the
+  24h log volume and buried the lock error above.
+  DOCS NOW WRONG, second time for this class: CLAUDE.md asserts as ground truth
+  "re-measured 2026-08-06" that "com.amux.serve.plist is the only server plist on disk"
+  and gives `launchctl kickstart -k gui/$(id -u)/com.amux.serve` as THE restart command.
+  There are two server plists now, and that command restarts 8823, not the canonical
+  port. The note is emphatic that a wrong label costs a debugging session; it is now
+  wrong itself.
+FIX: Not applied — choosing which job is canonical can take the dashboard down, and a
+  dev instance with its own AMUX_HOME is a legitimate configuration this could also be
+  (ethos rule 8). Needed: decide, `launchctl bootout` the loser, delete its plist,
+  correct CLAUDE.md's launchd note.
+
+## frustrations.md logged from ~/Developer/amux is stranded — that checkout cannot push
+AREA: instruments
+SEVERITY: blocks
+STATUS: open
+DATE: 2026-08-17
+SESSION: amux-errors-and-bugs
+CARD: AEAB-18
+SYMPTOM: Two copies of this file exist and the one a session is pointed at is the one
+  that cannot reach anyone. `~/Developer/amux/frustrations.md` holds 25 entries /
+  43,934 bytes; `~/amux/frustrations.md` (origin/main) holds 116 / 207,952. Same file,
+  same lineage — the local one is a stale revision that has ALSO diverged, holding at
+  least one entry that never reached origin. CLAUDE.md and `.claude/rules/frustrations.md`
+  both live in the stale checkout and say to append to "frustrations.md at the repo
+  root", which for a session cwd'd there resolves to the stranded copy. The append
+  succeeds. There is no error.
+COST: All four frustration entries from today's log review went into the stranded copy.
+  The whole argument for this file is that a single frustration is a complaint and a
+  cluster is an argument — three entries sharing an AREA is the signal. That only works
+  if they are in the file everyone reads. Mine were invisible to every other session and
+  to any AREA tally run upstream, and would have stayed so indefinitely: the unblocker
+  is the 4-unpushed-commit divergence that has been an open owner decision since
+  2026-08-13.
+  Distinct from that divergence rather than a restatement of it: that one is "the
+  checkout cannot fast-forward", which announces itself. This one is "the documented
+  place to log friction is INSIDE that checkout", so the divergence silently swallows
+  new writes instead of blocking a read.
+FIX: Migrated today's four entries here and verified against
+  `scripts/frustrations_audit.py` — no new structural problems, all four CARD ids
+  resolve on the live board. The underlying choice is open and worth making
+  deliberately: (a) resolve the divergence so the checkout syncs again — owner's call,
+  needed regardless; (b) point the rule at the build source, which can push, and say why;
+  (c) have the rule REFUSE to append to a checkout that is behind origin, or at minimum
+  warn. (c) is the one that survives the next time two checkouts drift, because this
+  failure is silent by construction.


### PR DESCRIPTION
Five frustration entries from today's daily log review. **Supersedes #109**, which conflicted once main moved 69 commits ahead and appended entries of its own. A new branch rather than a force-push.

Four of these were originally written into `~/Developer/amux/frustrations.md` — 1017 commits behind, 4 unpushed commits, `github-sync` failing 50+ consecutive runs. That copy holds 25 entries; this one holds 119. The appends succeeded and reached nobody. That stranding is the fifth entry (AEAB-18), filed as its own friction because it fails differently from the divergence: a diverged checkout *announces itself* on a pull, whereas "the documented place to log friction lives inside it" silently swallows writes.

## Entries

| entry | AREA | status |
|---|---|---|
| The verify nudge names `needs:you` as its escape and does not honour it | board | fixed — #106 |
| `amux board add` folds every flag into the title, and `--help` files a card | cli | fixed — #108 |
| The auto-builder ships any branch to the live fleet with no announcement | deploy | live deviation fixed; hazard open |
| Two amux servers on one SQLite DB, and endpoint.json points at the wrong one | port | open — owner's decision |
| frustrations.md logged from `~/Developer/amux` is stranded | instruments | open |

## How this was rebuilt, and a mistake worth naming

I resolved the conflict as a **union** first — main's content then mine, which is the obvious move for an append-only file. It silently mangled the file. The conflict hunks split *mid-entry*, so "ours then theirs" spliced fragments of different entries together and left the DESKT-10 supersede entry carrying another entry's `FIX:` line as its entire body.

The structural audit caught it, as that entry suddenly missing eight required fields. I would have shipped it had I not re-measured after resolving. **For an append-only file, a union merge of append-vs-append is not the safe operation it looks like.**

So this branch re-appends the five entries **verbatim** onto current main instead, extracted programmatically from the original commit rather than retyped.

## Verified against `origin/main` as the baseline

```
conflict markers            0
entries                     124   (119 from main + 5 mine)
entries lost from main      0
NEW structural problems     0
```

All five `CARD:` ids resolve against the live board with no title mismatch.

The one remaining drift (`DATE`/`STATUS` 125 vs 124) is **inherited from main**, where 18590ca8 appended an entry with no `## ` heading. #110 repairs that entry and the gate that let it through.

Closes #109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx
