### PR TITLE
fix(steer): the GENERATING-lane warning named a mode it could never report

### DIFF
--- a/crates/amux-server/src/api/session_verbs.rs
+++ b/crates/amux-server/src/api/session_verbs.rs
@@ -4501,15 +4501,33 @@ async fn send_text_inner(
         // — the exact question this bug turns on — could not be answered from
         // anything amux kept. A sweep can now count mid-turn deliveries, and
         // `mode="type"` here should be structurally impossible.
-        tracing::warn!(
-            session = %name,
-            mode = if use_paste { "paste" } else { "type" },
-            chars = text.chars().count(),
-            from_steering,
-            allow_mid_turn,
-            "delivering to a GENERATING lane — paste is the only mode measured as \
-             non-lossy mid-turn (AMUX-2909); mode=type here is a regression"
-        );
+        // AEAB-25. This was a single `warn!` whose TEXT asserted "mode=type here is
+        // a regression" while the structured field carried the mode that actually
+        // happened. 25 of 25 records, all-time, were mode="paste" — the mode the
+        // same sentence calls correct. It has never once fired on the condition it
+        // describes, so grepping it returns only healthy deliveries, and a REAL
+        // mode=type would be one line among them, indistinguishable.
+        //
+        // The comment above says the intent: make every mid-turn delivery
+        // self-announcing so a sweep can count them, and `mode="type"` "should be
+        // structurally impossible". That is instrumentation, not an alarm. So the
+        // record stays for every delivery — the sweep keeps working — and only the
+        // genuinely impossible case is a WARN.
+        if use_paste {
+            tracing::info!(
+                session = %name, mode = "paste", chars = text.chars().count(),
+                from_steering, allow_mid_turn,
+                "delivering to a GENERATING lane by paste — the mode measured as \
+                 non-lossy mid-turn (AMUX-2909)"
+            );
+        } else {
+            tracing::warn!(
+                session = %name, mode = "type", chars = text.chars().count(),
+                from_steering, allow_mid_turn,
+                "delivering to a GENERATING lane by TYPE — paste is the only mode \
+                 measured as non-lossy mid-turn (AMUX-2909); this is the regression"
+            );
+        }
     }
     send_key(name, "C-u").await;
     sleep_ms(40).await;
@@ -15539,6 +15557,34 @@ mod delivery_mode_tests {
         // Size and shape must not rescue it either.
         assert!(must_paste(true, 0, false), "even empty-ish text");
         assert!(must_paste(true, 5000, true));
+    }
+
+    /// AEAB-25. WHY the mode=type warning next to this predicate is currently
+    /// unreachable, stated as an assertion instead of left as a comment.
+    ///
+    /// `must_paste` is `generating || …`, so inside `if generating { … }` the
+    /// paste branch is taken for EVERY input. The old single warning there said
+    /// "mode=type here is a regression" while the structured field carried the
+    /// mode that actually happened — and it could never be `type`, by
+    /// construction. 25 of 25 records all-time were mode="paste", i.e. it fired
+    /// only on the healthy path and a real regression would have been one line
+    /// among them, indistinguishable.
+    ///
+    /// The warning is now split so only the genuinely impossible case warns. That
+    /// leaves a branch that cannot currently fire, which is fine ONLY while this
+    /// invariant holds — so if someone widens `must_paste` such that a generating
+    /// lane can be typed into, this fails loudly AND the warning becomes live and
+    /// correct at the same moment.
+    #[test]
+    fn a_generating_lane_always_pastes_so_the_type_warning_stays_unreachable() {
+        for chars in [0usize, 1, 12, 400, 401, 5000, 100_000] {
+            for picker in [false, true] {
+                assert!(
+                    must_paste(true, chars, picker),
+                    "generating must force paste (chars={chars}, picker={picker}) —                      if this ever fails, the mode=type warning is now reachable and                      must be treated as a live regression signal"
+                );
+            }
+        }
     }
 
     /// The control, without which the test above passes for a `must_paste` that


### PR DESCRIPTION
A single `warn!` whose **text** asserted `mode=type here is a regression` while the structured field carried the mode that actually happened.

**25 of 25 records, all-time, are `mode="paste"`** — the mode the same sentence calls correct.

And that isn't luck. `must_paste` is:

```rust
generating || chars > 400 || picker_shaped
```

so inside `if generating { … }` the paste branch is taken for **every** input. The condition the warning described was **unreachable by construction** — stronger than never-observed.

So the line fired only on the healthy path, and a genuine `mode=type` regression — if the invariant ever broke — would have arrived as one line among identical healthy ones, indistinguishable. Same shape as the scheduler's "nothing was delivered" (#107) two days ago, in the same file: a loud probe whose output doesn't discriminate.

## The fix follows the author's own stated intent

The surrounding comment already says it: make every mid-turn delivery self-announcing so a sweep can count them, and `mode="type"` *"should be structurally impossible"*. That's **instrumentation, not an alarm**.

So the record stays for every delivery, at `INFO`, and only the impossible case is a `WARN`.

## The unreachable branch is now pinned by an assertion, not a comment

That leaves a branch that can't currently fire, which is acceptable only while the invariant holds. So:

```rust
a_generating_lane_always_pastes_so_the_type_warning_stays_unreachable
```

sweeps chars `0..100_000` across both picker shapes. If anyone widens `must_paste` so a generating lane can be typed into, that test fails loudly **and** the warning becomes live and correct in the same moment.

## What I did not do

**No behavioural test for the log split itself**, and I'd rather say so than imply otherwise: it changes no delivery behaviour, and this repo has no tracing capture to assert on a log line. The discriminating evidence is the measurement above plus the pinned invariant.

`cargo clippy --workspace --all-targets -- -D warnings` exit 0; `cargo test --workspace` 39 result lines, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx
