### PR TITLE
feat(build): announce when the auto-builder installs an off-main revision

### DIFF
--- a/.claude/session-freshness.sh
+++ b/.claude/session-freshness.sh
@@ -93,6 +93,36 @@ if git remote get-url origin >/dev/null 2>&1; then
   fi
 fi
 
+# ── Axis 1c: was the RUNNING SERVER built from an unmerged revision? ─────────
+#
+# AEAB-12. The rust auto-builder rebuilds whenever the BUILD SOURCE's local HEAD
+# moves, on any branch, and the server self-adopts within 5s. That permissiveness
+# is deliberate — this machine has survived weeks pinned to an unmerged fix
+# branch — but it means a commit made on a feature branch inside the build source
+# is serving the whole fleet about a minute later, with no CI and no review.
+#
+# On 2026-08-17 that ran for 9h42m unnoticed, while the same condition also
+# stopped the machine tracking upstream, so the daily update schedule silently did
+# nothing. Nothing looked wrong anywhere.
+#
+# The builder records what it installed; this reads it. Deliberately a REPORT, not
+# a refusal, and not a re-derivation: only the builder knows which tree it built,
+# and a second implementation guessing at it would be the drift this file keeps
+# finding. Fails open like everything else here — no file, unreadable, or garbage
+# means silence.
+PROV="${AMUX_RS_BUILD_PROVENANCE:-$HOME/.amux/rust-build-provenance.json}"
+if [ -r "$PROV" ]; then
+  prov_on_main=$(sed -n 's/.*"on_main":"\([^"]*\)".*/\1/p' "$PROV" 2>/dev/null)
+  prov_ref=$(sed -n 's/.*"ref":"\([^"]*\)".*/\1/p' "$PROV" 2>/dev/null)
+  prov_sha=$(sed -n 's/.*"sha":"\([^"]*\)".*/\1/p' "$PROV" 2>/dev/null)
+  if [ "${prov_on_main:-yes}" = "no" ]; then
+    out+="  - the RUNNING SERVER was built from an unmerged revision: ${prov_sha:0:9} on '${prov_ref:-?}'"$'\n'
+    out+=$'    it is the live build for the whole fleet, with no CI and no review behind it\n'
+    out+=$'    intentional pin? fine. accident? put the build source back on main —\n'
+    out+=$'    develop in a git worktree, never in the checkout the builder watches\n'
+  fi
+fi
+
 # ── Axis 2: does what is INSTALLED match this checkout? ──────────────────────
 # The repo copy is the source; install.sh copies it. Editing the repo alone
 # changes nothing that a session or the dashboard actually executes.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -151,7 +151,8 @@ jobs:
       # unconditionally would pass the incident case while being pure noise, and
       # the hook's own header names silence-when-current as the reason it gets
       # read at all.
-      - name: SessionStart freshness hook (AEAB-18)
+      - name: SessionStart freshness hook (AEAB-18) + build provenance (AEAB-12)
         run: |
           set -uo pipefail
           ./scripts/test-session-freshness.sh
+          ./scripts/test-build-provenance.sh

--- a/scripts/rust-auto-build.sh
+++ b/scripts/rust-auto-build.sh
@@ -87,8 +87,63 @@ echo $$ > "$LOCK/pid"
 last=$(cat "$STAMP" 2>/dev/null || echo "")
 [ "$head" = "$last" ] && exit 0
 
+# PROVENANCE (AEAB-12). This builder rebuilds whenever $REPO's local HEAD moves
+# and does not care whether HEAD is on main or on somebody's feature branch. The
+# server then self-adopts within 5s. That permissiveness is CORRECT and must stay:
+# this machine survived weeks deliberately pinned to an unmerged fix branch, and
+# "only build main" would delete the rollback mechanism.
+#
+# The defect is that a deliberate pin and an ACCIDENTAL feature branch are
+# byte-identical to the builder, and the accidental one is announced nowhere. On
+# 2026-08-17 a commit made on a branch inside this checkout was serving the whole
+# fleet 76 seconds later and stayed there 9h42m — no CI had run on it, no review —
+# while the machine also could not track upstream, so the daily update schedule
+# silently did nothing. Everything looked healthy the entire time.
+#
+# So: say it. NOT a refusal, a fact, written where consumers can find it.
+#
+# The predicate is "HEAD is contained in main OR origin/main". Checking only
+# origin/main would false-positive right after a merge, because this script
+# deliberately does not fetch (it must not reach the network on a 60s timer) and
+# the local remote-tracking ref lags. Local `main` moves on the merge itself, so
+# the pair covers both orders.
+on_main=no
+if git -C "$REPO" merge-base --is-ancestor HEAD main 2>/dev/null \
+   || git -C "$REPO" merge-base --is-ancestor HEAD origin/main 2>/dev/null; then
+  on_main=yes
+fi
+head_ref=$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "?")
+# The sha reported is the one actually BUILT — the worktree below is created from
+# `rev-parse HEAD`. `$head` is a different thing: the last commit that touched the
+# build inputs, used as the rebuild stamp key. Reporting the stamp key here would
+# name a commit that is not what is running.
+built_sha=$(git -C "$REPO" rev-parse HEAD 2>/dev/null || echo "$head")
+# A file rather than only a log line, because ~/.amux/logs/rust-auto-build.log is
+# not somewhere anyone looks — a tag in a store the reader never opens is the same
+# failure as no tag. The SessionStart freshness hook reads this and says it at the
+# one moment a session is about to build on it.
+printf '{"sha":"%s","ref":"%s","on_main":"%s","built_at":"%s"}\n' \
+  "$built_sha" "$head_ref" "$on_main" "$(date '+%F %T')" \
+  > "${AMUX_RS_BUILD_PROVENANCE:-$HOME/.amux/rust-build-provenance.json}" 2>/dev/null || true
+
+# A seam so the predicate above is TESTABLE against real repos rather than
+# restated in a test that could not notice it changing. Everything before this
+# point is cheap and touches no network; a cargo build is neither, which is why
+# scripts/test-build-provenance.sh stops here instead of asserting on a copy of
+# the logic.
+if [ "${AMUX_RS_BUILD_PROVENANCE_ONLY:-}" = "1" ]; then
+  [ "$on_main" = "yes" ] || echo "OFF-MAIN $head_ref $built_sha"
+  exit 0
+fi
+
 {
   echo "== $(date '+%F %T') building $head (was: ${last:-none})"
+  if [ "$on_main" != "yes" ]; then
+    echo "== !! OFF-MAIN: $built_sha is on '$head_ref', which is not contained in main."
+    echo "==    Installing it makes it the live build for the WHOLE FLEET within ~5s,"
+    echo "==    with no CI and no review. Intentional pin? fine. Accident? put"
+    echo "==    $REPO back on main — develop in a git worktree, not the build source."
+  fi
   # Build from a clean, committed snapshot: a worktree of HEAD, so nobody's
   # uncommitted edits (or a mid-edit broken tree) can poison the deploy.
   WORK=$(mktemp -d /tmp/amux-rs-build.XXXXXX)

--- a/scripts/test-build-provenance.sh
+++ b/scripts/test-build-provenance.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# AEAB-12 — the auto-builder must SAY when it is about to install a revision that
+# is not on main.
+#
+# It rebuilds whenever the build source's local HEAD moves, on any branch, and the
+# server self-adopts within ~5s. That permissiveness is deliberate and stays — this
+# machine has survived weeks pinned to an unmerged fix branch. The defect is that a
+# deliberate pin and an ACCIDENTAL feature branch were byte-identical to the
+# builder. On 2026-08-17 a commit made on a branch inside the build source served
+# the whole fleet for 9h42m with no CI and no review, while the same condition
+# stopped the machine tracking upstream. Nothing looked wrong anywhere.
+#
+# Runs the SHIPPED script (via its provenance-only seam, which stops before the
+# cargo build) against REAL git repos, so this exercises the real predicate rather
+# than a restatement of it.
+#
+# The on-main cases are the load-bearing ones: a builder that shouted on every
+# build would be ignored within a day, and the whole value is that the line only
+# appears when something is actually off.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+BUILDER="$(pwd)/scripts/rust-auto-build.sh"
+PASS=0; FAIL=0
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t
+# Pin the default branch — CI has none and falls back to `master`, which silently
+# changed what these repos looked like (the mistake test-session-freshness.sh made).
+export GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=init.defaultBranch GIT_CONFIG_VALUE_0=main
+
+# $1 = case name, $2 = shell to run inside the repo after the base commit.
+run_case() {
+  local d="$TMP/$1"
+  git init -q -b main "$d"
+  ( cd "$d"
+    # Cargo.toml matters: the builder keys its rebuild stamp on the last commit
+    # touching crates/ | Cargo.toml | Cargo.lock, and exits early when there is
+    # none. A fixture without it exercises nothing (the first cut of this file
+    # did exactly that and reported 7 failures against working code).
+    mkdir -p crates; echo '[workspace]' > Cargo.toml; echo x > crates/f.rs
+    git add -A; git commit -qm base
+    eval "$2"
+  ) >/dev/null 2>&1
+  AMUX_RS_BUILD_PROVENANCE_ONLY=1 \
+  AMUX_REPO="$d" \
+  AMUX_RS_BUILD_STAMP="$d/.stamp" \
+  AMUX_RS_BUILD_LOG="$d/.log" \
+  AMUX_RS_BUILD_LOCK="$d/.lock" \
+  AMUX_RS_BUILD_PROVENANCE="$d/prov.json" \
+  bash "$BUILDER" >"$d/out" 2>&1
+  cat "$d/prov.json" 2>/dev/null
+}
+
+field() { sed -n "s/.*\"$1\":\"\([^\"]*\)\".*/\1/p" <<<"$2"; }
+is() { if [ "$2" = "$3" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); echo "FAIL: $1 — wanted '$3', got '$2'"; fi; }
+
+# (a) CONTROL — on main. Must record on_main=yes and say nothing.
+p=$(run_case onmain 'true')
+is "(a) on main -> on_main"  "$(field on_main "$p")" "yes"
+is "(a) on main -> ref"      "$(field ref "$p")"     "main"
+
+# (b) THE INCIDENT — a feature branch in the build source.
+p=$(run_case feature 'git checkout -q -b fix/my-thing; echo y > crates/g.rs; git add -A; git commit -qm work')
+is "(b) feature branch -> on_main" "$(field on_main "$p")" "no"
+is "(b) feature branch -> ref"     "$(field ref "$p")"     "fix/my-thing"
+
+# (c) A branch whose commits are ALREADY on main (e.g. just merged) is NOT off-main.
+#     Warning here would train people to ignore the line.
+p=$(run_case merged 'git checkout -q -b spur; git checkout -q main; git merge -q --ff-only spur; git checkout -q spur')
+is "(c) branch contained in main -> on_main" "$(field on_main "$p")" "yes"
+
+# (d) Detached HEAD at a commit on main — the deliberate-pin shape after a
+#     fast-forward — must also read as on main.
+p=$(run_case detached 'git checkout -q --detach HEAD')
+is "(d) detached at a main commit -> on_main" "$(field on_main "$p")" "yes"
+
+# (e) The human-facing line appears only in the off-main case.
+grep -q 'OFF-MAIN' "$TMP/feature/out" && PASS=$((PASS+1)) || { FAIL=$((FAIL+1)); echo "FAIL: (e) off-main case printed no OFF-MAIN line"; }
+grep -q 'OFF-MAIN' "$TMP/onmain/out"  && { FAIL=$((FAIL+1)); echo "FAIL: (e) on-main case must stay quiet"; } || PASS=$((PASS+1))
+
+echo
+echo "test-build-provenance: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/test-session-freshness.sh
+++ b/scripts/test-session-freshness.sh
@@ -103,6 +103,38 @@ out=$(mk ahead 2 0)
 lacks "$MARK" "$out"
 lacks "DIVERGED" "$out"
 
+# ---------------------------------------------------------------------------
+# (e) AEAB-12 — the running server's BUILD PROVENANCE. The builder records what
+#     it installed; the hook reports it. A session should not be able to be
+#     looking at a fleet-wide deploy of somebody's scratch branch without being
+#     told, which is what happened for 9h42m on 2026-08-17.
+#
+#     The on_main=yes and missing-file cases are the load-bearing ones: this line
+#     is only worth having if it stays absent in the normal case.
+# ---------------------------------------------------------------------------
+PROVMARK="was built from an unmerged revision"
+prov_run() { # $1 = file contents, or "" for no file
+  local d="$TMP/prov"; rm -rf "$d"; mkdir -p "$d/.claude"
+  cp "$HOOK" "$d/.claude/session-freshness.sh"
+  ( cd "$d"; git init -q -b main .; echo x > f; git add -A; git commit -qm x ) >/dev/null 2>&1
+  local pf="$d/prov.json"
+  if [ -n "$1" ]; then printf '%s\n' "$1" > "$pf"; else rm -f "$pf"; fi
+  ( cd "$d"; AMUX_RS_BUILD_PROVENANCE="$pf" bash .claude/session-freshness.sh 2>&1 )
+}
+
+out=$(prov_run '{"sha":"deadbeef1234","ref":"fix/my-thing","on_main":"no","built_at":"x"}')
+says "$PROVMARK" "$out"
+says "fix/my-thing" "$out"
+
+out=$(prov_run '{"sha":"deadbeef1234","ref":"main","on_main":"yes","built_at":"x"}')
+lacks "$PROVMARK" "$out"
+
+out=$(prov_run "")                       # no file at all — fail open, stay silent
+lacks "$PROVMARK" "$out"
+
+out=$(prov_run 'not json at all')        # garbage — must not warn on a bad parse
+lacks "$PROVMARK" "$out"
+
 echo
 echo "test-session-freshness: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
The rust auto-builder rebuilds whenever the build source's local HEAD moves — **on any branch** — and the server self-adopts within ~5s.

On 2026-08-17 a commit made on a feature branch *inside* that checkout was serving the whole fleet 76 seconds later, and stayed there **9h42m**. No CI had run on it, no review. The same condition also stopped the machine tracking upstream, so the daily update schedule silently did nothing. Everything looked healthy the entire time.

## The permissiveness is correct and stays

This machine survived weeks deliberately pinned to an unmerged fix branch, so "only build main" would delete the rollback mechanism.

The defect is that a **deliberate pin** and an **accidental feature branch** were byte-identical to the builder — and the accidental one was announced nowhere.

So: say it. A fact, not a refusal.

| | |
|---|---|
| **builder** | detects whether the revision it's about to install is contained in `main` or `origin/main`, logs a loud `OFF-MAIN` block, and writes `~/.amux/rust-build-provenance.json` |
| **hook** | SessionStart reads that file and tells the session — because `~/.amux/logs/rust-auto-build.log` is not somewhere anyone looks, and a tag in a store the reader never opens is the same failure as no tag |

## The predicate, and why it's a pair

"Contained in `main` **or** `origin/main`". Checking only `origin/main` would false-positive right after a merge: this script must not touch the network on a 60s timer, so the remote-tracking ref lags, while local `main` moves on the merge itself. The pair covers both orders.

Verified: a branch already merged into main reads as on-main, and so does a **detached HEAD at a main commit** — the deliberate-pin shape.

## Also corrected while here

Provenance reports the sha that is actually **built** (`rev-parse HEAD`, what the build worktree is created from), not `$head` — a different thing, the last commit touching the build inputs, used as the rebuild stamp key. Reporting the stamp key would name a commit that isn't what's running.

## Tests — both run the shipped scripts against real git repos

| suite | assertions | fails against `origin/main` |
|---|---|---|
| `scripts/test-build-provenance.sh` | 8 | **7 of 8** |
| `scripts/test-session-freshness.sh` | 15 (was 10) | **2 of 15** |

The builder one runs the real script through a provenance-only seam that stops before the cargo build.

**The quiet cases carry the weight in both**: on-main, already-merged, detached-at-main, provenance file absent, and provenance file garbage must all produce **no line**. A builder that shouted on every build would be ignored within a day, and the entire value is that the line appears only when something is actually off.

Both suites pass under `init.defaultBranch=main` **and** `=master` — CI has none set and falls back to `master`, which is exactly the difference that made an earlier harness pass locally and fail four assertions in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx
