### PR TITLE
feat(health): record and publish amux's own downtime (AEAB-29)

### DIFF
--- a/crates/amux-server/migrations/0021_heartbeat.sql
+++ b/crates/amux-server/migrations/0021_heartbeat.sql
@@ -1,0 +1,31 @@
+-- Server liveness heartbeat + downtime history (AEAB-29).
+--
+-- amux was down for 4h26m on 2026-08-18 and the product recorded that fact
+-- NOWHERE: the only evidence was a GAP between two lines in server-rs.log, and
+-- an absence is not a signal. Nothing counted it, nothing named it, and the
+-- restart logged the same "starting amux-rust" it logs after a routine 5-second
+-- auto-adopt. The user found out because their prompts stopped working.
+--
+-- `server_heartbeat` is one row, stamped while the server runs. `server_downtime`
+-- is the derived history: one row per boot that followed a gap, so "was it down,
+-- and for how long" is answerable AFTER the fact, which is the only time anyone
+-- ever asks.
+CREATE TABLE IF NOT EXISTS server_heartbeat (
+  id      INTEGER PRIMARY KEY CHECK (id = 1),
+  beat_at REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS server_downtime (
+  id        INTEGER PRIMARY KEY AUTOINCREMENT,
+  -- Last moment the server is KNOWN to have been alive. The true stop is
+  -- somewhere in (down_from, down_from + beat interval]; naming the last
+  -- confirmed beat rather than a guess keeps the number honest.
+  down_from REAL NOT NULL,
+  up_at     REAL NOT NULL,
+  seconds   REAL NOT NULL,
+  -- Which listener noticed. Two amux-server processes share this DB, so this
+  -- says which one won the race to observe the stale stamp.
+  port      INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_server_downtime_up_at ON server_downtime(up_at);

--- a/crates/amux-server/src/api/health.rs
+++ b/crates/amux-server/src/api/health.rs
@@ -46,6 +46,19 @@ pub struct Health {
     /// has never recorded a verdict. A growing age with `confidence:unknown` is
     /// a wedged monitor — visible instead of a frozen `healthy`.
     pub confidence_age_s: Option<f64>,
+    /// Seconds amux was NOT RUNNING immediately before this boot (AEAB-29).
+    ///
+    /// `uptime_s` alone cannot distinguish "restarted 60s ago to adopt a build"
+    /// from "restarted 60s ago after four hours down", and on 2026-08-18 that
+    /// was exactly the question — the user's prompts had been going nowhere and
+    /// the only evidence was a GAP between two log lines, which nothing counted.
+    /// This publishes the gap on the endpoint every consumer already polls.
+    ///
+    /// `None` is honestly different from `0.0`: it means no outage was recorded
+    /// for this boot — either there was none, or the heartbeat could not be
+    /// stamped (which logs a WARN of its own rather than reporting health).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub downtime_before_boot_s: Option<f64>,
 }
 
 #[derive(Serialize)]
@@ -119,6 +132,8 @@ pub async fn health(State(state): State<AppState>) -> (StatusCode, Json<Health>)
             fds,
             confidence: conf.as_str(),
             confidence_age_s: conf_age,
+            downtime_before_boot_s: crate::runtime_jobs::heartbeat::boot_gap()
+                .map(|g| g.seconds),
         }),
     )
 }
@@ -204,4 +219,53 @@ pub async fn debug_scan() -> axum::Json<serde_json::Value> {
             "deduped": serde_json::Map::new(),
         })),
     }
+}
+
+/// GET /api/debug/downtime — the recorded outages, most recent first (AEAB-29).
+///
+/// The CATALOG row for the `heartbeat` job advertises this path, and an
+/// advertised-but-unrouted instrument is ethos rule 6 (an audit trail that is
+/// claimed and not implemented). It answers the question that had no answer on
+/// 2026-08-18: was amux down, when, and for how long?
+pub async fn debug_downtime(State(state): State<AppState>) -> axum::Json<serde_json::Value> {
+    let conn = match state.store.read() {
+        Ok(c) => c,
+        Err(e) => {
+            return axum::Json(serde_json::json!({ "error": e.to_string() }));
+        }
+    };
+    let mut rows: Vec<serde_json::Value> = Vec::new();
+    if let Ok(mut stmt) = conn.prepare(
+        "SELECT down_from, up_at, seconds, port FROM server_downtime ORDER BY up_at DESC LIMIT 100",
+    ) {
+        if let Ok(it) = stmt.query_map([], |r| {
+            Ok(serde_json::json!({
+                "down_from": crate::api::request_log::local_when(r.get::<_, f64>(0)?),
+                "up_at": crate::api::request_log::local_when(r.get::<_, f64>(1)?),
+                "down_from_ts": r.get::<_, f64>(0)?,
+                "up_at_ts": r.get::<_, f64>(1)?,
+                "seconds": r.get::<_, f64>(2)?,
+                "minutes": (r.get::<_, f64>(2)? / 60.0 * 10.0).round() / 10.0,
+                "noticed_by_port": r.get::<_, Option<i64>>(3)?,
+            }))
+        }) {
+            rows.extend(it.filter_map(|r| r.ok()));
+        }
+    }
+    let last_beat: Option<f64> = conn
+        .query_row("SELECT beat_at FROM server_heartbeat WHERE id = 1", [], |r| r.get(0))
+        .ok();
+    axum::Json(serde_json::json!({
+        "note": "Stretches with no amux server running, derived from the liveness \
+                 heartbeat. `down_from` is the LAST CONFIRMED BEAT, so the true stop is \
+                 within one beat interval after it — the number is deliberately the one \
+                 that can be proved rather than a guess. A duration reported elsewhere \
+                 (steer queue age, rot, missed schedules) that spans one of these rows \
+                 includes time no lane could have made progress.",
+        "beat_interval_s": crate::runtime_jobs::heartbeat::beat_interval().as_secs(),
+        "min_gap_s": crate::runtime_jobs::heartbeat::min_gap_s(),
+        "last_beat_at": last_beat.map(crate::api::request_log::local_when),
+        "this_boot_followed_downtime_s": crate::runtime_jobs::heartbeat::boot_gap().map(|g| g.seconds),
+        "outages": rows,
+    }))
 }

--- a/crates/amux-server/src/api/mod.rs
+++ b/crates/amux-server/src/api/mod.rs
@@ -342,6 +342,7 @@ pub fn router(state: AppState) -> Router {
         // deviation). Advertised in ethos.md and the job registry but unrouted
         // until now. Public like its debug siblings (lane names and timings).
         .route("/api/debug/scan", axum::routing::get(health::debug_scan))
+        .route("/api/debug/downtime", axum::routing::get(health::debug_downtime))
         // Per-session logging health + a computed stale verdict (AMUX-2628).
         // Public like its debug siblings: session names and byte counts only.
         .route("/api/debug/logs", axum::routing::get(session_verbs::debug_logs))

--- a/crates/amux-server/src/api/request_log.rs
+++ b/crates/amux-server/src/api/request_log.rs
@@ -916,6 +916,7 @@ pub const ROUTE_TABLE: &[RouteEntry] = &[
     RouteEntry { path: "/api/calendar.ics", methods: &["GET"] },
     RouteEntry { path: "/api/debug/tmux", methods: &["GET"] },
     RouteEntry { path: "/api/debug/scan", methods: &["GET"] },
+    RouteEntry { path: "/api/debug/downtime", methods: &["GET"] },
     RouteEntry { path: "/api/debug/logs", methods: &["GET"] },
     RouteEntry { path: "/api/debug/boundary", methods: &["GET"] },
     RouteEntry { path: "/api/debug/legacy-port", methods: &["GET"] },

--- a/crates/amux-server/src/db/migrate.rs
+++ b/crates/amux-server/src/db/migrate.rs
@@ -126,6 +126,11 @@ const MIGRATIONS: &[Migration] = &[
         name: "0020_mdai_runs",
         sql: include_str!("../../migrations/0020_mdai_runs.sql"),
     },
+    Migration {
+        version: 21,
+        name: "0021_heartbeat",
+        sql: include_str!("../../migrations/0021_heartbeat.sql"),
+    },
 ];
 
 /// Migrations embedded in THIS binary that the DB has not recorded yet.

--- a/crates/amux-server/src/lib.rs
+++ b/crates/amux-server/src/lib.rs
@@ -208,6 +208,14 @@ async fn async_main() {
         }
     };
 
+    // AEAB-29: name the outage that preceded this boot, BEFORE anything else
+    // reports a duration. amux was down 4h26m on 2026-08-18 and the only
+    // evidence anywhere was a gap between two log lines — an absence nothing
+    // counted. This runs before the background loops so a stall/rot/schedule
+    // reader that starts up cannot report an age spanning the outage without
+    // the outage itself already being on the record.
+    runtime_jobs::heartbeat::record_boot(&store, cfg.port);
+
     // Migration-rehearsal mode (Phase 11): open + migrate + report + exit.
     // Lets docs/rust-migration/migration-rehearsal.sh exercise the EXACT production
     // migration path against a DB copy without binding ports.
@@ -357,6 +365,7 @@ async fn async_main() {
     // prune logic media-cache and uploads already had was correct and only ran
     // while those directories were GROWING, so a fleet that stopped transcoding
     // never evicted a transcode.
+    drop(runtime_jobs::heartbeat::spawn(store.clone()));
     drop(runtime_jobs::storage::spawn(state.clone()));
     // The token_ledger WRITER. Every reader of that table was ported at the
     // cutover and this was not, so /api/stats/daily served a confident

--- a/crates/amux-server/src/runtime_jobs/heartbeat.rs
+++ b/crates/amux-server/src/runtime_jobs/heartbeat.rs
@@ -1,0 +1,392 @@
+//! Server liveness heartbeat, and the downtime it makes visible (AEAB-29).
+//!
+//! # Why this exists
+//!
+//! On 2026-08-18 amux was down for 4h26m. A hardware undervoltage fault killed
+//! the machine at 14:03 EDT; it came back at 15:18, but amux's LaunchAgents are
+//! `Aqua` session-type, so nothing started until a human logged in at the
+//! console at 18:28. The user found out the way everyone finds out — their
+//! prompts stopped working — and asked what was wrong with the server.
+//!
+//! The product recorded the outage NOWHERE. The only evidence was a gap between
+//! two lines in `server-rs.log`, and **an absence is not a signal**: nothing
+//! counted it, nothing named it, and the restart emitted the same
+//! `starting amux-rust` it emits after a routine 5-second auto-adopt reload.
+//! Byte-identical framing for a 5s blip and a four-hour outage.
+//!
+//! That is ethos rule 4 — when this goes wrong, what will someone see, and will
+//! they see it WHERE THEY ALREADY LOOK? So the gap is now named at WARN, stored
+//! so it can be asked for after the fact (which is the only time anyone asks),
+//! and published on `/health`, the endpoint every consumer already polls.
+//!
+//! # Why it matters beyond "amux was down"
+//!
+//! Every duration amux reports is measured against wall-clock time that may
+//! include hours the server did not exist, and nothing marks which. On the day
+//! this was written a steering message showed `queued=1 oldest_min=2131
+//! reason=not-running` — some of those minutes were a genuinely wedged lane and
+//! some were minutes with no server at all. Those are different faults with
+//! different fixes and the log could not tell them apart. Same for schedules
+//! that did not fire and rot timers that aged. [`downtime_within`] exists so a
+//! reader can subtract the part that was not the lane's fault.
+//!
+//! # The two-process race is the dedupe
+//!
+//! Two amux-server processes share one DB (8823 and 8824), so a naive
+//! "read stamp, then write stamp" would have both report the same outage. The
+//! read and the write happen inside ONE [`crate::db::Store::write`] closure,
+//! which the writer thread runs under `BEGIN IMMEDIATE` — atomic across
+//! processes. Whichever process gets there first sees the stale stamp and files
+//! the gap; the second sees a fresh one and says nothing. One outage, one row.
+
+use crate::db::{Store, WriteOutcome};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+/// The job's registry id, and — because `spawn_periodic` derives the per-job
+/// isolation switch from the name — the source of `AMUX_HEARTBEAT_SECS`.
+pub const JOB: &str = crate::runtime_jobs::registry::ids::HEARTBEAT;
+
+/// How often the live server stamps the heartbeat row.
+pub fn beat_interval() -> Duration {
+    Duration::from_secs(
+        std::env::var("AMUX_HEARTBEAT_SECS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .unwrap_or(15)
+            .clamp(1, 600),
+    )
+}
+
+/// The gap that counts as an OUTAGE rather than a restart.
+///
+/// This server re-execs to adopt a new build, and that costs a few seconds; the
+/// heartbeat interval adds up to another. The default is deliberately far above
+/// both, because the expensive error here is crying outage on every deploy — a
+/// detector that fires on the healthy baseline is reporting that the machine is
+/// ON (ethos rule 7). It is NOT tuned to catch the smallest possible gap.
+pub fn min_gap_s() -> f64 {
+    std::env::var("AMUX_DOWNTIME_MIN_S")
+        .ok()
+        .and_then(|v| v.parse::<f64>().ok())
+        .unwrap_or(120.0)
+        .max(1.0)
+}
+
+/// A stretch with no live amux, bracketed by the last confirmed beat and this boot.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct Gap {
+    /// Last moment the server is KNOWN to have been alive. The true stop is
+    /// somewhere in `(down_from, down_from + beat_interval]` — naming the last
+    /// confirmed beat instead of a guess keeps the number honest.
+    pub down_from: f64,
+    pub up_at: f64,
+    pub seconds: f64,
+}
+
+static BOOT_GAP: OnceLock<Option<Gap>> = OnceLock::new();
+
+/// The outage that preceded THIS boot, if there was one. `None` also means
+/// "not measured yet" on a process that never called [`record_boot`], which is
+/// why `/health` reports it as an absent field rather than a zero.
+pub fn boot_gap() -> Option<Gap> {
+    BOOT_GAP.get().copied().flatten()
+}
+
+/// SQL body shared by boot and tick so the two cannot drift: read the previous
+/// stamp, write the current one, and hand back what was there before.
+fn stamp(conn: &rusqlite::Connection, now: f64) -> rusqlite::Result<Option<f64>> {
+    let prev: Option<f64> = conn
+        .query_row("SELECT beat_at FROM server_heartbeat WHERE id = 1", [], |r| r.get(0))
+        .ok();
+    conn.execute(
+        "INSERT INTO server_heartbeat (id, beat_at) VALUES (1, ?1)
+         ON CONFLICT(id) DO UPDATE SET beat_at = excluded.beat_at",
+        [now],
+    )?;
+    Ok(prev)
+}
+
+/// The whole boot decision, as one function against one connection, so the
+/// tests exercise the SHIPPED path rather than a paraphrase of it.
+///
+/// The read and the write are deliberately in the same call: [`record_boot`]
+/// runs this inside `Store::write`, whose writer thread wraps it in
+/// `BEGIN IMMEDIATE`, which is what makes it atomic across the two
+/// amux-server processes that share this database. Split them and both
+/// processes would file the same outage.
+fn boot_tx(
+    conn: &rusqlite::Connection,
+    now: f64,
+    min_gap: f64,
+    port: u16,
+) -> rusqlite::Result<Option<Gap>> {
+    let prev = stamp(conn, now)?;
+    let gap = match prev {
+        Some(p) if now - p > min_gap => Some(Gap { down_from: p, up_at: now, seconds: now - p }),
+        _ => None,
+    };
+    if let Some(g) = gap {
+        conn.execute(
+            "INSERT INTO server_downtime (down_from, up_at, seconds, port) \
+             VALUES (?1, ?2, ?3, ?4)",
+            rusqlite::params![g.down_from, g.up_at, g.seconds, port as i64],
+        )?;
+    }
+    Ok(gap)
+}
+
+/// Called once at startup, BEFORE the beat loop. Records this boot's stamp and,
+/// if the previous one is older than [`min_gap_s`], files and logs the outage.
+///
+/// Returns the gap so the caller can log it with the rest of the startup
+/// banner; it is also cached for `/health`.
+pub fn record_boot(store: &Store, port: u16) -> Option<Gap> {
+    // An isolated/test server must NOT stamp the fleet's row: a warm stamp from
+    // a process that is not the fleet would mask a real outage, which is the
+    // one thing this module exists to make visible. The predicate is BORROWED
+    // from the spawn path rather than re-derived here — a view that re-invents
+    // the filter of the mechanism it describes is how the two drift.
+    if let Some(reason) = crate::runtime_jobs::fleet_isolation_reason(JOB) {
+        tracing::info!(
+            switch = %reason,
+            "heartbeat: not stamping — this server is isolated from the fleet, and a \
+             stamp from a non-fleet process would hide the next real outage"
+        );
+        let _ = BOOT_GAP.set(None);
+        return None;
+    }
+    let now = crate::runtime_jobs::registry::unix_now();
+    let min_gap = min_gap_s();
+    let res = store.write(move |conn| {
+        boot_tx(conn, now, min_gap, port)?;
+        // `applied: false` is LOAD-BEARING, not laziness. `applied` bumps the
+        // global revision, and the global revision is what SSE delta-sync hangs
+        // off — so a heartbeat that "applied" would make every connected
+        // dashboard refetch the world every 15 seconds, forever. That is the
+        // ethos rule 7 trap where the detector's cost is paid in the same
+        // resource as the fault it watches. The row still commits; `applied`
+        // only controls whether subscribers are told something changed, and
+        // nothing user-visible did.
+        Ok(WriteOutcome { applied: false, events: vec![] })
+    });
+
+    if let Err(e) = res {
+        // A heartbeat that cannot be written must not be mistaken for a server
+        // that was never down. Say so loudly and leave BOOT_GAP unset.
+        tracing::warn!(error = %e, "heartbeat: could not stamp boot — downtime detection is OFF for this run");
+        return None;
+    }
+
+    // Re-derive the gap from the row we just displaced. The write closure cannot
+    // return a value, so this reads `server_downtime` for the row keyed to this
+    // boot — which also proves the insert actually landed, rather than trusting
+    // that it did (ethos rule 6: verify the operand you just wrote).
+    let gap = store
+        .read()
+        .ok()
+        .and_then(|c| {
+            c.query_row(
+                "SELECT down_from, up_at, seconds FROM server_downtime \
+                 WHERE up_at = ?1 ORDER BY id DESC LIMIT 1",
+                [now],
+                |r| Ok(Gap { down_from: r.get(0)?, up_at: r.get(1)?, seconds: r.get(2)? }),
+            )
+            .ok()
+        });
+
+    let _ = BOOT_GAP.set(gap);
+
+    if let Some(g) = gap {
+        tracing::warn!(
+            down_from = %crate::api::request_log::local_when(g.down_from),
+            up_at = %crate::api::request_log::local_when(g.up_at),
+            seconds = g.seconds,
+            minutes = (g.seconds / 60.0).round(),
+            "amux was DOWN — no server was running for this stretch. Durations reported \
+             across it (steer queue age, rot timers, missed schedules) include time with \
+             no amux, not just a stalled lane (AEAB-29)"
+        );
+    }
+    gap
+}
+
+/// One tick of the beat loop.
+pub fn beat(store: &Store) {
+    let now = crate::runtime_jobs::registry::unix_now();
+    if let Err(e) = store.write(move |conn| {
+        stamp(conn, now)?;
+        // See record_boot: never bump the global revision from a heartbeat.
+        Ok(WriteOutcome { applied: false, events: vec![] })
+    }) {
+        tracing::warn!(error = %e, "heartbeat: stamp failed");
+    }
+}
+
+/// Seconds of KNOWN downtime inside `[from, to]`, for readers that want to say
+/// how much of a long duration was the server's absence rather than a lane's.
+pub fn downtime_within(conn: &rusqlite::Connection, from: f64, to: f64) -> f64 {
+    let mut stmt = match conn.prepare(
+        "SELECT down_from, up_at FROM server_downtime WHERE up_at >= ?1 AND down_from <= ?2",
+    ) {
+        Ok(s) => s,
+        Err(_) => return 0.0,
+    };
+    let rows = stmt.query_map([from, to], |r| Ok((r.get::<_, f64>(0)?, r.get::<_, f64>(1)?)));
+    match rows {
+        Ok(it) => it
+            .filter_map(|r| r.ok())
+            .map(|(a, b)| (b.min(to) - a.max(from)).max(0.0))
+            .sum(),
+        Err(_) => 0.0,
+    }
+}
+
+
+/// Spawns the beat loop. Registered like every other background job, so a
+/// heartbeat that stopped ticking is visible in `/api/system-jobs` — a dead
+/// liveness probe that nobody can see is the failure this module is about,
+/// one level up.
+pub fn spawn(store: std::sync::Arc<Store>) -> super::PeriodicTask {
+    let secs = beat_interval().as_secs();
+    super::spawn_periodic(JOB, secs, move || {
+        let store = store.clone();
+        async move {
+            let _ = tokio::task::spawn_blocking(move || beat(&store)).await;
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+
+    /// Builds the schema from the SHIPPED migration file, not from a hand-typed
+    /// copy. A test schema that has drifted from the real one proves nothing
+    /// about the real one.
+    fn db() -> Connection {
+        let c = Connection::open_in_memory().unwrap();
+        c.execute_batch(include_str!("../../migrations/0021_heartbeat.sql")).unwrap();
+        c
+    }
+
+    fn outages(c: &Connection) -> Vec<(f64, f64, f64)> {
+        let mut st = c
+            .prepare("SELECT down_from, up_at, seconds FROM server_downtime ORDER BY id")
+            .unwrap();
+        let v: Vec<_> = st
+            .query_map([], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        v
+    }
+
+    /// The NEGATIVE half. Without this, every assertion below is satisfied by a
+    /// function that files an outage unconditionally.
+    #[test]
+    fn a_first_ever_boot_is_not_an_outage() {
+        let c = db();
+        let gap = boot_tx(&c, 1_000.0, 120.0, 8824).unwrap();
+        assert!(gap.is_none(), "an empty heartbeat table means no history, not a four-hour outage");
+        assert!(outages(&c).is_empty());
+    }
+
+    /// The other NEGATIVE half, and the one that matters in production: this
+    /// server re-execs to adopt new builds several times a day. If a deploy
+    /// filed an outage, the signal would be pure noise within a week.
+    #[test]
+    fn a_quick_restart_is_not_an_outage() {
+        let c = db();
+        boot_tx(&c, 1_000.0, 120.0, 8824).unwrap();
+        // 5s later: a self-adopt restart, well inside the 120s floor.
+        let gap = boot_tx(&c, 1_005.0, 120.0, 8824).unwrap();
+        assert!(gap.is_none(), "a 5s restart must not read as downtime");
+        assert!(outages(&c).is_empty());
+    }
+
+    /// The POSITIVE half, rebuilt from the incident's own numbers rather than
+    /// from a conveniently-shaped case: 2026-08-18, last beat 14:03 EDT, server
+    /// back 18:29 EDT, 4h26m.
+    #[test]
+    fn the_2026_08_18_outage_is_named_with_its_real_span() {
+        let c = db();
+        let last_beat = 1_000_000.0;
+        let back_up = last_beat + (4.0 * 3600.0 + 26.0 * 60.0);
+        // Seed the heartbeat as the dead server left it.
+        stamp(&c, last_beat).unwrap();
+        let gap = boot_tx(&c, back_up, 120.0, 8824).unwrap().expect("4h26m must register");
+        assert_eq!(gap.down_from, last_beat);
+        assert_eq!(gap.up_at, back_up);
+        assert!((gap.seconds - 15_960.0).abs() < 0.001, "seconds = {}", gap.seconds);
+        let rows = outages(&c);
+        assert_eq!(rows.len(), 1, "one outage, one row");
+        assert!((rows[0].2 / 60.0 - 266.0).abs() < 0.001, "4h26m = 266 minutes");
+    }
+
+    /// The boundary, asserted from BOTH sides — a threshold tested only from
+    /// the far side is a threshold whose comparison could be inverted.
+    #[test]
+    fn the_threshold_discriminates_at_its_own_boundary() {
+        let c = db();
+        stamp(&c, 0.0).unwrap();
+        assert!(boot_tx(&c, 120.0, 120.0, 1).unwrap().is_none(), "exactly at the floor is not an outage");
+        stamp(&c, 0.0).unwrap();
+        assert!(boot_tx(&c, 120.5, 120.0, 1).unwrap().is_some(), "past the floor is");
+    }
+
+    /// The two-process dedupe. 8823 and 8824 share one DB and boot together;
+    /// the writer thread's BEGIN IMMEDIATE serialises these two calls, so the
+    /// second must see the FRESH stamp the first just wrote and stay quiet.
+    /// Without this the fleet would file every outage twice.
+    #[test]
+    fn only_the_process_that_wins_the_race_files_the_outage() {
+        let c = db();
+        stamp(&c, 0.0).unwrap();
+        let first = boot_tx(&c, 10_000.0, 120.0, 8824).unwrap();
+        let second = boot_tx(&c, 10_000.1, 120.0, 8823).unwrap();
+        assert!(first.is_some(), "the first process through sees the stale stamp");
+        assert!(second.is_none(), "the second sees a stamp 0.1s old — no second row");
+        assert_eq!(outages(&c).len(), 1);
+    }
+
+    /// A beat must keep the stamp warm, or a long-running server would report
+    /// its own uptime as an outage on the next restart.
+    #[test]
+    fn beats_keep_the_stamp_warm_so_uptime_is_never_read_as_downtime() {
+        let c = db();
+        boot_tx(&c, 0.0, 120.0, 1).unwrap();
+        for t in 1..=400 {
+            stamp(&c, t as f64 * 15.0).unwrap();   // 100 minutes of 15s beats
+        }
+        let gap = boot_tx(&c, 400.0 * 15.0 + 5.0, 120.0, 1).unwrap();
+        assert!(gap.is_none(), "a served 100 minutes must not be filed as a 100-minute outage");
+        assert!(outages(&c).is_empty());
+    }
+
+    #[test]
+    fn downtime_within_reports_only_the_overlap() {
+        let c = db();
+        stamp(&c, 0.0).unwrap();
+        boot_tx(&c, 1_000.0, 120.0, 1).unwrap();   // outage [0, 1000]
+
+        // Fully inside the window.
+        assert!((downtime_within(&c, 0.0, 2_000.0) - 1_000.0).abs() < 0.001);
+        // Half overlapping: only the overlap counts, or a caller subtracting
+        // this from a duration would go negative.
+        assert!((downtime_within(&c, 500.0, 2_000.0) - 500.0).abs() < 0.001);
+        // Disjoint — the negative control. Without it, a function returning the
+        // full span unconditionally passes both assertions above.
+        assert_eq!(downtime_within(&c, 2_000.0, 3_000.0), 0.0);
+    }
+
+    /// The clamps are not decoration: `AMUX_HEARTBEAT_SECS=0` reaches
+    /// `spawn_periodic`'s isolation check and stops the job, so if it ALSO
+    /// reached `Duration::from_secs(0)` the tick loop would busy-spin.
+    #[test]
+    fn the_interval_can_never_be_zero() {
+        assert!(beat_interval().as_secs() >= 1);
+        assert!(min_gap_s() >= 1.0);
+    }
+}

--- a/crates/amux-server/src/runtime_jobs/mod.rs
+++ b/crates/amux-server/src/runtime_jobs/mod.rs
@@ -51,6 +51,7 @@ pub mod autofix;
 pub mod board_drive;
 pub mod commit_nudge;
 pub mod ghost_rescue;
+pub mod heartbeat;
 pub mod pane_size;
 /// The live registry of the jobs below — see [`registry`] for why it is
 /// derived from the spawn sites rather than declared alongside them.
@@ -158,7 +159,7 @@ fn isolation_reason_with<F: Fn(&str) -> Option<String>>(name: &str, get: F) -> O
 }
 
 /// [`isolation_reason_with`] against the live process environment.
-fn fleet_isolation_reason(name: &str) -> Option<String> {
+pub(crate) fn fleet_isolation_reason(name: &str) -> Option<String> {
     isolation_reason_with(name, |k| std::env::var(k).ok())
 }
 

--- a/crates/amux-server/src/runtime_jobs/registry.rs
+++ b/crates/amux-server/src/runtime_jobs/registry.rs
@@ -107,6 +107,7 @@ pub mod ids {
     pub const GHOST_RESCUE: &str = "ghost-rescue";
     pub const PANE_SIZE: &str = "pane_size";
     pub const STORAGE: &str = "storage";
+    pub const HEARTBEAT: &str = "heartbeat";
 }
 
 /// Every id above, enumerated. `mod ids` is a set of constants and Rust cannot
@@ -132,6 +133,7 @@ pub const ALL_IDS: &[&str] = &[
     ids::GHOST_RESCUE,
     ids::PANE_SIZE,
     ids::STORAGE,
+    ids::HEARTBEAT,
 ];
 
 /// An env var this job reads at startup. It is a READOUT, never a switch: a
@@ -236,6 +238,30 @@ pub const CATALOG: &[Doc] = &[
             effect: "off still detects and records every finding; only the board card is skipped",
         }),
         detail: Some("/api/debug/autofix"),
+    },
+    Doc {
+        id: ids::HEARTBEAT,
+        name: "Liveness heartbeat",
+        purpose: "Stamps a row while the server runs, so the NEXT boot can name how long amux was down instead of leaving a gap in a log file that nothing counts (AEAB-29).",
+        env: &[
+            EnvControl {
+                var: "AMUX_HEARTBEAT_SECS",
+                effect: "seconds between stamps (default 15); bounds how precisely an outage's start can be named",
+                // TRUE, and checked by the code that spawns, not by this row:
+                // `spawn_periodic` derives the per-job switch from the job name,
+                // so `AMUX_HEARTBEAT_SECS=0` really does stop this loop. The
+                // same var is honoured by `record_boot`, so an isolated server
+                // does not stamp the fleet's row either.
+                off: Some("0"),
+            },
+            EnvControl {
+                var: "AMUX_DOWNTIME_MIN_S",
+                effect: "gap that counts as an outage rather than a restart (default 120)",
+                off: None,
+            },
+        ],
+        pref: None,
+        detail: Some("/api/debug/downtime"),
     },
     Doc {
         id: ids::STORAGE,

--- a/frustrations.md
+++ b/frustrations.md
@@ -3074,3 +3074,72 @@ FIX: Migrated today's four entries here and verified against
   (c) have the rule REFUSE to append to a checkout that is behind origin, or at minimum
   warn. (c) is the one that survives the next time two checkouts drift, because this
   failure is silent by construction.
+
+---
+## amux was down for 4h26m and recorded that fact nowhere — the outage was visible only as a GAP between two log lines
+AREA: instruments
+SEVERITY: slows
+STATUS: fixed
+DATE: 2026-08-18
+SESSION: amux-errors-and-bugs
+CARD: AEAB-29
+SYMPTOM: The user asked "My prompts are hanging. What's wrong with my Amux server?" The
+  server had not been hanging — it had been DOWN from 14:03 to 18:29 EDT. The only
+  evidence anywhere was that `server-rs.log` had no line between `18:03:32Z` and
+  `22:29:24Z`. Nothing counted the gap, nothing named it, nothing surfaced it. The
+  restart logged `starting amux-rust`, byte-identical to what it logs after a routine
+  5-second auto-adopt reload — same framing for a 5s blip and a four-hour outage.
+  Reconstructing it took `kern.boottime`, `last`, and a macOS ResetCounter diagnostic,
+  none of which are amux.
+COST: The user had to notice by their own prompts failing and open a ticket to ask.
+  ~35 minutes of forensics to establish something the server itself knew and did not
+  say. Worse, and still live elsewhere: every duration amux reports is measured against
+  wall-clock time that may include hours with no server, and nothing marks which. The
+  same log carries `steering queue STALLED ... queued=1 oldest_min=2131
+  reason=not-running` — some of those 2131 minutes were a genuinely wedged lane and
+  some were minutes when no amux existed to deliver anything. The instrument cannot
+  express the discriminator (ethos rule 4), so any conclusion drawn from that number is
+  a guess with a confident-looking figure attached.
+FIX: Fixed on branch `fix/server-downtime-record`. A liveness heartbeat row stamped
+  every 15s; at boot the previous stamp is read and written inside ONE `Store::write`
+  closure (the writer thread's `BEGIN IMMEDIATE` is what makes it atomic across the two
+  amux-server processes sharing this DB, so one outage files exactly one row, not two).
+  A gap past `AMUX_DOWNTIME_MIN_S` (default 120s, comfortably above a self-adopt
+  restart) logs at WARN, persists to `server_downtime`, and publishes as
+  `downtime_before_boot_s` on `/health` — the endpoint every consumer already polls —
+  plus `GET /api/debug/downtime` for the history. `downtime_within()` is there so the
+  stall/rot/schedule readers can subtract the part that was not the lane's fault; wiring
+  those callers is NOT done and is the obvious follow-up.
+  The heartbeat write is `applied: false` on purpose: `applied` bumps the global
+  revision that SSE delta-sync hangs off, so a heartbeat that "applied" would make every
+  connected dashboard refetch the world every 15 seconds — a detector whose cost lands
+  on the same resource it watches.
+  Tests assert BOTH directions and were verified by mutation, not by being green: making
+  the detector never fire fails 4 of 8, making it fire unconditionally fails 4 of 8, and
+  the positive case is rebuilt from this incident's own numbers (14:03 -> 18:29, 266
+  minutes) rather than from a conveniently-shaped one.
+
+---
+## The two causes behind that outage are not amux bugs, and amux had nothing to say about either
+AREA: instruments
+SEVERITY: annoys
+STATUS: open
+DATE: 2026-08-18
+SESSION: amux-errors-and-bugs
+CARD: AEAB-28
+SYMPTOM: The machine was up and on the network at 15:18; amux did not start until the
+  console login at 18:28 — 3h10m later. All four amux units are user LaunchAgents in
+  `~/Library/LaunchAgents` with no `LimitLoadToSessionType`, so they are `Aqua`: they
+  load at GUI LOGIN, not at boot. `ls /Library/LaunchDaemons | grep -i amux` -> none.
+  `RunAtLoad=true` is doing exactly what it says; "load" just never happened. Separately,
+  the machine died in the first place from a hardware undervoltage fault
+  (`Boot faults: uv,vdd_boost_uvlo`, `Boot failure count: 2`) — AEAB-30.
+COST: Turned a ~75-minute hardware outage into a 4h26m amux outage. On a headless box
+  this is unbounded: it ends when a human happens to sit down.
+FIX: Owner's call, and genuinely a trade — `LimitLoadToSessionType = Background` starts
+  at boot but leaves the login keychain locked, so lanes needing provider credentials
+  may fail in a way that looks like a broken lane rather than a locked keychain;
+  automatic login is simpler but is incompatible with FileVault and is a posture change
+  on a Tailscale-reachable machine. Filed rather than chosen (ethos rule 8). What is NOT
+  the owner's call and should ship regardless: `install.sh` says nothing about this
+  property, so every amux install has it and no operator has been told.


### PR DESCRIPTION
## What happened

A user asked: *"My prompts are hanging. What's wrong with my Amux server?"*

The server had not been hanging. It had been **down for 4h26m** — and amux recorded
that fact nowhere. The only evidence anywhere was that `server-rs.log` had no line
between `18:03:32Z` and `22:29:24Z`. Nothing counted the gap, nothing named it, nothing
surfaced it, and the restart logged `starting amux-rust` — byte-identical to what it
logs after a routine 5-second auto-adopt reload. Same framing for a blip and a
four-hour outage.

Reconstructing the timeline needed `kern.boottime`, `last`, and a macOS ResetCounter
diagnostic. None of those are amux. That is ethos rule 4: when this goes wrong, what
will someone see, and will they see it **where they already look**?

## What this adds

| | |
|---|---|
| `migrations/0021_heartbeat.sql` | `server_heartbeat` (one stamped row), `server_downtime` (derived outage history) |
| `runtime_jobs/heartbeat.rs` | `record_boot` at startup, `beat` every 15s, `downtime_within()` for readers |
| `/health` | new `downtime_before_boot_s` |
| `GET /api/debug/downtime` | the outage history, with the beat interval and threshold in the payload |
| system-jobs CATALOG | registered, so a heartbeat that stops ticking is itself visible |

## Three decisions that are load-bearing, not incidental

**1. The boot read and write are one `Store::write` closure.** The writer thread wraps
it in `BEGIN IMMEDIATE`, which is atomic *across the two amux-server processes sharing
this database*. Whichever gets there first sees the stale stamp and files the outage;
the second sees a fresh one and stays quiet. One outage, one row. Split the read from
the write and the fleet double-reports every outage forever. There is a test for
exactly this.

**2. The heartbeat write is `applied: false`.** `applied` bumps the global revision that
SSE delta-sync hangs off — so a heartbeat that "applied" would make every connected
dashboard refetch the world every 15 seconds. That is the rule 7 trap where the
detector's cost is paid in the same resource it watches. The row still commits;
`applied` only controls whether subscribers are told something user-visible changed,
and nothing did.

**3. `record_boot` is skipped under fleet isolation, borrowing `fleet_isolation_reason`
rather than re-deriving the predicate.** A warm stamp from a test server would *mask*
the next real outage — the one thing this module exists to prevent. Re-deriving the
filter is how a view drifts from the mechanism it describes.

The threshold (`AMUX_DOWNTIME_MIN_S`, default 120s) sits comfortably above a self-adopt
restart on purpose. A detector that fires on the healthy baseline is reporting that the
machine is on.

## Verification — mutation-checked, not just green

Green tests prove nothing until you have watched them fail, so I mutated the detector:

| mutation | result |
|---|---|
| detector can never fire | **4 of 8 fail** |
| detector fires unconditionally | **4 of 8 fail** (incl. both negative controls) |

The positive case is rebuilt from this incident's own numbers — 14:03 → 18:29 EDT, 266
minutes — rather than from a case that is easy to construct. The negative controls
matter as much: `a_first_ever_boot_is_not_an_outage` (an empty table is no history, not
a four-hour outage) and `a_quick_restart_is_not_an_outage` (this server re-execs several
times a day; if a deploy filed an outage the signal would be noise within a week).
`downtime_within` carries a disjoint-range control so a function returning the full span
unconditionally cannot pass.

Local: `cargo check --workspace --all-targets` = 0, `cargo clippy --workspace
--all-targets -- -D warnings` = 0, heartbeat tests 10/10. Full `cargo test --workspace`
is CI's gate.

## What this deliberately does NOT do

`downtime_within()` is implemented and tested and **has no callers yet.** The consumers
that should use it: the steer-queue stall warning (today it reports `oldest_min=2131
reason=not-running` without saying how many of those minutes had no server at all), rot
timers, and missed-schedule reporting. Until they subtract known downtime they overstate
how long a *lane* was wedged. That is a follow-up card, not a silent extension of this
PR.

## Siblings

- **AEAB-28** — why amux stayed down 3h10m *after* the machine came back: the
  LaunchAgents are `Aqua` session-type, so they load at GUI login, not at boot. Owner's
  decision, costed on the card.
- **AEAB-30** — the hardware undervoltage fault that started it (`Boot faults:
  uv,vdd_boost_uvlo`, `Boot failure count: 2`).
- **AEAB-27** — the original captured prompt, discarded with a pointer to these three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx
