### PR TITLE
docs(readme): fix the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,4 +213,4 @@ amux is growing into the durable operating system around agents: it owns executi
 
 If amux saves you time, a ⭐ helps others find it.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=mixpeek/amux&type=Date)](https://star-history.com/#mixpeek/amux&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=mixpeek/amux&type=Date)](https://star-history.dera.page/#mixpeek/amux&Date)


### PR DESCRIPTION
The star history chart in the README no longer loads: the endpoint it pointed at is broken because of GitHub stargazer API restrictions, so anyone landing on the README sees a dead image instead of the project's growth.

This swaps the chart image and its link to star-history.dera.page, a maintained mirror that works without an API token and keeps the same owner and type parameters. No other badges or links are touched.