### PR TITLE
fix(ci): make main green — a false-positive tmux audit and a duplicate _fmtBytes

### DIFF
--- a/crates/amux-dashboard/static/app.js
+++ b/crates/amux-dashboard/static/app.js
@@ -7774,7 +7774,7 @@ async function saveGlobalMemory() {
   }
 }
 
-const APP_VER = '0.9.665';   // bump together with the sw.js CACHE version
+const APP_VER = '0.9.666';   // bump together with the sw.js CACHE version
 
 // ── No silent failures (Ethan, 2026-08-09: "make sure every action has some
 // kind of response in the ui — i just deleted a worker and nothing happened").
@@ -28578,14 +28578,23 @@ const _KIND_COLORS = {
   data: '#58a6ff', code: '#6e7681', build: '#f85149', doc: '#39c5cf', other: '#484f58',
 };
 
-function _fmtBytes(n) {
-  n = +n || 0;
-  if (n >= 1099511627776) return (n / 1099511627776).toFixed(2) + ' TB';
-  if (n >= 1073741824) return (n / 1073741824).toFixed(1) + ' GB';
-  if (n >= 1048576) return (n / 1048576).toFixed(0) + ' MB';
-  if (n >= 1024) return (n / 1024).toFixed(0) + ' KB';
-  return n + ' B';
-}
+// _fmtBytes is NOT redefined here. A second `function _fmtBytes` lived at this
+// spot and was DEAD CODE: both declarations are top-level in this file, so the
+// later one (the B/KB/MB/GB version, further down) is hoisted over this one and
+// wins for every caller. Verified in node rather than reasoned about. Deleting
+// it is therefore a no-op at runtime, and it is what the two pointer comments
+// above (near the request-log and storage sections) already describe as the
+// single shared implementation.
+//
+// It also broke the build: `no-redeclare` is an ERROR in the SPA static gate, so
+// this one duplicate failed `rust.yml` on main and every open PR inherited a red
+// `check`/`e2e` and looked broken (AEAB-20).
+//
+// The deleted copy carried one thing the survivor does not: a TB tier (and a
+// `+n || 0` coercion). That was not restored here, deliberately — adding a tier
+// CHANGES rendered output above 1 TB, and this deletion is meant to change
+// nothing. If the storage view wants TB, add it to the single shared function as
+// its own reviewable change.
 
 function _metricsSetMode(mode) {
   _metricsMode = mode;

--- a/crates/amux-dashboard/static/sw.js
+++ b/crates/amux-dashboard/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'amux-v0.9.665';
+const CACHE = 'amux-v0.9.666';
 const SHELL_URLS = ['/', '/manifest.json', '/icon.svg', '/icon.png', '/icon-192.png', '/icon-512.png'];
 
 // Install: pre-cache entire app shell

--- a/crates/amux-server/tests/tmux_target_audit.rs
+++ b/crates/amux-server/tests/tmux_target_audit.rs
@@ -49,6 +49,87 @@ fn normalise(expr: &str) -> String {
     e.trim().to_string()
 }
 
+/// Positive evidence that this `-t` belongs to a program that is NOT tmux.
+///
+/// AEAB-20. The scanner searched every `.rs` under `src/` for the literal
+/// `"-t"` and treated whatever followed as a tmux target, with no notion of
+/// which program was being invoked. `integrations/email.rs` runs
+/// `Command::new("touch").args(["-t", stamp, ...])` to backdate a fixture —
+/// `touch -t` is a TIMESTAMP, not a pane — and the audit failed `main` over it,
+/// which in turn made every open PR inherit a red `check` job and look broken.
+///
+/// Deliberately requires POSITIVE evidence and fails SAFE: only a literal
+/// `Command::new("x")` with x != "tmux" exempts a site. Anything the scanner
+/// cannot attribute stays audited, so this narrows the false positives without
+/// opening a hole — `api/metrics.rs` reaches tmux through a
+/// `cmd_output("tmux", ...)` helper with no `Command::new` at all, and must and
+/// does remain covered.
+///
+/// The alternative shape — "skip anything whose statement does not mention
+/// tmux" — was rejected for being the wrong polarity: it would exempt a real
+/// `let args = ["-t", target]; tmux(&args)` split across two statements, which
+/// is precisely the offender this file exists to catch.
+fn non_tmux_program(src: &str, at: usize) -> Option<String> {
+    // The enclosing statement, back to the nearest `;` / `{` / `}`.
+    let start = src[..at].rfind([';', '{', '}']).map_or(0, |i| i + 1);
+    let span = &src[start..at];
+    const KEY: &str = "Command::new(\"";
+    let i = span.rfind(KEY)?;
+    let rest = &span[i + KEY.len()..];
+    let end = rest.find('"')?;
+    let prog = &rest[..end];
+    (prog != "tmux").then(|| prog.to_string())
+}
+
+/// Walk one source text and return every non-exact `-t` target expression.
+///
+/// Extracted so `offenders()` and `the_audit_detects_a_planted_non_exact_target`
+/// run the SAME code. They used to be two copies of this loop — the test
+/// re-implemented ~30 lines of it inline — which meant the test could not
+/// observe a change in the real scanner. Simulating what you believe a function
+/// does cannot catch that function doing something else (ethos rule 7), and the
+/// exemption added above would have been entirely untested under that shape.
+fn scan(src: &str) -> Vec<(usize, String)> {
+    let mut found = Vec::new();
+    let mut from = 0usize;
+    while let Some(rel) = src[from..].find("\"-t\"") {
+        let at = from + rel;
+        from = at + 4;
+        if non_tmux_program(src, at).is_some() {
+            continue;
+        }
+        // Skip the separator after the literal, then take the argument up
+        // to the next `,` / `]` / `)` at this nesting level.
+        let rest = &src[from..];
+        let Some(comma) = rest.find(',') else { continue };
+        let tail = &rest[comma + 1..];
+        let mut depth = 0i32;
+        let mut end = tail.len();
+        for (i, c) in tail.char_indices() {
+            match c {
+                '(' | '[' | '{' => depth += 1,
+                ')' | ']' | '}' => {
+                    if depth == 0 {
+                        end = i;
+                        break;
+                    }
+                    depth -= 1;
+                }
+                ',' if depth == 0 => {
+                    end = i;
+                    break;
+                }
+                _ => {}
+            }
+        }
+        let expr = normalise(&tail[..end]);
+        if !ALLOWED.contains(&expr.as_str()) {
+            found.push((at, expr));
+        }
+    }
+    found
+}
+
 fn offenders() -> Vec<String> {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
     let mut files = Vec::new();
@@ -58,38 +139,7 @@ fn offenders() -> Vec<String> {
     let mut bad = Vec::new();
     for f in files {
         let src = std::fs::read_to_string(&f).unwrap_or_default();
-        let mut from = 0usize;
-        while let Some(rel) = src[from..].find("\"-t\"") {
-            let at = from + rel;
-            from = at + 4;
-            // Skip the separator after the literal, then take the argument up
-            // to the next `,` / `]` / `)` at this nesting level.
-            let rest = &src[from..];
-            let Some(comma) = rest.find(',') else { continue };
-            let tail = &rest[comma + 1..];
-            let mut depth = 0i32;
-            let mut end = tail.len();
-            for (i, c) in tail.char_indices() {
-                match c {
-                    '(' | '[' | '{' => depth += 1,
-                    ')' | ']' | '}' => {
-                        if depth == 0 {
-                            end = i;
-                            break;
-                        }
-                        depth -= 1;
-                    }
-                    ',' if depth == 0 => {
-                        end = i;
-                        break;
-                    }
-                    _ => {}
-                }
-            }
-            let expr = normalise(&tail[..end]);
-            if ALLOWED.contains(&expr.as_str()) {
-                continue;
-            }
+        for (at, expr) in scan(&src) {
             let line = src[..at].matches('\n').count() + 1;
             bad.push(format!(
                 "{}:{line}: tmux -t target `{expr}` is not one of {ALLOWED:?} \
@@ -119,44 +169,15 @@ fn every_tmux_target_uses_the_exact_match_helpers() {
 #[test]
 fn the_audit_detects_a_planted_non_exact_target() {
     // Same text shape the scanner walks in a real source file, including the
-    // prefix-matching target that motivated the rule.
+    // prefix-matching target that motivated the rule. Runs the SHIPPED `scan`
+    // rather than a copy of it — this test used to re-implement the loop inline,
+    // so it could not have observed the AEAB-20 exemption at all.
     let planted = r#"
         let _ = tmux(&["pipe-pane", "-t", &format!("amux-{name}"), &cmd]).await;
         let _ = tmux(&["send-keys", "-t", "amux-amux", "Enter"]).await;
         let _ = tmux(&["kill-session", "-t", &stq]).await;
     "#;
-    let mut found = Vec::new();
-    let mut from = 0usize;
-    while let Some(rel) = planted[from..].find("\"-t\"") {
-        let at = from + rel;
-        from = at + 4;
-        let rest = &planted[from..];
-        let Some(comma) = rest.find(',') else { continue };
-        let tail = &rest[comma + 1..];
-        let mut depth = 0i32;
-        let mut end = tail.len();
-        for (i, c) in tail.char_indices() {
-            match c {
-                '(' | '[' | '{' => depth += 1,
-                ')' | ']' | '}' => {
-                    if depth == 0 {
-                        end = i;
-                        break;
-                    }
-                    depth -= 1;
-                }
-                ',' if depth == 0 => {
-                    end = i;
-                    break;
-                }
-                _ => {}
-            }
-        }
-        let expr = normalise(&tail[..end]);
-        if !ALLOWED.contains(&expr.as_str()) {
-            found.push(expr);
-        }
-    }
+    let found: Vec<String> = scan(planted).into_iter().map(|(_, e)| e).collect();
     assert_eq!(
         found.len(),
         2,
@@ -164,4 +185,56 @@ fn the_audit_detects_a_planted_non_exact_target() {
     );
     assert!(found.iter().any(|f| f.contains("format!")), "missed the format! target: {found:?}");
     assert!(found.iter().any(|f| f.contains("\"amux-amux\"")), "missed the literal prefix target: {found:?}");
+}
+
+/// AEAB-20, both directions. The exemption must silence `touch -t` and MUST NOT
+/// silence a tmux target — a fix that just stopped flagging things would satisfy
+/// "main is green" while deleting the guard, which is the whole failure mode this
+/// file was written to avoid.
+#[test]
+fn a_non_tmux_program_is_exempt_but_tmux_is_never_exempt() {
+    // The real specimen, reduced from integrations/email.rs:1330. `touch -t` is a
+    // timestamp; flagging it failed main and made every open PR look broken.
+    let touch = r#"
+        let set = |name: &str, stamp: &str| {
+            std::process::Command::new("touch")
+                .args(["-t", stamp, tok.join(format!("{name}.json")).to_str().unwrap()])
+                .status()
+                .unwrap();
+        };
+    "#;
+    assert!(scan(touch).is_empty(), "touch -t is a timestamp, not a pane: {:?}", scan(touch));
+
+    // THE CONTROL. Identical shape, program `tmux`: must still be caught.
+    let tmux_cmd = r#"
+        std::process::Command::new("tmux")
+            .args(["send-keys", "-t", "amux-amux", "Enter"])
+            .status()
+            .unwrap();
+    "#;
+    let f: Vec<String> = scan(tmux_cmd).into_iter().map(|(_, e)| e).collect();
+    assert_eq!(f.len(), 1, "a hand-spelled tmux target must still be flagged: {f:?}");
+    assert!(f[0].contains("amux-amux"), "wrong expression captured: {f:?}");
+
+    // And a helper that names tmux WITHOUT Command::new stays covered — this is
+    // api/metrics.rs's shape (`cmd_output("tmux", &[...])`), where there is no
+    // literal program to attribute, so the fail-safe keeps it audited.
+    let helper = r#"
+        let _ = cmd_output("tmux", &["list-panes", "-t", "amux-amux", "-F", "x"]);
+    "#;
+    assert_eq!(scan(helper).len(), 1, "a helper-invoked tmux target must stay audited");
+
+    // A non-tmux program reached the same way is NOT exempt either, for the same
+    // reason: no literal program means no positive evidence, so it stays flagged.
+    // Recorded rather than "fixed" — erring toward a reviewable false positive is
+    // the correct direction for this guard, and pretending otherwise would need a
+    // real parser.
+    let other_helper = r#"
+        let _ = cmd_output("touch", &["-t", "202608161200", "f.json"]);
+    "#;
+    assert_eq!(
+        scan(other_helper).len(),
+        1,
+        "documented limitation: without Command::new there is nothing to attribute"
+    );
 }


### PR DESCRIPTION
`origin/main` fails its own `rust.yml` on **both** jobs, so every open PR inherits two red checks and a broken PR is indistinguishable from a clean one. Two unrelated causes, each a single line.

## 1. `check` → `every_tmux_target_uses_the_exact_match_helpers`

**False positive.** The audit scanned every `.rs` under `src/` for the literal `"-t"` and treated whatever followed as a tmux target — with no notion of which *program* was being invoked. `integrations/email.rs` runs:

```rust
Command::new("touch").args(["-t", stamp, ...])   // backdates a test fixture
```

`touch -t` is a timestamp, not a pane.

Fixed by requiring **positive evidence** to exempt a site: only a literal `Command::new("x")` with `x != "tmux"` in the enclosing statement. It **fails safe** — anything unattributable stays audited, so `api/metrics.rs`, which reaches tmux through a `cmd_output("tmux", ...)` helper with no `Command::new` at all, remains covered.

The opposite shape — "skip unless the statement mentions tmux" — was rejected as the wrong polarity. It would exempt a real `let args = ["-t", target]; tmux(&args)` split across two statements, which is exactly the offender this file exists to catch.

**The scanner is now a `scan()` shared by the audit and its planted-offender test.** They were two copies of the same 30-line loop, so the test could not observe a change in the real scanner and the exemption would have shipped untested.

New test asserts **both directions**: `touch -t` exempt, `Command::new("tmux")` with a hand-spelled target still flagged, helper-invoked tmux still audited. A fix that merely stopped flagging things would satisfy "main is green" while deleting the guard.

## 2. `e2e` → SPA static gate: `'_fmtBytes' is already defined`

Two top-level `function _fmtBytes` in `app.js`. The later one wins by hoisting — **verified in node, not reasoned about** — so the earlier copy was dead code and deleting it is a no-op at runtime. It is also what the file's own two pointer comments already describe as the single shared implementation.

The deleted copy carried a TB tier and a `+n || 0` coercion. **Not restored here, deliberately:** adding a tier changes rendered output above 1 TB, and this deletion is meant to change nothing. If the storage view wants TB, that belongs in the surviving function as its own reviewable change with its own decision attached.

## Verification — against the real gates, not by inspection

| gate | before | after |
|---|---|---|
| `scripts/spa-lint.sh` | 1 error | **0 errors**, exit 0 |
| `cargo test --workspace` | 1 failed | **39 result lines, 0 failed** |
| `tmux_target_audit` | 1 passed, 1 failed | **3 passed** |

I reproduced the CI lint failure locally first (`29103:10 error '_fmtBytes' is already defined`) so the "after" means something.

`APP_VER` and sw.js `CACHE` bumped together per CLAUDE.md, `0.9.665` → `0.9.666`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx
