### PR TITLE
fix(ci): unbreak main's clippy, and let the tmux audit test the exemption

### DIFF
--- a/crates/amux-server/src/runtime_jobs/scheduler.rs
+++ b/crates/amux-server/src/runtime_jobs/scheduler.rs
@@ -2303,7 +2303,7 @@ mod tests {
             RunOutcome::ShellError { note: "exit 1".into() },
         ] {
             assert!(o.lost(), "{o:?} reached nobody and is not pending");
-            assert!(should_warn_undelivered(&[o.clone()]), "{o:?} must still warn");
+            assert!(should_warn_undelivered(std::slice::from_ref(&o)), "{o:?} must still warn");
         }
         // Nothing attempted still reads as silence — unchanged behaviour.
         assert!(should_warn_undelivered(&[]));

--- a/crates/amux-server/tests/tmux_target_audit.rs
+++ b/crates/amux-server/tests/tmux_target_audit.rs
@@ -49,6 +49,80 @@ fn normalise(expr: &str) -> String {
     e.trim().to_string()
 }
 
+/// Walk one source text and return every non-exact `-t` target as
+/// `(byte offset of the "-t" literal, normalised target expression)`.
+///
+/// AEAB-23. This loop used to exist TWICE: here, over real files, and again
+/// inline inside `the_audit_detects_a_planted_non_exact_target`, over a string
+/// fixture. Two copies meant the test could not observe a change to the real
+/// scanner — and one had already slipped through: 8db43264 added the
+/// `Command::new("x")` exemption below and nothing tested it, because the
+/// planted test simply did not contain that logic and passed identically with
+/// or without it.
+///
+/// Simulating what you believe a function does cannot catch that function doing
+/// something else (ethos rule 7). One implementation, both callers.
+///
+/// Pure text-in/values-out so a test can drive it with a fixture; the file
+/// walking and message formatting stay in `offenders()`.
+fn scan(src: &str) -> Vec<(usize, String)> {
+    let mut found = Vec::new();
+    let mut from = 0usize;
+    while let Some(rel) = src[from..].find("\"-t\"") {
+        let at = from + rel;
+        from = at + 4;
+        // Skip a `-t` that belongs to a NON-tmux external command in the
+        // SAME statement — e.g. `Command::new("touch").args(["-t", stamp,…])`
+        // setting a file mtime in a #[cfg(test)] module (email.rs:1330).
+        // Only tmux's -t names a session/pane; `touch -t` is a timestamp.
+        // Real tmux -t calls go through the tmux()/self.run() helpers and
+        // carry no Command::new in the statement, so they are unaffected;
+        // a literal `Command::new("tmux")` is still audited (name == tmux).
+        let before = &src[..at];
+        let stmt_start = before
+            .rfind([';', '{', '}'])
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        if let Some(cn) = before[stmt_start..].rfind("Command::new(") {
+            let after = &before[stmt_start + cn + "Command::new(".len()..];
+            let name = after.trim_start().strip_prefix('"').and_then(|s| s.split('"').next());
+            if matches!(name, Some(n) if n != "tmux") {
+                continue;
+            }
+        }
+        // Skip the separator after the literal, then take the argument up
+        // to the next `,` / `]` / `)` at this nesting level.
+        let rest = &src[from..];
+        let Some(comma) = rest.find(',') else { continue };
+        let tail = &rest[comma + 1..];
+        let mut depth = 0i32;
+        let mut end = tail.len();
+        for (i, c) in tail.char_indices() {
+            match c {
+                '(' | '[' | '{' => depth += 1,
+                ')' | ']' | '}' => {
+                    if depth == 0 {
+                        end = i;
+                        break;
+                    }
+                    depth -= 1;
+                }
+                ',' if depth == 0 => {
+                    end = i;
+                    break;
+                }
+                _ => {}
+            }
+        }
+        let expr = normalise(&tail[..end]);
+        if ALLOWED.contains(&expr.as_str()) {
+            continue;
+        }
+        found.push((at, expr));
+    }
+    found
+}
+
 fn offenders() -> Vec<String> {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
     let mut files = Vec::new();
@@ -58,57 +132,7 @@ fn offenders() -> Vec<String> {
     let mut bad = Vec::new();
     for f in files {
         let src = std::fs::read_to_string(&f).unwrap_or_default();
-        let mut from = 0usize;
-        while let Some(rel) = src[from..].find("\"-t\"") {
-            let at = from + rel;
-            from = at + 4;
-            // Skip a `-t` that belongs to a NON-tmux external command in the
-            // SAME statement — e.g. `Command::new("touch").args(["-t", stamp,…])`
-            // setting a file mtime in a #[cfg(test)] module (email.rs:1330).
-            // Only tmux's -t names a session/pane; `touch -t` is a timestamp.
-            // Real tmux -t calls go through the tmux()/self.run() helpers and
-            // carry no Command::new in the statement, so they are unaffected;
-            // a literal `Command::new("tmux")` is still audited (name == tmux).
-            let before = &src[..at];
-            let stmt_start = before
-                .rfind([';', '{', '}'])
-                .map(|i| i + 1)
-                .unwrap_or(0);
-            if let Some(cn) = before[stmt_start..].rfind("Command::new(") {
-                let after = &before[stmt_start + cn + "Command::new(".len()..];
-                let name = after.trim_start().strip_prefix('"').and_then(|s| s.split('"').next());
-                if matches!(name, Some(n) if n != "tmux") {
-                    continue;
-                }
-            }
-            // Skip the separator after the literal, then take the argument up
-            // to the next `,` / `]` / `)` at this nesting level.
-            let rest = &src[from..];
-            let Some(comma) = rest.find(',') else { continue };
-            let tail = &rest[comma + 1..];
-            let mut depth = 0i32;
-            let mut end = tail.len();
-            for (i, c) in tail.char_indices() {
-                match c {
-                    '(' | '[' | '{' => depth += 1,
-                    ')' | ']' | '}' => {
-                        if depth == 0 {
-                            end = i;
-                            break;
-                        }
-                        depth -= 1;
-                    }
-                    ',' if depth == 0 => {
-                        end = i;
-                        break;
-                    }
-                    _ => {}
-                }
-            }
-            let expr = normalise(&tail[..end]);
-            if ALLOWED.contains(&expr.as_str()) {
-                continue;
-            }
+        for (at, expr) in scan(&src) {
             let line = src[..at].matches('\n').count() + 1;
             bad.push(format!(
                 "{}:{line}: tmux -t target `{expr}` is not one of {ALLOWED:?} \
@@ -138,44 +162,16 @@ fn every_tmux_target_uses_the_exact_match_helpers() {
 #[test]
 fn the_audit_detects_a_planted_non_exact_target() {
     // Same text shape the scanner walks in a real source file, including the
-    // prefix-matching target that motivated the rule.
+    // prefix-matching target that motivated the rule. Drives the SHIPPED `scan`
+    // rather than a copy of it (AEAB-23) — this test used to re-implement the
+    // loop inline, which is why the `Command::new` exemption below went in
+    // untested.
     let planted = r#"
         let _ = tmux(&["pipe-pane", "-t", &format!("amux-{name}"), &cmd]).await;
         let _ = tmux(&["send-keys", "-t", "amux-amux", "Enter"]).await;
         let _ = tmux(&["kill-session", "-t", &stq]).await;
     "#;
-    let mut found = Vec::new();
-    let mut from = 0usize;
-    while let Some(rel) = planted[from..].find("\"-t\"") {
-        let at = from + rel;
-        from = at + 4;
-        let rest = &planted[from..];
-        let Some(comma) = rest.find(',') else { continue };
-        let tail = &rest[comma + 1..];
-        let mut depth = 0i32;
-        let mut end = tail.len();
-        for (i, c) in tail.char_indices() {
-            match c {
-                '(' | '[' | '{' => depth += 1,
-                ')' | ']' | '}' => {
-                    if depth == 0 {
-                        end = i;
-                        break;
-                    }
-                    depth -= 1;
-                }
-                ',' if depth == 0 => {
-                    end = i;
-                    break;
-                }
-                _ => {}
-            }
-        }
-        let expr = normalise(&tail[..end]);
-        if !ALLOWED.contains(&expr.as_str()) {
-            found.push(expr);
-        }
-    }
+    let found: Vec<String> = scan(planted).into_iter().map(|(_, e)| e).collect();
     assert_eq!(
         found.len(),
         2,
@@ -183,4 +179,58 @@ fn the_audit_detects_a_planted_non_exact_target() {
     );
     assert!(found.iter().any(|f| f.contains("format!")), "missed the format! target: {found:?}");
     assert!(found.iter().any(|f| f.contains("\"amux-amux\"")), "missed the literal prefix target: {found:?}");
+}
+
+/// The `Command::new("x")` exemption (8db43264), in BOTH directions.
+///
+/// It shipped untested: the planted test above re-implemented the scanner, so
+/// nothing exercised the exemption at all. It is the kind of change that is easy
+/// to get subtly wrong in the expensive direction — an exemption that is a shade
+/// too broad silences the guard while leaving `main` green, which is
+/// indistinguishable from the guard working.
+///
+/// So each case below asserts a different half:
+///   - `touch -t` must be exempt          (the false positive that failed CI)
+///   - `Command::new("tmux")` must NOT be (or the fix deleted the guard)
+///   - helper-invoked tmux must NOT be    (the fail-safe: nothing to attribute)
+#[test]
+fn the_non_tmux_exemption_silences_touch_but_never_tmux() {
+    // The real specimen, reduced from integrations/email.rs. `touch -t` is a
+    // timestamp, not a pane; flagging it failed main and made every open PR
+    // inherit a red check.
+    let touch = r#"
+        let set = |name: &str, stamp: &str| {
+            std::process::Command::new("touch")
+                .args(["-t", stamp, tok.join(format!("{name}.json")).to_str().unwrap()])
+                .status()
+                .unwrap();
+        };
+    "#;
+    assert!(scan(touch).is_empty(), "touch -t is a timestamp, not a pane: {:?}", scan(touch));
+
+    // CONTROL. Same shape, program `tmux`: still an offender.
+    let tmux_cmd = r#"
+        std::process::Command::new("tmux")
+            .args(["send-keys", "-t", "amux-amux", "Enter"])
+            .status()
+            .unwrap();
+    "#;
+    let f: Vec<String> = scan(tmux_cmd).into_iter().map(|(_, e)| e).collect();
+    assert_eq!(f.len(), 1, "a literal Command::new(\"tmux\") target must still be flagged: {f:?}");
+    assert!(f[0].contains("amux-amux"), "wrong expression captured: {f:?}");
+
+    // FAIL-SAFE. api/metrics.rs's real shape: tmux reached through a helper, so
+    // there is no literal program to attribute. Absent positive evidence the site
+    // stays audited — this is the case a broader exemption would silently lose.
+    let helper = r#"
+        let _ = cmd_output("tmux", &["list-panes", "-t", "amux-amux", "-F", "x"]);
+    "#;
+    assert_eq!(scan(helper).len(), 1, "a helper-invoked tmux target must stay audited");
+
+    // And an ALLOWED target reached the same way is still allowed, so the guard
+    // is discriminating on the expression rather than on the call shape.
+    let ok = r#"
+        let _ = cmd_output("tmux", &["list-panes", "-t", &pt, "-F", "x"]);
+    "#;
+    assert!(scan(ok).is_empty(), "pane_target() output must pass: {:?}", scan(ok));
 }


### PR DESCRIPTION
Two things, and **the first is urgent: main is red and it's my fault.**

## 1. `clippy (deny warnings)` fails on main as of `f0be7a46` (my #107 merge)

```
warning: unnecessary use of `clone` to create a slice from a reference
    --> crates/amux-server/src/runtime_jobs/scheduler.rs:2306:45
```

One line: `&[o.clone()]` → `std::slice::from_ref(&o)`.

**Why it got through:** I verified with `cargo clippy -p amux-server --lib`. CI runs `cargo clippy --workspace --all-targets -- -D warnings`. The lint is in a **test**, which `--lib` never compiles. I checked a narrower surface than the gate does and read the green as if it meant the same thing.

Verified here with CI's exact command rather than a convenient shorthand.

## 2. AEAB-23 — the planted-offender test re-implemented the scanner

`offenders()` and `the_audit_detects_a_planted_non_exact_target` held two copies of the same ~30-line loop, so the test could not observe a change to the real scanner.

Extracted `scan(src) -> Vec<(usize, String)>`, used by both. **The exemption logic and its comment are 8db43264's, moved verbatim** — a test-only refactor with no behaviour change.

### The card overstated this, and I'm correcting it

I wrote that "NOTHING tests" the exemption. Not quite. `every_tmux_target_uses_the_exact_match_helpers` covers the narrow direction **incidentally** — remove the exemption and it fails, because `email.rs` really does contain a `touch -t`. That coverage is accidental (it evaporates the moment that unrelated file changes) but it isn't nothing.

**The real hole is the other direction, and it's the one that matters.** Measured, not argued — widen the exemption so it swallows tmux too (`if matches!(name, Some(_n))`):

| | result |
|---|---|
| against **main's** tests | `2 passed, 0 failed` — guard fully disabled, CI green |
| against **these** tests | `1 failed` — caught |

An exemption a shade too broad silences the guard while leaving main green, which is indistinguishable from the guard working. That's the expensive direction, and main could not see it.

So `the_non_tmux_exemption_silences_touch_but_never_tmux` asserts all three:

- `touch -t` is exempt — the false positive that failed CI
- a literal `Command::new("tmux")` is **still flagged** — or the fix deleted the guard
- a **helper-invoked** tmux target still audited — `api/metrics.rs`'s real `cmd_output("tmux", …)` shape, where there's no literal program to attribute. This is the fail-safe case a broader exemption loses first.

## Verification — CI's exact commands, all three

```
cargo check --workspace --all-targets            clean
cargo clippy --workspace --all-targets -D warnings   exit 0
cargo test --workspace                           39 result lines, 0 failed
tmux_target_audit                                3 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx
