### PR TITLE
fix(rules): warn when a diverged checkout will strand a frustrations entry

### DIFF
--- a/.claude/rules/frustrations.md
+++ b/.claude/rules/frustrations.md
@@ -5,6 +5,27 @@ notice that misattributes, a gate you cannot satisfy honestly, a probe that cann
 express the answer, a nudge that fires forever — **append an entry to
 `frustrations.md` at the repo root.**
 
+**"The repo root" means the checkout that can actually PUSH.** On a machine with
+more than one clone this is not a pedantic distinction, it is the whole value of
+the file: on 2026-08-17 four entries were appended to a checkout that was ~1000
+commits behind with unpushed local commits and an hourly sync job that had failed
+80+ runs. That copy held 25 entries; the real one held 124. The appends
+SUCCEEDED — no error, nothing to notice — and reached nobody. The argument this
+file exists to make is that one frustration is a complaint and a cluster is an
+argument; a cluster only forms in the file everyone reads.
+
+So before appending, confirm the checkout is not stranded:
+
+```bash
+git rev-list --count origin/main..HEAD   # unpushed commits here
+git rev-list --count HEAD..origin/main   # how far behind
+```
+
+If BOTH are non-zero the checkout has diverged, cannot fast-forward, and nothing
+will carry your entry upstream — append to a clone that is current instead. The
+SessionStart freshness hook now says this out loud when it applies, because a
+rule that only asks you to remember is the kind ethos rule 6 warns about.
+
 This is not a diary. It is the input to deciding what to fix next, so it has to be
 greppable and it has to be honest about cost.
 

--- a/.claude/session-freshness.sh
+++ b/.claude/session-freshness.sh
@@ -41,6 +41,7 @@ if git remote get-url origin >/dev/null 2>&1; then
   base="$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo origin/main)"
   if git rev-parse --verify -q "$base" >/dev/null 2>&1; then
     behind="$(git rev-list --count "HEAD..$base" 2>/dev/null || echo 0)"
+    ahead="$(git rev-list --count "$base..HEAD" 2>/dev/null || echo 0)"
     if [ "${behind:-0}" -gt 0 ]; then
       # Name the files that actually matter here, not just a number: "110
       # commits behind" reads as bookkeeping, "crates/ changed upstream"
@@ -64,6 +65,30 @@ if git remote get-url origin >/dev/null 2>&1; then
       [ -n "$hot" ] && out+=" — including: ${hot}"
       out+=$'\n'
       out+=$'    git pull --rebase origin main   (review first: this checkout is SHARED)\n'
+    fi
+
+    # ── Axis 1b: DIVERGED, so append-only shared files written here strand ───
+    #
+    # Behind alone is recoverable: pull, and your work still reaches origin.
+    # Behind AND ahead is not — the checkout cannot fast-forward, so the hourly
+    # sync job refuses (correctly, it must never rewrite a shared tree) and
+    # nothing carries anything here upstream until a human reconciles it.
+    #
+    # The reason this is worth its own line rather than folding into the count
+    # above: the failure is SILENT AND WRITE-SHAPED. A stale checkout announces
+    # itself the moment you pull. Appending to `frustrations.md` here succeeds,
+    # prints nothing, and reaches nobody. On 2026-08-17 four entries went in
+    # this way — that copy held 25 entries while origin held 124 — and it was
+    # noticed only by chance, days later (AEAB-18).
+    #
+    # Names frustrations.md specifically because it is the append-only shared
+    # file a session is INSTRUCTED to write on its own initiative, so it is the
+    # one that gets stranded without anybody choosing to risk it.
+    if [ "${behind:-0}" -gt 0 ] && [ "${ahead:-0}" -gt 0 ]; then
+      out+="  - this checkout has DIVERGED (${ahead} unpushed, ${behind} behind ${base})"$'\n'
+      out+=$'    it cannot fast-forward, so nothing here reaches origin until a human reconciles it\n'
+      out+=$'    do NOT append to frustrations.md here — the write succeeds and reaches nobody\n'
+      out+=$'    log friction in a clone that is current instead (.claude/rules/frustrations.md)\n'
     fi
   fi
 fi

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -139,3 +139,19 @@ jobs:
         run: |
           set -uo pipefail
           node scripts/test-linkify-paths.mjs
+
+      # AEAB-18. The freshness hook is a SHELL script outside crates/, so
+      # rust.yml's path filter never sees it. It also guards a silent,
+      # write-shaped failure — appending to a shared append-only file from a
+      # diverged checkout succeeds and reaches nobody — which means the only way
+      # to know the warning still fires is to fire it. The test builds real git
+      # repos and runs the shipped hook against them.
+      #
+      # Its control cases matter as much as its positive one: a hook that warned
+      # unconditionally would pass the incident case while being pure noise, and
+      # the hook's own header names silence-when-current as the reason it gets
+      # read at all.
+      - name: SessionStart freshness hook (AEAB-18)
+        run: |
+          set -uo pipefail
+          ./scripts/test-session-freshness.sh

--- a/scripts/test-session-freshness.sh
+++ b/scripts/test-session-freshness.sh
@@ -24,29 +24,55 @@ HOOK="$(pwd)/.claude/session-freshness.sh"
 PASS=0; FAIL=0
 TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
 export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t
+# Pin the default branch instead of inheriting it. The first cut of this file did
+# not, and passed locally (init.defaultBranch=main) while failing 4 assertions in
+# CI, where git has no default set and falls back to `master`: the bare repo's
+# HEAD was master, the pushes created main, and the clone ended up tracking
+# nothing — so the hook found no upstream and printed NOTHING. The failure then
+# read as "the hook is broken" when the harness was.
+export GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=init.defaultBranch GIT_CONFIG_VALUE_0=main
 
 # Build: a bare origin, a clone, and the hook installed inside the clone.
 # `n_behind` commits land on origin after the clone; `n_ahead` land locally.
 mk() { # $1 name  $2 n_ahead  $3 n_behind
   local d="$TMP/$1"
-  git init -q --bare "$d/origin.git"
+  git init -q --bare -b main "$d/origin.git"
   git clone -q "$d/origin.git" "$d/work" 2>/dev/null
   ( cd "$d/work"
+    git checkout -q -B main
     mkdir -p .claude
     cp "$HOOK" .claude/session-freshness.sh
-    echo seed > seed.txt; git add -A; git commit -qm seed; git push -q origin HEAD:main
-    git branch -q -M main; git branch -q --set-upstream-to=origin/main main 2>/dev/null
+    echo seed > seed.txt; git add -A; git commit -qm seed
+    git push -q -u origin main
   )
   if [ "$3" -gt 0 ]; then   # commits that exist ONLY on origin
     git clone -q "$d/origin.git" "$d/other" 2>/dev/null
-    ( cd "$d/other"; for i in $(seq 1 "$3"); do echo "up$i" > "up$i.txt"; git add -A; git commit -qm "up$i"; done; git push -q origin HEAD:main )
+    ( cd "$d/other"; git checkout -q -B main origin/main
+      for i in $(seq 1 "$3"); do echo "up$i" > "up$i.txt"; git add -A; git commit -qm "up$i"; done
+      git push -q origin main )
   fi
   if [ "$2" -gt 0 ]; then   # commits that exist ONLY here
     ( cd "$d/work"; for i in $(seq 1 "$2"); do echo "loc$i" > "loc$i.txt"; git add -A; git commit -qm "loc$i"; done )
   fi
-  ( cd "$d/work"; git fetch -q origin 2>/dev/null; bash .claude/session-freshness.sh 2>&1 )
+  # HARNESS SELF-CHECK, before the hook is consulted at all. Without it a setup
+  # bug is indistinguishable from a hook bug — which is exactly how the CI
+  # failure above read. If the repo is not in the shape the case name claims,
+  # say SETUP and fail loudly rather than blaming the thing under test.
+  ( cd "$d/work"
+    git fetch -q origin 2>/dev/null
+    a=$(git rev-list --count origin/main..HEAD 2>/dev/null || echo x)
+    b=$(git rev-list --count HEAD..origin/main 2>/dev/null || echo x)
+    if [ "$a" != "$2" ] || [ "$b" != "$3" ]; then
+      echo "SETUP BROKEN for '$1': wanted ahead=$2 behind=$3, got ahead=$a behind=$b"
+      exit 0
+    fi
+    bash .claude/session-freshness.sh 2>&1
+  )
 }
 
+# A harness failure is not a test result. Surface it as its own failure so it can
+# never be mistaken for the hook misbehaving.
+setup_ok() { case "$2" in *"SETUP BROKEN"*) FAIL=$((FAIL+1)); echo "$2" | head -1; return 1;; esac; return 0; }
 says()  { case "$2" in *"$1"*) PASS=$((PASS+1));; *) FAIL=$((FAIL+1)); echo "FAIL: expected output to mention '$1'"; echo "  got: ${2:-<empty>}";; esac; }
 lacks() { case "$2" in *"$1"*) FAIL=$((FAIL+1)); echo "FAIL: output should NOT mention '$1'"; echo "  got: ${2:-<empty>}";; *) PASS=$((PASS+1));; esac; }
 

--- a/scripts/test-session-freshness.sh
+++ b/scripts/test-session-freshness.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# AEAB-18 — the SessionStart freshness hook must warn when THIS checkout has
+# diverged, because an append to a shared append-only file here reaches nobody.
+#
+# The failure being guarded is silent and write-shaped. A merely-stale checkout
+# announces itself the moment you pull. A DIVERGED one does not: appending to
+# frustrations.md succeeds, prints nothing, and never reaches origin, because the
+# hourly sync job refuses to fast-forward (correctly — it must not rewrite a
+# shared tree). On 2026-08-17 four entries went in that way; that copy held 25
+# entries while origin held 124, and it was noticed by chance days later.
+#
+# Every case builds REAL git repos and runs the SHIPPED hook as a subprocess, so
+# this exercises the actual dispatch path rather than a paraphrase of its logic.
+#
+# The (a) and (c)/(d) cases are the load-bearing ones: a hook that warned
+# unconditionally would satisfy (b) while being pure noise, and noise is how a
+# banner gets ignored — which the hook's own header calls out as the reason it
+# stays silent when everything is current.
+#
+# Exit 0 = all pass, 1 = a failure. Wired into .github/workflows/checks.yml.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+HOOK="$(pwd)/.claude/session-freshness.sh"
+PASS=0; FAIL=0
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t
+
+# Build: a bare origin, a clone, and the hook installed inside the clone.
+# `n_behind` commits land on origin after the clone; `n_ahead` land locally.
+mk() { # $1 name  $2 n_ahead  $3 n_behind
+  local d="$TMP/$1"
+  git init -q --bare "$d/origin.git"
+  git clone -q "$d/origin.git" "$d/work" 2>/dev/null
+  ( cd "$d/work"
+    mkdir -p .claude
+    cp "$HOOK" .claude/session-freshness.sh
+    echo seed > seed.txt; git add -A; git commit -qm seed; git push -q origin HEAD:main
+    git branch -q -M main; git branch -q --set-upstream-to=origin/main main 2>/dev/null
+  )
+  if [ "$3" -gt 0 ]; then   # commits that exist ONLY on origin
+    git clone -q "$d/origin.git" "$d/other" 2>/dev/null
+    ( cd "$d/other"; for i in $(seq 1 "$3"); do echo "up$i" > "up$i.txt"; git add -A; git commit -qm "up$i"; done; git push -q origin HEAD:main )
+  fi
+  if [ "$2" -gt 0 ]; then   # commits that exist ONLY here
+    ( cd "$d/work"; for i in $(seq 1 "$2"); do echo "loc$i" > "loc$i.txt"; git add -A; git commit -qm "loc$i"; done )
+  fi
+  ( cd "$d/work"; git fetch -q origin 2>/dev/null; bash .claude/session-freshness.sh 2>&1 )
+}
+
+says()  { case "$2" in *"$1"*) PASS=$((PASS+1));; *) FAIL=$((FAIL+1)); echo "FAIL: expected output to mention '$1'"; echo "  got: ${2:-<empty>}";; esac; }
+lacks() { case "$2" in *"$1"*) FAIL=$((FAIL+1)); echo "FAIL: output should NOT mention '$1'"; echo "  got: ${2:-<empty>}";; *) PASS=$((PASS+1));; esac; }
+
+MARK="do NOT append to frustrations.md here"
+
+# (a) CONTROL — current checkout: the hook must stay SILENT. Without this, a hook
+#     that printed the warning unconditionally would pass every other case.
+out=$(mk clean 0 0)
+if [ -z "$(printf '%s' "$out" | tr -d '[:space:]')" ]; then PASS=$((PASS+1));
+else FAIL=$((FAIL+1)); echo "FAIL: (a) a current checkout must produce NO output; got: $out"; fi
+
+# (b) THE INCIDENT — diverged (unpushed AND behind): must warn, and must say why.
+out=$(mk diverged 2 3)
+says "DIVERGED" "$out"
+says "$MARK" "$out"
+says "2 unpushed" "$out"
+lacks "reached nobody" "$out"   # the rationale belongs in the rule, not the banner
+
+# (c) Behind ONLY — recoverable by a pull, so the strand warning must NOT fire.
+#     It should still report the ordinary staleness line.
+out=$(mk behind 0 3)
+lacks "$MARK" "$out"
+lacks "DIVERGED" "$out"
+says "commit(s) behind" "$out"
+
+# (d) Ahead ONLY — ordinary in-flight work; a push still reaches origin.
+out=$(mk ahead 2 0)
+lacks "$MARK" "$out"
+lacks "DIVERGED" "$out"
+
+echo
+echo "test-session-freshness: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Four frustration entries were appended on 2026-08-17 to `~/Developer/amux` — a checkout ~1000 commits behind, with unpushed local commits and an hourly sync job that had failed 80+ runs. That copy held **25** entries; origin held **124**.

The appends **succeeded**. No error, nothing to notice. They reached nobody.

`.claude/rules/frustrations.md` says to append to "`frustrations.md` at the repo root", and `CLAUDE.md` lives in that same stale checkout. So for a session working there — the documented working directory — **the instruction is correct as written and produces an invisible write.**

## Why this is its own defect, not just "the checkout is stale"

A stale checkout announces itself the moment you pull. A **diverged** one swallows *writes* instead of blocking a *read*. So the entire premise of the file is quietly lost: one frustration is a complaint and a cluster is an argument, and a cluster only forms in the file everyone reads.

## Two halves, because either alone is weak

**1. The rule** now says "the repo root" means the checkout that can actually **push**, with the two `rev-list` commands to check it and the divergence condition spelled out.

**2. The SessionStart hook** gains a third axis and says it at the one moment it matters. A doc that only asks you to remember is exactly what ethos rule 6 warns about; the hook is where a session already looks.

It fires **only on divergence** (ahead *and* behind), never on merely-behind — that's recoverable by a pull, and a push still reaches origin, so warning there would be noise. The hook's own header names silence-when-current as the reason it gets read at all.

## Verified against the incident's own artifact

Run against `~/Developer/amux` right now:

```
  - this checkout has DIVERGED (8 unpushed, 1109 behind origin/main)
    it cannot fast-forward, so nothing here reaches origin until a human reconciles it
    do NOT append to frustrations.md here — the write succeeds and reaches nobody
    log friction in a clone that is current instead (.claude/rules/frustrations.md)
```

## Test

`scripts/test-session-freshness.sh` builds **real git repos** and runs the **shipped hook** against them. 10 assertions, **verified to fail 3/10 against `origin/main`'s hook**.

Its control cases carry the weight:

| case | expected |
|---|---|
| current checkout | **no output at all** |
| diverged (2 unpushed, 3 behind) | warns, names both counts |
| behind only | must **not** fire |
| ahead only | must **not** fire |

A hook that warned unconditionally would pass the incident case while being pure noise — and noise is how a banner stops being read.

Wired into `checks.yml`, since a shell script outside `crates/` is invisible to `rust.yml`'s path filter.

## Not fixed here — owner's call

The divergence itself (AMUX-49 / LR-1): now **8 unpushed commits and 81 consecutive sync failures**. This PR makes the consequence visible; it does not reconcile the tree, and reconciling a shared checkout is not an agent's decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx
