### PR TITLE
fix(freshness): merging is not deploying — report the running build's lag (AEAB-32)

### DIFF
--- a/.claude/session-freshness.sh
+++ b/.claude/session-freshness.sh
@@ -121,6 +121,48 @@ if [ -r "$PROV" ]; then
     out+=$'    intentional pin? fine. accident? put the build source back on main —\n'
     out+=$'    develop in a git worktree, never in the checkout the builder watches\n'
   fi
+
+  # ── Axis 1d (AEAB-32): is the RUNNING BUILD behind origin/main? ────────────
+  #
+  # `on_main` above catches a build off a BRANCH. It says nothing about the more
+  # common and more dangerous case: the build is on main, on_main reads `yes`,
+  # and main has simply moved on without it. Both look identical in the
+  # provenance file, so the one instrument that exists here could not express
+  # the difference.
+  #
+  # It matters because MERGING IS NOT DEPLOYING. The builder rebuilds when the
+  # build source's LOCAL HEAD moves, and it deliberately never fetches — it runs
+  # on a 60s timer and must not touch the network, which is a decision recorded
+  # in rust-auto-build.sh and left alone here. So a merged fix reaches the fleet
+  # only when somebody advances that checkout by hand. Measured twice:
+  # `423dd00c` fixed a live worker panic at 2026-08-13 22:15 and the fleet ran
+  # the panicking binary until 09:11 the next morning (39 panics fired inside
+  # that window); and on 2026-08-18 a merged PR did not reach the fleet until
+  # the build source was moved off the feature branch by hand.
+  #
+  # This hook is the right place for it precisely because it ALREADY fetched
+  # above — the number costs nothing here and would cost a network call per
+  # minute in the builder. Report, never act: nothing below touches a tree.
+  if [ -n "${prov_sha:-}" ] && git rev-parse --verify -q origin/main >/dev/null 2>&1; then
+    if git cat-file -e "${prov_sha}^{commit}" 2>/dev/null; then
+      built_behind="$(git rev-list --count "${prov_sha}..origin/main" 2>/dev/null || echo 0)"
+      if [ "${built_behind:-0}" -gt 0 ]; then
+        # Age of the OLDEST commit the running build is missing. A count alone
+        # reads as bookkeeping; "and the oldest is 11 hours old" is the number
+        # that says whether a fix has been sitting undeployed overnight.
+        oldest="$(git log -1 --format=%cr "${prov_sha}..origin/main" 2>/dev/null | tail -1)"
+        out+="  - the RUNNING SERVER is ${built_behind} commit(s) behind origin/main"$'\n'
+        out+="    built ${prov_sha:0:9}; oldest undeployed commit landed ${oldest:-?}"$'\n'
+        out+=$'    merging does NOT deploy — the build source advances only when someone\n'
+        out+=$'    moves it. A fix on main is not a fix in prod until then.\n'
+      fi
+    else
+      # An unknown sha is INFORMATIVE, not a parse failure to swallow: it means
+      # the fleet is running a commit that never reached origin at all.
+      out+="  - the RUNNING SERVER's build ${prov_sha:0:9} is not a commit this checkout knows"$'\n'
+      out+=$'    it never reached origin — nothing upstream contains what is running\n'
+    fi
+  fi
 fi
 
 # ── Axis 2: does what is INSTALLED match this checkout? ──────────────────────

--- a/scripts/test-session-freshness.sh
+++ b/scripts/test-session-freshness.sh
@@ -66,7 +66,14 @@ mk() { # $1 name  $2 n_ahead  $3 n_behind
       echo "SETUP BROKEN for '$1': wanted ahead=$2 behind=$3, got ahead=$a behind=$b"
       exit 0
     fi
-    bash .claude/session-freshness.sh 2>&1
+    # ISOLATION. Point provenance at a path that does not exist, so these cases
+    # test the git axes ONLY. Without this the hook reads the developer's real
+    # ~/.amux/rust-build-provenance.json — whose sha a synthetic repo has never
+    # heard of — and case (a) fails on this machine while passing in CI, where
+    # no such file exists. A test whose verdict depends on the host's state is
+    # not testing the hook.
+    AMUX_RS_BUILD_PROVENANCE="$TMP/no-such-provenance.json" \
+      bash .claude/session-freshness.sh 2>&1
   )
 }
 
@@ -134,6 +141,91 @@ lacks "$PROVMARK" "$out"
 
 out=$(prov_run 'not json at all')        # garbage — must not warn on a bad parse
 lacks "$PROVMARK" "$out"
+
+# ---------------------------------------------------------------------------
+# (f) AEAB-32 — the RUNNING BUILD's lag behind origin/main. `on_main` cannot
+#     express this: a build sitting on main while main moves on reads `yes`.
+#     Measured cost of not saying it: a worker-panic fix merged 2026-08-13 22:15
+#     did not reach the fleet until 09:11 the next morning, and 39 panics fired
+#     in between.
+#
+#     The CONTROL (h) is the load-bearing case here. A probe wired to the wrong
+#     ref would report a lag on every session, and a banner that always fires is
+#     one nobody reads — which this hook's own header names as the reason it
+#     stays silent when things are current.
+# ---------------------------------------------------------------------------
+BEHINDMARK="behind origin/main"
+NEVERMARK="not a commit this checkout knows"
+
+# Builds an origin+clone, then writes a provenance file naming a commit that is
+# `$1` commits back from origin/main. Real repos and the shipped hook, so this
+# cannot pass against a paraphrase of the logic.
+lag_run() { # $1 = how many commits the BUILT sha is behind origin/main
+  local d="$TMP/lag$1"; rm -rf "$d"
+  git init -q --bare -b main "$d/origin.git"
+  git clone -q "$d/origin.git" "$d/work" 2>/dev/null
+  local built=""
+  ( cd "$d/work"
+    git checkout -q -B main
+    mkdir -p .claude; cp "$HOOK" .claude/session-freshness.sh
+    echo seed > seed.txt; git add -A; git commit -qm seed
+    git push -q -u origin main ) >/dev/null 2>&1
+  built=$(cd "$d/work" && git rev-parse HEAD)
+  if [ "$1" -gt 0 ]; then
+    ( cd "$d/work"
+      for i in $(seq 1 "$1"); do echo "n$i" > "n$i.txt"; git add -A; git commit -qm "n$i"; done
+      git push -q origin main ) >/dev/null 2>&1
+  fi
+  local pf="$d/prov.json"
+  printf '{"sha":"%s","ref":"main","on_main":"yes","built_at":"x"}\n' "$built" > "$pf"
+  # SELF-CHECK before consulting the hook: if the repo is not in the shape the
+  # case claims, a setup bug would read as a hook bug.
+  ( cd "$d/work"
+    git fetch -q origin 2>/dev/null
+    got=$(git rev-list --count "${built}..origin/main" 2>/dev/null || echo x)
+    if [ "$got" != "$1" ]; then echo "SETUP BROKEN for lag$1: wanted behind=$1, got $got"; exit 0; fi
+    AMUX_RS_BUILD_PROVENANCE="$pf" bash .claude/session-freshness.sh 2>&1 )
+}
+
+# (f) the running build is 3 commits stale — must say so, with the count.
+out=$(lag_run 3)
+if setup_ok "lag3" "$out"; then
+  says "$BEHINDMARK" "$out"
+  says "3 commit(s) behind" "$out"
+  says "merging does NOT deploy" "$out"
+  lacks "$PROVMARK" "$out"        # it IS on main; only the LAG is the complaint
+fi
+
+# (g) CONTROL — the running build IS origin/main. Silence, or the banner is noise.
+out=$(lag_run 0)
+if setup_ok "lag0" "$out"; then
+  lacks "$BEHINDMARK" "$out"
+  lacks "$NEVERMARK" "$out"
+fi
+
+# (h) A sha this checkout has never heard of: the fleet is running something that
+#     never reached origin. That is informative, not a parse error to swallow —
+#     and it must NOT be reported as an ordinary lag, which would understate it.
+#     Needs a REAL origin: with no origin/main the hook cannot judge any sha and
+#     correctly stays silent, so reusing prov_run here would have asserted
+#     nothing (it is how this case failed on first run).
+unknown_run() {
+  local d="$TMP/unknown"; rm -rf "$d"
+  git init -q --bare -b main "$d/origin.git"
+  git clone -q "$d/origin.git" "$d/work" 2>/dev/null
+  ( cd "$d/work"
+    git checkout -q -B main
+    mkdir -p .claude; cp "$HOOK" .claude/session-freshness.sh
+    echo seed > seed.txt; git add -A; git commit -qm seed
+    git push -q -u origin main ) >/dev/null 2>&1
+  local pf="$d/prov.json"
+  printf '{"sha":"%s","ref":"main","on_main":"yes","built_at":"x"}\n' \
+    "0123456789abcdef0123456789abcdef01234567" > "$pf"
+  ( cd "$d/work"; AMUX_RS_BUILD_PROVENANCE="$pf" bash .claude/session-freshness.sh 2>&1 )
+}
+out=$(unknown_run)
+says "$NEVERMARK" "$out"
+lacks "$BEHINDMARK" "$out"
 
 echo
 echo "test-session-freshness: $PASS passed, $FAIL failed"


### PR DESCRIPTION
The provenance file says WHICH commit was built. It cannot say whether that
commit is current, so a build sitting on main while main moves on reads
on_main:yes and looks healthy. That is the common case and the dangerous one.

It matters because the builder rebuilds when the build source's LOCAL HEAD
moves and deliberately never fetches -- it runs on a 60s timer and must not
touch the network. So a merged fix reaches the fleet only when somebody
advances that checkout by hand, and nothing anywhere reports the gap.

Measured twice:

- 423dd00c fixed a live Map-index worker panic at 2026-08-13 22:15. The
  builder's own log shows the fleet stayed on 8747d20f until 09:11 the next
  morning; 39 panics fired inside that window at 01:48. The fix was on main
  the whole time.
- 2026-08-18: PR #123 merged, and the builder did not pick it up because the
  build source had been left on the feature branch. It only built the merge
  commit after the checkout was moved by hand.

An earlier draft of this proposed making the builder fetch. That contradicts a
decision already recorded in rust-auto-build.sh, so it is not what shipped.
The SessionStart hook ALREADY fetches, so the number is free there, and it is
where a session is about to act on the answer.

Two branches, deliberately distinct: behind origin/main reports the count, the
built sha and how long ago the OLDEST undeployed commit landed (a bare count
reads as bookkeeping; "oldest landed 11 hours ago" says a fix sat overnight).
A sha this checkout has never heard of is reported separately -- the fleet is
running something that never reached origin, and calling that an ordinary lag
would understate it.

The tests caught two real defects on their first run:

- Every pre-existing mk case was reading the developer's REAL
  ~/.amux/rust-build-provenance.json. It had never mattered because the old
  code only fired on on_main:no and the real file says yes. The new branch
  fires on an unknown sha, which a synthetic repo always produces -- so the
  control failed on this machine and would have PASSED in CI, where no such
  file exists. A test whose verdict depends on host state is not testing the
  hook. Now pinned to a nonexistent path.
- Case (h) ran against a repo with no origin, where the hook cannot judge any
  sha and correctly says nothing -- so it was asserting over a path it never
  reached. Rebuilt with a real origin.

Mutation-checked: reporting unconditionally fails the control (1 of 23);
never reporting fails 3 of 23. 23/23 on the real code. Live: silent in the
build source (built sha == origin/main), and in a checkout 1159 commits behind
it reports the CHECKOUT lag and no build lag -- a stale checkout and a stale
deploy are different facts and now read differently.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx
