### PR TITLE
fix(upload): a stuck attachment can always be removed, and closing the peek no longer strands one

### DIFF
--- a/crates/amux-dashboard/static/app.css
+++ b/crates/amux-dashboard/static/app.css
@@ -1890,8 +1890,26 @@
   .peek-attach-chip img { width: 24px; height: 24px; object-fit: cover; border-radius: 3px; flex-shrink: 0; }
   .peek-attach-chip .chip-icon { font-size: 1rem; line-height: 1; flex-shrink: 0; }
   .peek-attach-chip .chip-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex: 1; min-width: 0; }
-  .peek-attach-chip .chip-remove { cursor: pointer; color: var(--dim); flex-shrink: 0; font-size: 1.1rem; line-height: 1; opacity: 0.7; }
+  .peek-attach-chip .chip-remove { cursor: pointer; color: var(--dim); flex-shrink: 0; font-size: 1.1rem; line-height: 1; opacity: 0.7;
+    min-width: 22px; min-height: 22px; display: inline-flex; align-items: center; justify-content: center; }
   .peek-attach-chip .chip-remove:hover { color: var(--red); opacity: 1; }
+  /* A failed chip stays put, holds still (no pulse — it is not progressing) and
+     carries its own way out: retry, or remove. */
+  .peek-attach-chip.failed { border-color: var(--red); animation: none; opacity: 1; }
+  .peek-attach-chip .chip-err { color: var(--red); font-size: 0.75rem; font-weight: 700; flex-shrink: 0; }
+  .peek-attach-chip .chip-retry { cursor: pointer; color: var(--dim); flex-shrink: 0; font-size: 0.85rem; line-height: 1;
+    min-width: 22px; min-height: 22px; display: inline-flex; align-items: center; justify-content: center; }
+  .peek-attach-chip .chip-retry:hover { color: var(--accent); }
+  @media (max-width: 600px) {
+    /* Thumb-sized targets. A remove control you cannot reliably hit is the same
+       as no remove control, which is the bug this change exists to fix. Two
+       adjacent 44px-WIDE targets do not fit a 180px chip without overlapping
+       each other's hit area, so the chip is allowed to take the full row and
+       the controls get full 44px height with a comfortable width. */
+    .peek-attach-chip { max-width: 100%; gap: 8px; }
+    .peek-attach-chip .chip-remove,
+    .peek-attach-chip .chip-retry { min-width: 36px; min-height: 44px; font-size: 1.2rem; }
+  }
   .peek-attach-summary {
     display: flex; align-items: center; gap: 8px; padding: 6px 10px;
     background: var(--card); border: 1px solid var(--border); border-radius: 8px;

--- a/crates/amux-dashboard/static/app.js
+++ b/crates/amux-dashboard/static/app.js
@@ -7779,7 +7779,7 @@ async function saveGlobalMemory() {
   }
 }
 
-const APP_VER = '0.9.680';   // bump together with the sw.js CACHE version
+const APP_VER = '0.9.681';   // bump together with the sw.js CACHE version
 
 // ── No silent failures (Ethan, 2026-08-09: "make sure every action has some
 // kind of response in the ui — i just deleted a worker and nothing happened").
@@ -9825,9 +9825,14 @@ function renderPeekFiles() {
     const totalMB = peekFiles.reduce((a, f) => a + (parseFloat(f.sizeMB) || 0), 0);
     const queued = _uploadQueue.length;
     let status = '';
+    const failed = peekFiles.filter(f => !f.path && (f.error || !f.inflight)).length;
     if (uploading > 0) {
       const avgPct = peekFiles.filter(f => !f.path).reduce((a, f) => a + (f.totalChunks ? f.chunk / f.totalChunks : 0), 0) / (uploading || 1);
-      status = `<span style="color:var(--dim)">${done}/${peekFiles.length} done (${Math.round(avgPct * 100)}%)${queued ? ', ' + queued + ' queued' : ''}</span>`;
+      // Failures must be visible in the COLLAPSED summary. Past 12 files the
+      // chips are hidden by default, so a failed upload would block Send from
+      // behind a row that only ever reported progress.
+      status = `<span style="color:var(--dim)">${done}/${peekFiles.length} done (${Math.round(avgPct * 100)}%)${queued ? ', ' + queued + ' queued' : ''}</span>`
+        + (failed ? `<span style="color:var(--red)">${failed} failed — tap to fix</span>` : '');
     } else {
       status = `<span style="color:var(--green)">all uploaded</span>`;
     }
@@ -9851,13 +9856,24 @@ function _renderPeekFileChips() {
       thumb = `<span class="chip-icon">${_fileIcon(f.name)}</span>`;
     }
     let statusHtml = '';
-    if (isUploading) {
+    if (!isUploading) {
+      statusHtml = `<span style="color:var(--green);font-size:0.75rem;margin-right:2px;">✓</span>`;
+    } else if (f.error) {
+      statusHtml = `<span class="chip-err" title="${esc(f.error)}">!</span>`
+        + `<span class="chip-retry" onclick="retryPeekFile(${i})" title="Retry this upload">↻</span>`;
+    } else {
       const pct = f.totalChunks ? Math.round(f.chunk / f.totalChunks * 100) : 0;
       statusHtml = `<span style="color:var(--dim);font-size:0.6rem;">${pct}%</span>`;
-    } else {
-      statusHtml = `<span style="color:var(--green);font-size:0.75rem;margin-right:2px;">✓</span><span class="chip-remove" onclick="removePeekFile(${i})">×</span>`;
     }
-    return `<div class="peek-attach-chip${isUploading ? ' uploading' : ''}">
+    // The × is rendered on EVERY chip, in every state. It used to appear only
+    // once an upload had FINISHED, so an attachment that never completed had no
+    // remove control at all — and sendPeekCmd() refuses while any chip lacks a
+    // .path, so one stuck chip made the composer permanently unsendable with no
+    // way out but abandoning the draft. An escape hatch that exists only in the
+    // success state is not an escape hatch.
+    statusHtml += `<span class="chip-remove" onclick="removePeekFile(${i})" title="Remove this attachment">×</span>`;
+    const _cls = f.path ? '' : (f.error || !f.inflight ? ' failed' : ' uploading');
+    return `<div class="peek-attach-chip${_cls}">
       ${thumb}
       <span class="chip-name">${esc(f.name)}</span>
       ${statusHtml}
@@ -9865,15 +9881,36 @@ function _renderPeekFileChips() {
   }).join('');
 }
 
+// Cancellation is a FLAG ON THE OBJECT, never "is it still in peekFiles?".
+// peekFiles is swapped wholesale by _peekFilesStash/_peekFilesRestore when the
+// peek closes or switches worker, so membership-based detection read a STASH as
+// a REMOVAL: it abandoned the transfer and left the placeholder sitting in the
+// stashed array at 0% forever. That is the zombie chip that blocks Send.
+function _cancelUpload(f) {
+  if (!f) return;
+  f.cancelled = true;
+  try { if (f.aborter) f.aborter.abort(); } catch (e) {}
+  f.inflight = false;
+}
+
 function removePeekFile(idx) {
   const f = peekFiles[idx];
-  if (f && f.previewUrl) URL.revokeObjectURL(f.previewUrl);
+  if (!f) return;
+  _cancelUpload(f);
+  if (f.previewUrl) URL.revokeObjectURL(f.previewUrl);
   peekFiles.splice(idx, 1);
   renderPeekFiles();
 }
 
+function retryPeekFile(idx) {
+  const f = peekFiles[idx];
+  if (!f || f.path || f.inflight) return;
+  if (!f.file) { showToast('The original file is no longer held — remove this chip and re-attach'); return; }
+  _runUpload(f);
+}
+
 function clearPeekFiles() {
-  peekFiles.forEach(f => { if (f && f.previewUrl) URL.revokeObjectURL(f.previewUrl); });
+  peekFiles.forEach(f => { _cancelUpload(f); if (f && f.previewUrl) URL.revokeObjectURL(f.previewUrl); });
   peekFiles = [];
   // Drop the stash too, or a send would clear the bar and the next open would
   // resurrect the files that were just sent.
@@ -9899,6 +9936,11 @@ function _peekFilesStash(session) {
 
 function _peekFilesRestore(session) {
   peekFiles = (session && _peekFilesBySession[session]) || [];
+  // An attachment that is neither uploaded nor still in flight cannot finish on
+  // its own. Show it as FAILED (Retry + ×) rather than as a chip frozen at a
+  // percentage, which is indistinguishable from progress and blocks Send with
+  // no recourse.
+  peekFiles.forEach(f => { if (f && !f.path && !f.inflight && !f.error) f.error = 'interrupted'; });
   renderPeekFiles();
 }
 
@@ -9945,52 +9987,77 @@ async function uploadAndAttach(file) {
   // another chip, a second attach, a failed-chunk retry that splices — so a
   // numeric index goes stale and the finished file writes to the wrong slot or a
   // placeholder never gets its .path (send then stalls on "wait for upload").
-  const placeholder = { name: file.name, path: null, url: null, isImage, previewUrl, sizeMB, chunk: 0, totalChunks };
+  //
+  // `file` is RETAINED so a failed upload can be retried from the chip itself.
+  // Without it, a transient failure (a server restart mid-upload answers the
+  // next chunk with 404 "unknown upload") means picking the file again by hand.
+  const placeholder = { name: file.name, path: null, url: null, isImage, previewUrl, sizeMB,
+                        chunk: 0, totalChunks, file, error: null, inflight: false, cancelled: false };
   peekFiles.push(placeholder);
+  await _runUpload(placeholder);
+}
+
+// Drives one attachment to completion. Safe to call again on a failed chip.
+// Progress is written by mutating `f` in place, so the transfer does not care
+// which array `f` currently lives in — the peek can close, switch worker and
+// reopen mid-upload and the chip still lands on its path.
+async function _runUpload(f) {
+  const file = f.file;
+  if (!file) { f.error = 'file no longer held'; renderPeekFiles(); return; }
+  f.error = null; f.cancelled = false; f.inflight = true; f.chunk = 0;
+  f.aborter = (typeof AbortController !== 'undefined') ? new AbortController() : null;
+  const _sig = f.aborter ? f.aborter.signal : undefined;
+  const totalChunks = f.totalChunks;
   _scheduleRenderPeekFiles();
-  const _present = () => peekFiles.indexOf(placeholder) >= 0;
 
   try {
     const startR = await fetch(API + '/api/upload/start', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: file.name, size: file.size, chunks: totalChunks })
+      body: JSON.stringify({ name: file.name, size: file.size, chunks: totalChunks }),
+      signal: _sig
     });
     const startD = await startR.json();
     if (!startR.ok || startD.error) throw new Error(startD.error || 'start failed');
     const uploadId = startD.id;
 
     for (let i = 0; i < totalChunks; i++) {
-      if (!_present()) return;
+      if (f.cancelled) return;   // user removed the chip mid-upload — stop cleanly
       const start = i * CHUNK_SIZE;
       const end = Math.min(start + CHUNK_SIZE, file.size);
       const blob = file.slice(start, end);
       const r = await fetch(API + '/api/upload/' + uploadId + '/chunk/' + i, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/octet-stream' },
-        body: blob
+        body: blob,
+        signal: _sig
       });
       if (!r.ok) {
         const d = await r.json().catch(() => ({}));
         throw new Error(d.error || 'chunk ' + i + ' failed');
       }
-      placeholder.chunk = i + 1;
+      f.chunk = i + 1;   // mutate the same object, wherever it now sits
       _scheduleRenderPeekFiles();
     }
 
-    const finR = await fetch(API + '/api/upload/' + uploadId + '/finish', { method: 'POST' });
+    const finR = await fetch(API + '/api/upload/' + uploadId + '/finish', { method: 'POST', signal: _sig });
     const finD = await finR.json();
     if (!finR.ok || finD.error) throw new Error(finD.error || 'finalize failed');
-    if (!_present()) return;
-    placeholder.path = finD.path;
-    placeholder.url = finD.url;
+    if (f.cancelled) return;   // removed while finishing — don't resurrect it
+    f.path = finD.path;
+    f.url = finD.url;
   } catch(e) {
+    if (f.cancelled) return;
     console.error('Upload error:', e);
-    showToast('Upload failed: ' + e.message);
-    const i = peekFiles.indexOf(placeholder);
-    if (i >= 0) peekFiles.splice(i, 1);
+    // KEEP the chip in a failed state instead of splicing it out. A vanishing
+    // chip loses the file silently behind one toast; a failed chip carries its
+    // own Retry and ×, so the user can act on it.
+    f.error = (e && e.message) || 'upload failed';
+    showToast('Upload failed: ' + f.error + ' — tap ↻ to retry or × to remove');
+  } finally {
+    f.inflight = false;
+    _scheduleRenderPeekFiles();
   }
-  _scheduleRenderPeekFiles();
 }
 
 function handlePeekFileInput(e) {
@@ -10074,7 +10141,18 @@ setTimeout(_updateSendSplit, 0);
 
 async function sendPeekCmd() {
   if (!peekSession) return;
-  if (peekFiles.some(f => !f.path)) { showToast('Wait for upload to finish'); return; }
+  // Name the blocker and say what to do about it. "Wait for upload to finish"
+  // is a lie when nothing is still transferring — which is exactly the state a
+  // stuck chip is in — and it left the user waiting on an upload that was never
+  // going to complete.
+  const _stuck = peekFiles.filter(f => !f.path);
+  if (_stuck.length) {
+    const _more = _stuck.length > 1 ? ' (+' + (_stuck.length - 1) + ' more)' : '';
+    showToast(_stuck.some(f => f.inflight)
+      ? 'Still uploading ' + _stuck[0].name + _more
+      : _stuck[0].name + _more + " didn't upload — tap ↻ to retry or × to remove");
+    return;
+  }
   const inp = document.getElementById('peek-cmd-input');
   const text = inp.value.trim();
   const files = peekFiles.filter(f => f.path);

--- a/crates/amux-dashboard/static/sw.js
+++ b/crates/amux-dashboard/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'amux-v0.9.680';
+const CACHE = 'amux-v0.9.681';
 const SHELL_URLS = ['/', '/manifest.json', '/icon.svg', '/icon.png', '/icon-192.png', '/icon-512.png'];
 
 // Install: pre-cache entire app shell

--- a/crates/amux-server/src/api/upload.rs
+++ b/crates/amux-server/src/api/upload.rs
@@ -129,6 +129,31 @@ async fn start(state: UploadState, Json(body): Json<StartReq>) -> Response {
         }
     }
 
+    // The map above is IN MEMORY, so every restart orphans the .chunked-* dirs
+    // on disk with no record left to purge them by — they accumulate forever
+    // (four empty ones were sitting in ~/.amux/uploads when this was found).
+    // Sweep the directory itself, skipping anything still tracked: a live
+    // upload's dir gets an mtime bump with each chunk written into it.
+    if let Ok(rd) = std::fs::read_dir(uploads_dir()) {
+        for ent in rd.flatten() {
+            let name = ent.file_name().to_string_lossy().to_string();
+            let Some(other_uid) = name.strip_prefix(".chunked-") else { continue };
+            if other_uid == uid || map.contains_key(other_uid) {
+                continue;
+            }
+            let is_stale = ent
+                .metadata()
+                .ok()
+                .filter(|m| m.is_dir())
+                .and_then(|m| m.modified().ok())
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .is_some_and(|d| d.as_secs() < cutoff);
+            if is_stale {
+                let _ = std::fs::remove_dir_all(ent.path());
+            }
+        }
+    }
+
     map.insert(uid.clone(), InFlight {
         filename,
         chunks: total_chunks,

--- a/e2e/upload-chip-escape.spec.ts
+++ b/e2e/upload-chip-escape.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * A peek attachment must ALWAYS be removable, and closing the peek must not
+ * strand one.
+ *
+ * WHAT BROKE (reported 2026-08-18, with the artifact: four EMPTY `.chunked-*`
+ * dirs in ~/.amux/uploads — uploads that got `start` and never wrote chunk 0).
+ *
+ * Two defects compounded into a composer that could not be used at all:
+ *
+ *   1. `uploadAndAttach` decided "did the user cancel?" by asking whether its
+ *      placeholder was still inside `peekFiles`. But `_peekFilesStash` SWAPS
+ *      THAT ARRAY WHOLESALE when the peek closes or switches worker, so closing
+ *      the peek mid-upload read as a removal: the transfer was abandoned and the
+ *      placeholder was left in the stashed array at 0%, forever.
+ *   2. The chip rendered its × only in the `done` branch. So the stranded chip —
+ *      the one state where you most need it — had no remove control, and
+ *      `sendPeekCmd()` refuses while any chip lacks a `.path`.
+ *
+ * Net effect: attach a picture, close the peek, reopen, and the composer is
+ * permanently unsendable with no way out but abandoning the draft.
+ *
+ * This drives the REAL functions against a stalled server, because the bug only
+ * exists while a transfer is in flight — a test that attaches an
+ * instantly-completing file passes against the broken code. The assertions are
+ * on the DOM and on a real click, not on internal state: the reported symptom
+ * was "no remove button", which is a rendering fact.
+ */
+
+type Win = Window & typeof globalThis & Record<string, any>;
+
+// Stall chunk 0 until released, so the chip is genuinely mid-upload.
+async function stubStalledUpload(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    const w = window as Win;
+    w.__release = null;
+    const gate = new Promise<void>((r) => { w.__release = r; });
+    w.__origFetch = w.fetch;
+    w.fetch = async (url: any, opts: any) => {
+      const u = String(url);
+      if (u.includes('/api/upload/start')) {
+        return new Response(JSON.stringify({ id: 'test01', chunks: 1 }), { status: 200 });
+      }
+      if (u.includes('/chunk/')) {
+        await Promise.race([
+          gate,
+          new Promise((_, rej) => opts?.signal?.addEventListener('abort', () => rej(new Error('aborted')))),
+        ]);
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      if (u.includes('/finish')) {
+        return new Response(JSON.stringify({ path: '/tmp/IMG_2987.png', url: '/api/uploads/IMG_2987.png' }), { status: 200 });
+      }
+      return w.__origFetch(url, opts);
+    };
+  });
+}
+
+async function attachStalledFile(page: import('@playwright/test').Page) {
+  await page.evaluate(() => {
+    const w = window as Win;
+    const f = new File([new Uint8Array(64)], 'IMG_2987.png', { type: 'image/png' });
+    w.uploadAndAttach(f);          // deliberately NOT awaited — it is stalled
+  });
+  await expect(page.locator('#peek-attach-bar .peek-attach-chip')).toHaveCount(1);
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+  await page.waitForFunction(() => typeof (window as any).uploadAndAttach === 'function', { timeout: 20000 });
+  await stubStalledUpload(page);
+});
+
+test('an in-flight attachment can still be removed', async ({ page }) => {
+  await attachStalledFile(page);
+
+  const chip = page.locator('#peek-attach-bar .peek-attach-chip');
+  const x = chip.locator('.chip-remove');
+  // The reported symptom, asserted directly: the control must EXIST while the
+  // upload is still running, not only after it succeeds.
+  await expect(x, 'an uploading chip must carry a remove control').toHaveCount(1);
+
+  await x.click();
+  await expect(chip, 'clicking x must actually remove the chip').toHaveCount(0);
+});
+
+test('closing the peek mid-upload does not strand the attachment', async ({ page }) => {
+  await attachStalledFile(page);
+
+  // Exactly what closePeek() -> openPeek() do around the composer draft.
+  await page.evaluate(() => (window as Win)._peekFilesStash('worker-a'));
+  await expect(page.locator('#peek-attach-bar .peek-attach-chip')).toHaveCount(0);
+
+  // The transfer must still be alive: let the stalled chunk through while the
+  // peek is CLOSED, which is the precise moment the old code gave up.
+  await page.evaluate(() => (window as Win).__release());
+
+  await page.evaluate(() => (window as Win)._peekFilesRestore('worker-a'));
+  const chip = page.locator('#peek-attach-bar .peek-attach-chip');
+  await expect(chip).toHaveCount(1);
+
+  // Either it finished (no longer 'uploading'), or it is honestly marked failed
+  // with a retry — what it must NOT be is a chip frozen mid-progress that no
+  // longer has anything driving it.
+  await expect
+    .poll(async () => chip.evaluate((el) => el.className), { timeout: 10_000 })
+    .not.toContain('uploading');
+
+  // And whatever state it landed in, there is a way out of it.
+  await expect(chip.locator('.chip-remove'), 'a restored chip must offer a way out').toHaveCount(1);
+});
+
+test('a failed attachment keeps its chip, with retry and remove', async ({ page }) => {
+  // Server rejects the chunk — the shape a mid-upload server restart produces
+  // ("unknown upload"), which used to delete the chip behind a single toast.
+  await page.evaluate(() => {
+    const w = window as Win;
+    w.fetch = async (url: any, opts: any) => {
+      const u = String(url);
+      if (u.includes('/api/upload/start')) {
+        return new Response(JSON.stringify({ id: 'test02', chunks: 1 }), { status: 200 });
+      }
+      if (u.includes('/chunk/')) {
+        return new Response(JSON.stringify({ error: 'unknown upload' }), { status: 404 });
+      }
+      return w.__origFetch(url, opts);
+    };
+  });
+
+  await page.evaluate(() => {
+    const w = window as Win;
+    w.uploadAndAttach(new File([new Uint8Array(8)], 'BROKEN.png', { type: 'image/png' }));
+  });
+
+  const chip = page.locator('#peek-attach-bar .peek-attach-chip');
+  await expect(chip, 'a failed upload must not silently vanish').toHaveCount(1);
+  await expect(chip.locator('.chip-retry'), 'failed chip offers retry').toHaveCount(1);
+  await expect(chip.locator('.chip-remove'), 'failed chip offers remove').toHaveCount(1);
+});

--- a/e2e/upload-chip-escape.spec.ts
+++ b/e2e/upload-chip-escape.spec.ts
@@ -68,7 +68,25 @@ async function attachStalledFile(page: import('@playwright/test').Page) {
 
 test.beforeEach(async ({ page }) => {
   await page.goto('/');
+  // Skip the first-run walkthrough via its own Skip button, as golden.spec.ts
+  // does. Its backdrop covers the page and swallows the chip click this suite
+  // is here to prove works — which failed as "x does not remove the chip", i.e.
+  // as the product bug, on all three targets.
+  const wt = page.locator('#wt-overlay.open');
+  await wt.waitFor({ state: 'visible', timeout: 8_000 }).catch(() => {});
+  if (await wt.isVisible()) {
+    await page.locator('#wt-tooltip .wt-skip').click();
+    await expect(wt).toBeHidden();
+  }
   await page.waitForFunction(() => typeof (window as any).uploadAndAttach === 'function', { timeout: 20000 });
+  // Open a peek so the composer is REALLY interactive. Without it the attach bar
+  // still renders and Playwright still calls the chip visible, but the closed
+  // overlay takes no pointer events, so the click lands on <body> — which
+  // reports as "x does not remove the chip", i.e. as this very bug. Calling
+  // openPeek directly is the house idiom (tab-customizer.spec.ts): the harness
+  // has no sessions to click on.
+  await page.evaluate(() => (window as Win).openPeek('e2e-probe'));
+  await page.waitForSelector('#peek-overlay', { state: 'visible', timeout: 15000 });
   await stubStalledUpload(page);
 });
 
@@ -88,15 +106,16 @@ test('an in-flight attachment can still be removed', async ({ page }) => {
 test('closing the peek mid-upload does not strand the attachment', async ({ page }) => {
   await attachStalledFile(page);
 
-  // Exactly what closePeek() -> openPeek() do around the composer draft.
-  await page.evaluate(() => (window as Win)._peekFilesStash('worker-a'));
+  // Switch to another worker and back — the real path, which is openPeek's own
+  // _peekFilesStash/_peekFilesRestore pair, not a hand-rolled imitation of it.
+  await page.evaluate(() => (window as Win).openPeek('e2e-other'));
   await expect(page.locator('#peek-attach-bar .peek-attach-chip')).toHaveCount(0);
 
   // The transfer must still be alive: let the stalled chunk through while the
   // peek is CLOSED, which is the precise moment the old code gave up.
   await page.evaluate(() => (window as Win).__release());
 
-  await page.evaluate(() => (window as Win)._peekFilesRestore('worker-a'));
+  await page.evaluate(() => (window as Win).openPeek('e2e-probe'));
   const chip = page.locator('#peek-attach-bar .peek-attach-chip');
   await expect(chip).toHaveCount(1);
 

--- a/frustrations.md
+++ b/frustrations.md
@@ -3074,3 +3074,56 @@ FIX: Migrated today's four entries here and verified against
   (c) have the rule REFUSE to append to a checkout that is behind origin, or at minimum
   warn. (c) is the one that survives the next time two checkouts drift, because this
   failure is silent by construction.
+
+---
+## An attachment stuck mid-upload has no remove control, and Send refuses forever
+AREA: instruments
+SEVERITY: blocks
+STATUS: fixed
+DATE: 2026-08-18
+SESSION: amux (Doron, reported from the phone)
+CARD: AMUX-85
+SYMPTOM: Attach images in a peek, close or switch the peek before they finish, reopen.
+  The chips come back frozen at a percentage and render NO × — the remove control only
+  ever existed in the `done` branch of `_renderPeekFileChips`. `sendPeekCmd` refuses
+  while any chip lacks a `.path`, and its toast says "Wait for upload to finish" for an
+  upload that no longer has anything driving it. Physical artifact: four EMPTY
+  `.chunked-*` dirs in ~/.amux/uploads — `/api/upload/start` succeeded, chunk 0 never
+  wrote, because `uploadAndAttach` inferred "the user cancelled" from
+  `peekFiles.indexOf(placeholder) >= 0` and `_peekFilesStash` swaps that array wholesale.
+COST: The composer was unusable for that worker — the user could not send the prompt the
+  pictures were attached to, and re-uploading only added more unremovable chips. The
+  reported experience was "no delete button, no remove button, no way for me to send".
+  Two failure modes of the same shape: a failed upload also deleted its own chip behind
+  one toast, silently losing the file.
+FIX: 8b89c89c — cancellation is an explicit flag plus an AbortController rather than array
+  membership, so a stash is no longer read as a removal; the × renders in EVERY chip
+  state; a failed upload keeps its chip with a retry (the File is retained); the send
+  guard names the file and says what to do. Regression cover:
+  e2e/upload-chip-escape.spec.ts, verified to FAIL against the parent commit.
+
+---
+## The freshness hook says a DELETED file "changed upstream", so a stale checkout gets fixed in the dead architecture
+AREA: instruments
+SEVERITY: slows
+STATUS: open
+DATE: 2026-08-18
+SESSION: amux (upload-chip fix)
+CARD: AMUX-86
+SYMPTOM: SessionStart reported "checkout is 1158 commit(s) behind origin/main — including:
+  CLAUDE.md amux amux-server.py". That names amux-server.py the way it names any changed
+  file. It was not changed, it was DELETED: the server is Rust now, the SPA lives in
+  `crates/amux-dashboard/static/`, and upstream CLAUDE.md line 28 says so plainly. The
+  local CLAUDE.md — 1158 commits old and the one actually loaded into context — still
+  describes the single-file Python server as ground truth, mentions `amux-server.py` 14
+  times, and prescribes `launchctl kickstart` to see a change go live.
+COST: A complete fix, its syntax checks and a 16-assertion behavioural harness, all
+  written against a file that no longer exists upstream, before the PR step revealed it.
+  The work ported, so the cost was time rather than a wrong result — but the failure mode
+  it sets up is worse than that: the honest next move for a session that does NOT check
+  is `git push origin main` of a commit re-adding a 70k-line deleted file. Following the
+  loaded CLAUDE.md exactly is what produces this.
+FIX: Have the hook classify by status, not just name: `git diff --diff-filter=D --name-only
+  HEAD..origin/main` distinguishes "changed" from "deleted upstream", and a deleted file
+  that CLAUDE.md still instructs sessions to edit deserves its own loud line. Ethos rule 7:
+  the sanctioned instruction was itself the theatre.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "amux",
+  "name": "up",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## The report

> I want to upload pictures but something [was] preventing me from uploading pictures last time so I re-uploaded them except I can't hit send because there are still pictures that seem to be trying to upload and no delete button. No remove button no way for me to send this prompt.

## Root cause — two defects that compound

**1. Cancellation was inferred from array membership.** `uploadAndAttach` decided "did the user remove this chip?" by asking `peekFiles.indexOf(placeholder) >= 0`. But `_peekFilesStash` **swaps `peekFiles` wholesale** when the peek closes or switches worker — so closing the peek mid-upload read as a *removal*. The transfer was abandoned and the placeholder was left sitting in the stashed array at 0%, with nothing left to drive it.

The artifact confirms it: four **empty** `.chunked-*` dirs in `~/.amux/uploads`. `/api/upload/start` had succeeded; chunk 0 never wrote. That is the signature of the loop bailing at `i = 0`.

**2. The escape hatch existed only in the success state.** The chip rendered its `×` inside the `done` branch, so the one state where you need it most — an upload that never finished — had no remove control at all. `sendPeekCmd()` refuses while any chip lacks a `.path`, so a single stranded chip made the composer permanently unsendable.

## The fix

- Cancellation is an **explicit flag + `AbortController`**, not array membership. The upload no longer cares which array it currently lives in: close the peek, switch worker, reopen — it still lands on its path.
- The **`×` renders on every chip in every state**.
- A **failed upload keeps its chip** with a retry, instead of being spliced out behind one toast (which silently lost the file). The original `File` is retained so retry is real.
- `_peekFilesRestore` marks an orphan (no path, not in flight) as failed, so it presents as something to act on rather than as frozen progress.
- The send guard **names the file and says what to do**. "Wait for upload to finish" is a lie when nothing is transferring — it is what kept the user waiting on an upload that was never going to complete.
- The >12-file summary row surfaces a **failed count**; past that threshold chips are collapsed, so a blocker could otherwise sit behind a row that only reported progress.
- **Server:** sweep orphan `.chunked-*` dirs by mtime. The in-flight map is in memory, so every restart orphaned its tmpdirs with no record left to purge them by.
- **Mobile:** 44px-tall chip controls, per the project rule.

## Verification

`e2e/upload-chip-escape.spec.ts` drives the real functions against a **stalled** upload, because the bug only exists while a transfer is in flight — a test using an instantly-completing file passes against the broken code.

| | pre-fix | post-fix |
|---|---|---|
| in-flight chip can be removed | ❌ | ✅ |
| closing the peek does not strand it | ❌ | ✅ |
| failed upload keeps chip + retry | ❌ | ✅ |

Control run with product code reverted to the parent commit and the spec kept: **all three fail**. Against the fix: **9/9 pass** on desktop, mobile and ios-safari. `npm run lint:spa` clean (0 errors, verified the gate still fails on an injected undefined name); `cargo check` and `cargo clippy -p amux-server` clean.

Logged in `frustrations.md` as AMUX-85, plus AMUX-86 for a separate instrument defect found on the way in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)