### PR TITLE
feat(dashboard): file paths in session output link to the file browser

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -79,3 +79,15 @@ jobs:
           echo "frustrations_audit exit=$rc (0 clean, 1 real problems, 2 board unreachable)"
           if [ "$rc" = "1" ]; then exit 1; fi
           exit 0
+
+      # AEAB-22. Lives here, not in rust.yml, for the same reason as the other
+      # CLI/asset gates: rust.yml is path-filtered to `crates/**` + `Cargo.*` +
+      # `e2e/**`, and while app.js IS under crates/, this test also guards
+      # scripts/ and needs no Rust toolchain. It loads the SHIPPED functions out
+      # of app.js and runs them, so it fails if the linkifier is removed OR if a
+      # render path stops calling it — the second being the actual defect it was
+      # written for (the previous linkifier was perfect and had zero callers).
+      - name: SPA path linkifier (AEAB-22)
+        run: |
+          set -uo pipefail
+          node scripts/test-linkify-paths.mjs

--- a/crates/amux-dashboard/static/app.js
+++ b/crates/amux-dashboard/static/app.js
@@ -7774,7 +7774,7 @@ async function saveGlobalMemory() {
   }
 }
 
-const APP_VER = '0.9.667';   // bump together with the sw.js CACHE version
+const APP_VER = '0.9.668';   // bump together with the sw.js CACHE version
 
 // ── No silent failures (Ethan, 2026-08-09: "make sure every action has some
 // kind of response in the ui — i just deleted a worker and nothing happened").
@@ -7960,8 +7960,8 @@ function _offlineCacheInfo() {
 function _paintCachedPeek(cached) {
   if (!cached || (!cached.output && !cached.history)) return false;
   _peekHistoryRaw = cached.history || '';
-  _peekHistoryHTML = cached.histHTML || (cached.history ? wrapBoxBlocks(_fitRules(highlightPrompts(ansiToHtml(cached.history)))) : '');
-  _lastLiveHTML = cached.liveHTML || (cached.output ? wrapBoxBlocks(_fitRules(highlightPrompts(ansiToHtml(cached.output)))) : '');
+  _peekHistoryHTML = cached.histHTML || (cached.history ? _peekHtml(cached.history) : '');
+  _lastLiveHTML = cached.liveHTML || (cached.output ? _peekHtml(cached.output) : '');
   lastPeekHTML = _peekEarlierHTML() + _peekHistoryHTML + _lastLiveHTML;
   applyPeekSearch();
   const ago = Math.floor((Date.now() - (cached.time || Date.now())) / 60000);
@@ -8944,58 +8944,92 @@ function _osc8Resolve(html, urls) {
     .replace(/\uE000\d+\uE001|\uE002/g, '');
 }
 
-function linkifyOutput(text) {
-  // Split text into segments: URLs, file paths, and plain text
-  // URL regex: match http/https URLs
-  const urlRe = /https?:\/\/[^\s<>\]\)'"`,;]+/g;
-  // File path regex: absolute paths or relative paths with extensions
-  const fileRe = /(?:^|[\s(])((\/[\w./-]+(?:\.\w+)(?::[\d]+)?)|(\.\/[\w./-]+(?:\.\w+)(?::[\d]+)?))/gm;
+// Resolve a path as it appeared in a session's OUTPUT into something the file
+// APIs can use. Output is written from the worker's cwd, so `customers/rothco/
+// data/x.csv` is only meaningful relative to that session's dir — which is what
+// `peekSessionDir` holds. An absolute path is returned untouched.
+function _resolveOutputPath(p) {
+  const raw = String(p || '').replace(/:\d+$/, '');   // strip a trailing :linenum
+  if (raw.startsWith('/')) return raw;
+  const base = (typeof peekSessionDir === 'string' && peekSessionDir) ? peekSessionDir.replace(/\/+$/, '') : '';
+  const rel = raw.replace(/^\.\//, '');
+  return base ? base + '/' + rel : rel;
+}
 
-  const parts = [];
-  let last = 0;
+// Click target for a path in session output: open the FILE BROWSER at it.
+//
+// The browser is a directory view, so a file path opens its containing folder —
+// you land looking at the file, in context, with the session's shortcuts loaded
+// and the "back to <session>" affordance wired up. A path with no extension in
+// its last segment is treated as a directory and opened directly.
+//
+// Deliberately the browser rather than the file-preview overlay: peek output is
+// most often naming a file so you can go LOOK at it and what is around it, and
+// the browser is reachable from a preview while the reverse costs a round trip.
+function _openPathFromOutput(p) {
+  if (window.getSelection && String(window.getSelection()) !== '') return;  // a drag-select is not a click
+  const full = _resolveOutputPath(p);
+  const lastSeg = full.slice(full.lastIndexOf('/') + 1);
+  const looksLikeFile = /\.[A-Za-z0-9]{1,8}$/.test(lastSeg);
+  const dir = looksLikeFile ? (full.slice(0, full.lastIndexOf('/')) || '/') : full;
+  openExplore(dir, (typeof peekSession !== 'undefined' && peekSession) ? peekSession : null);
+}
 
-  // First pass: find all URLs
-  const matches = [];
-  let m;
-  while ((m = urlRe.exec(text)) !== null) {
-    // Strip trailing punctuation that's likely not part of URL
-    let url = m[0].replace(/[.,;:!?)]+$/, '');
-    matches.push({ start: m.index, end: m.index + url.length, type: 'url', value: url });
-  }
+// Turn file paths in ALREADY-ESCAPED peek HTML into links to the file browser.
+//
+// Replaces a `linkifyOutput` that had ZERO callers — it was written for this
+// surface (its `.file-link`/`.md-link` classes are styled under `.overlay-body`,
+// which is exactly `#peek-body`'s class) and was never wired into the pipeline,
+// so every path in every session's output has always rendered as dead text.
+// Capability that reaches nobody does not improve when anything else does.
+//
+// It also could not have matched the reported case. Its regex required a leading
+// `/` or `./`, and real output says `Contacts are in customers/rothco/data/
+// jewishlink-prospects.csv.` — a BARE relative path, which is how a worker
+// naturally writes a path inside its own cwd.
+//
+// Runs on escaped HTML so it composes AFTER the URL/OSC-8 linkification that
+// ansiToHtml already did, using the same `(?![^<]*>)` tail-guard as _linkifyUrls
+// to skip anything sitting inside a tag's attributes.
+function _linkifyPaths(safeHtml) {
+  try {
+    // Leading boundary is CAPTURED and re-emitted rather than matched by a
+    // lookbehind: iOS Safari is the primary client here and this keeps the
+    // pattern portable. The class deliberately excludes `/`, `:`, `.`, `@` and
+    // word characters, which is what stops a URL's own path (`https://h/a/b.js`)
+    // being re-linkified inside the anchor ansiToHtml just built for it.
+    // `(?:\.?\/)?` covers all three shapes seen in real output: `/abs/x.py`,
+    // `./rel/x.py` and the bare `customers/rothco/data/x.csv` that started this.
+    // The segment class excludes quotes on purpose — a path containing `'` would
+    // break out of the inline onclick below, so such a path is simply not linked
+    // rather than linked unsafely.
+    const RE = /(^|[\s(\[>"'`,;=])((?:\.?\/)?(?:[\w.@-]+\/)+[\w.@-]+\.[A-Za-z0-9]{1,8})(:\d+)?(?![^<]*>)/gm;
+    return String(safeHtml).replace(RE, (m, pre, path, line) => {
+      // Trailing sentence punctuation is prose, not filename: "…prospects.csv."
+      let p = path, tail = line || '';
+      const dot = p.match(/\.$/);
+      if (dot) { p = p.slice(0, -1); tail = '.' + tail; }
+      if (!/\.[A-Za-z0-9]{1,8}$/.test(p)) return m;
+      // A RELATIVE path is only meaningful against the session's cwd. With no
+      // cwd we cannot resolve it, and linking it anyway would render text that
+      // looks clickable and does nothing — the precise failure this file already
+      // records for the OSC-8 hyperlinks above. Leave it as plain text instead.
+      if (!p.startsWith('/') && !(typeof peekSessionDir === 'string' && peekSessionDir)) return m;
+      const cls = /\.md$/i.test(p) ? 'md-link' : 'file-link';
+      const shown = p + (line || '');
+      return pre + '<span class="' + cls + '" title="Open in the file browser: '
+        + esc(_resolveOutputPath(p)) + '" onclick="event.preventDefault();event.stopPropagation();'
+        + "_openPathFromOutput('" + escJs(p) + "')" + '">' + esc(shown) + '</span>'
+        + (dot ? '.' : '');
+    });
+  } catch (e) { return safeHtml; }
+}
 
-  // Second pass: find file paths (skip if overlapping with URL)
-  while ((m = fileRe.exec(text)) !== null) {
-    const path = m[1];
-    const pathStart = m.index + m[0].indexOf(path);
-    const pathEnd = pathStart + path.length;
-    const overlaps = matches.some(x => pathStart < x.end && pathEnd > x.start);
-    if (!overlaps) {
-      matches.push({ start: pathStart, end: pathEnd, type: 'file', value: path });
-    }
-  }
-
-  matches.sort((a, b) => a.start - b.start);
-
-  // Build HTML
-  let html = '';
-  for (const match of matches) {
-    if (match.start > last) {
-      html += esc(text.slice(last, match.start));
-    }
-    if (match.type === 'url') {
-      html += `<a href="${esc(match.value)}" target="_blank" rel="noopener noreferrer">${esc(match.value)}</a>`;
-    } else if (match.type === 'file') {
-      const rawPath = match.value.replace(/:[\d]+$/, '');  // strip :linenum
-      const isMd = /\.md$/i.test(rawPath);
-      const cls = isMd ? 'md-link' : 'file-link';
-      html += `<span class="${cls}" onclick="if(window.getSelection().toString())return;event.preventDefault();event.stopPropagation();openFilePreview('${esc(rawPath)}')">${esc(match.value)}</span>`;
-    }
-    last = match.end;
-  }
-  if (last < text.length) {
-    html += esc(text.slice(last));
-  }
-  return rewriteLocalhostUrls(html);
+// ONE peek render pipeline. The four call sites each spelled the chain out, so
+// adding a stage meant finding all of them — which is how the path linkifier
+// would have been half-wired.
+function _peekHtml(raw) {
+  return wrapBoxBlocks(_fitRules(highlightPrompts(_linkifyPaths(ansiToHtml(raw)))));
 }
 
 // The MARKERS amux stamps on everything it injects into a pane. Structural, not
@@ -9374,12 +9408,12 @@ async function refreshPeek(liveOnly, bypassTrim) {
     let histChanged = false;
     if (histRaw !== null && histRaw !== _peekHistoryRaw) {   // full fetch → (re)render history once
       _peekHistoryRaw = histRaw;
-      _peekHistoryHTML = histRaw ? wrapBoxBlocks(_fitRules(highlightPrompts(ansiToHtml(histRaw)))) : '';
+      _peekHistoryHTML = histRaw ? _peekHtml(histRaw) : '';
       histChanged = true;
     }
     const atBottom = _isScrolledToBottom(body);
     if (atBottom) _peekScrollLocked = false;
-    const newHTML = wrapBoxBlocks(_fitRules(highlightPrompts(ansiToHtml(output))));
+    const newHTML = _peekHtml(output);
     if (peekSelecting || (window.getSelection()?.toString().length > 0)) return;
     if (_sendingSnapshot && newHTML !== _sendingSnapshot) clearSendingIndicator();
     // Claude runs on the terminal's ALT SCREEN: tmux holds only the viewport,

--- a/crates/amux-dashboard/static/sw.js
+++ b/crates/amux-dashboard/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'amux-v0.9.667';
+const CACHE = 'amux-v0.9.668';
 const SHELL_URLS = ['/', '/manifest.json', '/icon.svg', '/icon.png', '/icon-192.png', '/icon-512.png'];
 
 // Install: pre-cache entire app shell

--- a/scripts/test-linkify-paths.mjs
+++ b/scripts/test-linkify-paths.mjs
@@ -1,0 +1,110 @@
+// AEAB-22 — file paths in session output must link to the file browser.
+//
+// `linkifyOutput` existed for this surface and had ZERO callers, so every path in
+// every session's output rendered as dead text. Its `.file-link`/`.md-link`
+// classes are styled under `.overlay-body`, which is exactly `#peek-body`'s
+// class — it was written for the peek pane and never wired in.
+//
+// It also could not have matched the reported case: its regex required a leading
+// `/` or `./`, while real output says "Contacts are in
+// customers/rothco/data/jewishlink-prospects.csv." — a BARE relative path, which
+// is how a worker naturally writes a path inside its own cwd.
+//
+// These load the SHIPPED functions straight out of app.js and run them, rather
+// than restating the regex — a copy of the pattern would pass while the pipeline
+// stayed unwired, which is the exact failure being fixed.
+//
+// Run: node scripts/test-linkify-paths.mjs   (exit 0 = pass). Wired into checks.yml.
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Resolve from the SCRIPT, not the cwd, so CI and a shell in any directory agree.
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const src = fs.readFileSync(path.join(REPO, 'crates/amux-dashboard/static/app.js'), 'utf8');
+// Pull the two pure functions out and run them standalone.
+// Fail LEGIBLY if the function is gone, rather than throwing a stack trace from
+// deep inside `new Function`. Against the pre-fix app.js this is the assertion
+// that fires, and "not found in app.js" is the useful sentence to read.
+const grab = n => { const i = src.indexOf('function '+n+'(');
+  if (i < 0) { console.error(`FAIL: function ${n}() not found in app.js — the path linkifier is missing or renamed`); process.exit(1); }
+  let d=0,j=src.indexOf('{',i);
+  for(let k=j;k<src.length;k++){ if(src[k]==='{')d++; else if(src[k]==='}'){d--; if(!d){return src.slice(i,k+1);} } } };
+const esc = s => String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+const escJs = s => String(s).replace(/\\/g,'\\\\').replace(/'/g,"\\'");
+let peekSessionDir = '/Users/d/Projects/amux-gtm', peekSession='amux-gtm';
+const fn = new Function('esc','escJs','peekSessionDir','peekSession',
+  grab('_resolveOutputPath') + '\n' + grab('_linkifyPaths') + '\n return {_linkifyPaths,_resolveOutputPath};')
+  (esc, escJs, peekSessionDir, peekSession);
+
+let pass=0, fail=0;
+const t=(label,cond,extra='')=>{ if(cond){pass++;} else {fail++; console.log('FAIL:',label, extra);} };
+
+// (a) THE REPORTED SPECIMEN — a bare relative path, which the old regex could not match.
+let out = fn._linkifyPaths(esc('  Contacts are in customers/rothco/data/jewishlink-prospects.csv.'));
+t('(a) bare relative path is linked', out.includes('class="file-link"'), out);
+t('(a) full path captured', out.includes('customers/rothco/data/jewishlink-prospects.csv</span>'), out);
+t('(a) trailing sentence period left OUTSIDE the link', out.endsWith('</span>.'), out);
+t('(a) resolves against the session cwd for the title',
+  out.includes('/Users/d/Projects/amux-gtm/customers/rothco/data/jewishlink-prospects.csv'), out);
+
+// (b) absolute and ./ forms still work
+t('(b) absolute', fn._linkifyPaths(esc('see /Users/d/x/y.py now')).includes('file-link'));
+t('(b) dot-slash', fn._linkifyPaths(esc('see ./src/main.rs now')).includes('file-link'));
+t('(b) .md gets md-link', fn._linkifyPaths(esc('see docs/plan.md now')).includes('md-link'));
+t('(b) :linenum kept in the label', fn._linkifyPaths(esc('at src/a/b.rs:42 here')).includes('b.rs:42</span>'));
+
+// (c) THE CONTROLS — must NOT link.
+const url = '<a href="https://h.io/a/b.js" target="_blank">https://h.io/a/b.js</a>';
+t('(c) existing anchor untouched', fn._linkifyPaths(url) === url, fn._linkifyPaths(url));
+t('(c) no link inside tag attributes',
+  !fn._linkifyPaths('<span title="a/b.css">hi</span>').includes('file-link'),
+  fn._linkifyPaths('<span title="a/b.css">hi</span>'));
+t('(c) prose with a slash but no extension is not a path',
+  !fn._linkifyPaths(esc('use and/or here')).includes('file-link'));
+t('(c) a bare filename with no slash is not linked',
+  !fn._linkifyPaths(esc('open report.csv now')).includes('file-link'));
+t('(c) a version number is not a path',
+  !fn._linkifyPaths(esc('bumped to 0.9.665 today')).includes('file-link'));
+
+// (d) escaping: a quote in the path must not break the onclick
+// A path containing a quote would break out of the inline onclick, so it must
+// FAIL SAFE (not linked) rather than be linked unsafely.
+const tricky = fn._linkifyPaths(esc("it's in a/b'c.txt ok"));
+t('(d) quoted path fails safe: not linked, no raw quote injected',
+  !tricky.includes('file-link'), tricky);
+// And prose apostrophes must not glue onto a neighbouring path.
+const prose = fn._linkifyPaths(esc("it's in data/x.csv ok"));
+t('(d) prose apostrophe does not break a real path', prose.includes('data/x.csv</span>'), prose);
+
+// (e) resolution
+t('(e) absolute stays absolute', fn._resolveOutputPath('/a/b.txt') === '/a/b.txt');
+t('(e) relative joins cwd', fn._resolveOutputPath('a/b.txt') === '/Users/d/Projects/amux-gtm/a/b.txt');
+t('(e) ./ stripped', fn._resolveOutputPath('./a/b.txt') === '/Users/d/Projects/amux-gtm/a/b.txt');
+t('(e) linenum stripped for the API', fn._resolveOutputPath('a/b.rs:42') === '/Users/d/Projects/amux-gtm/a/b.rs');
+
+// (g) No session cwd => a relative path is NOT linked. Rendering a link we
+// cannot resolve would be text that looks clickable and does nothing, which is
+// the failure this file's OSC-8 comment already records. An ABSOLUTE path needs
+// no cwd and must still link.
+const noCwd = new Function('esc','escJs','peekSessionDir','peekSession',
+  grab('_resolveOutputPath') + '\n' + grab('_linkifyPaths') + '\n return {_linkifyPaths};')
+  (esc, escJs, '', '');
+t('(g) relative path not linked without a session cwd',
+  !noCwd._linkifyPaths(esc('see customers/rothco/x.csv now')).includes('file-link'),
+  noCwd._linkifyPaths(esc('see customers/rothco/x.csv now')));
+t('(g) absolute path still linked without a session cwd',
+  noCwd._linkifyPaths(esc('see /Users/d/x/y.py now')).includes('file-link'));
+
+// THE WIRING, which is the half that was actually broken before: a perfect
+// linkifier that no render path calls is what shipped for months. Assert the
+// peek pipeline actually runs it.
+t('(f) _peekHtml exists and calls _linkifyPaths',
+  /function _peekHtml\([\s\S]{0,200}?_linkifyPaths\(/.test(src),
+  'the peek pipeline does not call _linkifyPaths');
+t('(f) no peek call site bypasses the shared pipeline',
+  !/highlightPrompts\(ansiToHtml\(/.test(src),
+  'a render site still spells the chain out and so skips path linkification');
+
+console.log(`\n_linkifyPaths: ${pass} passed, ${fail} failed`);
+process.exit(fail?1:0);


### PR DESCRIPTION
Reported with a screenshot of peek output reading:

```
  Contacts are in customers/rothco/data/jewishlink-prospects.csv.
```

…where the path is plain, dead text.

## Two defects, and the second is why the first stayed invisible

**1. `linkifyOutput` had zero callers.** It was written for exactly this surface — its `.file-link` / `.md-link` classes are styled under `.overlay-body`, which is precisely `#peek-body`'s class — and was never wired into the render pipeline. So every file path in every session's output has always rendered as dead text.

**2. It could not have matched the reported case anyway.** Its regex required a leading `/` or `./`. Output written from a worker's own cwd naturally says `customers/rothco/data/x.csv` — a **bare relative path**.

So it was deleted and replaced rather than wired up.

## What's there now

| | |
|---|---|
| `_linkifyPaths()` | Runs on **already-escaped** HTML, so it composes after the URL/OSC-8 linkification `ansiToHtml` already did, using the same `(?![^<]*>)` tail-guard as `_linkifyUrls`. The boundary char is captured and re-emitted rather than matched by a lookbehind, keeping it portable for iOS Safari. |
| `_resolveOutputPath()` | Joins a relative path onto the session's cwd. |
| `_openPathFromOutput()` | Opens the **file browser** at the containing folder, with the session attached so its shortcuts and the "back to \<session\>" affordance work. |
| `_peekHtml()` | **One** pipeline. The four render sites each spelled the chain out — which is how a stage gets half-wired in the first place. A test now fails if any site starts bypassing it. |

**A relative path is not linked when there is no session cwd to resolve it against.** Linking it anyway would render text that looks clickable and does nothing — the exact failure this same file already records for its OSC-8 hyperlinks. Found by the live browser check below, not by reading the code.

Also deliberately not linked: a path containing a quote (it would break out of the inline `onclick`, so it fails safe), prose like `and/or`, bare filenames with no slash, and version numbers like `0.9.665`.

## Verified in a real browser, not just in unit tests

The functions were installed into the running dashboard and driven through a real DOM click:

```
link element   true, text = customers/rothco/data/jewishlink-prospects.csv
title          Open in the file browser: /Users/…/amux-gtm/customers/rothco/data/jewishlink-prospects.csv
cursor/color   pointer / rgb(5,80,174)      ← the existing CSS does apply here
click ->       openExplore("/Users/…/amux-gtm/customers/rothco/data", "amux-gtm")
page errors    none
```

That run is also what caught the unresolvable-relative-path case above — the first attempt happily produced a link that could not go anywhere.

## Test

`scripts/test-linkify-paths.mjs`, 23 assertions. It loads the **shipped** functions out of `app.js` rather than restating the regex — a copy of the pattern would pass while the pipeline stayed unwired, which is precisely the defect being fixed.

**Verified to fail against `origin/main`'s `app.js`**: exit 1, `function _resolveOutputPath() not found in app.js`.

Two assertions are about the **wiring** rather than the matching, for the same reason:

```js
t('(f) _peekHtml exists and calls _linkifyPaths', …)
t('(f) no peek call site bypasses the shared pipeline', …)
```

Wired into `checks.yml`. `spa-lint`: 0 errors. `APP_VER` + sw.js `CACHE` bumped together, `0.9.667` → `0.9.668`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx
