### PR TITLE
fix(autofix): the du size cache went to ~/.amux/.amux/, and a premise correction

### DIFF
--- a/crates/amux-server/src/runtime_jobs/autofix.rs
+++ b/crates/amux-server/src/runtime_jobs/autofix.rs
@@ -1679,7 +1679,12 @@ pub fn detect_disk(now: f64, home: &std::path::Path) -> (Vec<Finding>, Vec<Suppr
 
     // Only now pay for `du` — a directory walk on every tick would be a
     // detector whose cost lands on the resource it is watching.
-    let du_cache = home.join(".amux").join("du-sizes.json");
+    // `home` here is the AMUX home (`~/.amux`), NOT `$HOME` — see the call site,
+    // which passes `autofix::amux_home()`. Joining ".amux" again wrote the cache
+    // to `~/.amux/.amux/du-sizes.json`, which worked but left a stray nested
+    // directory and would confuse anyone looking for it. Caught only by checking
+    // the shipped path in prod rather than assuming the deploy matched intent.
+    let du_cache = home.join("du-sizes.json");
     let top = du_top(&disk_candidates(home), 8, Some(&du_cache));
     // A carried-forward figure is LABELLED, never presented as a fresh
     // measurement. The whole value of keeping it is that the reader can weigh
@@ -3365,6 +3370,27 @@ mod tests {
         assert!(
             reloaded.contains_key(&dir.path().display().to_string()),
             "a fresh process must be able to read back what this one measured: {reloaded:?}"
+        );
+    }
+
+    /// Pins WHERE the cache lives, because the name `home` at the detect_disk
+    /// call site is the AMUX home (`~/.amux`), not `$HOME` — and the first cut of
+    /// this joined ".amux" again, writing to `~/.amux/.amux/du-sizes.json`. It
+    /// worked, so no test and no log line objected; it was found by looking at
+    /// the shipped filesystem after the deploy. This asserts the file lands
+    /// directly in the directory it is given.
+    #[test]
+    fn the_size_cache_lands_directly_in_the_amux_home_not_a_nested_one() {
+        let _g = du_env_lock();
+        let fake_amux_home = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("f"), vec![0u8; 32 * 1024]).unwrap();
+        let cf = fake_amux_home.path().join("du-sizes.json");
+        let _ = du_top(&[dir.path().to_path_buf()], 8, Some(&cf));
+        assert!(cf.exists(), "cache must be written at the path given");
+        assert!(
+            !fake_amux_home.path().join(".amux").exists(),
+            "no nested .amux directory may be created"
         );
     }
 

--- a/frustrations.md
+++ b/frustrations.md
@@ -3157,9 +3157,18 @@ SYMPTOM: `disk: size ranking is INCOMPLETE — these paths exceeded the du budge
   Measured by hand with `du` unbounded, those paths hold 9.9G + 6.4G, against 3.7G free.
   `du` time scales with size, so the budget skips the LARGEST directories by
   construction: the ranking that survives lists the also-rans as the top consumers. And
-  `~/.Trash` never times out at all — `du` returns "Operation not permitted" (macOS TCC)
-  — but a failure and a timeout both returned `None` and were reported under the same
-  "exceeded the du budget" message, which is false for that path and always will be.
+  a failure and a timeout both returned `None` and were reported under the same "exceeded
+  the du budget" message, so an unreadable path was indistinguishable from a slow one.
+  CORRECTION, measured in prod AFTER the fix shipped and recorded here rather than left
+  standing: I claimed `~/.Trash` was the specimen — "Operation not permitted, not slow".
+  That is true of MY SHELL and NOT of the server. The launchd-spawned server has the
+  access my interactive shell lacks, so it really does walk `.Trash` and really does time
+  out; prod has logged ZERO "could not be READ" lines since deploy and `.Trash` still
+  appears in the timed-out list. I measured from the producer's vantage and attributed it
+  to the consumer, which is the exact inversion ethos rule 4 warns about. The code change
+  is still correct — an unreadable path and a timeout genuinely need different responses —
+  but the motivating example was wrong, and no test would have caught that because the
+  test asks `du` itself whether the case is live and correctly skipped when it was not.
 COST: The auto-filed card AMUX-30 ("disk: 4.2 GB free, below the 50 GB floor") says of
   itself "It is a REPORT, not a diagnosis: the evidence below is computed, the cause is
   not." The cause was missing because this ranker skipped it — so the one card raised


### PR DESCRIPTION
Two things found by checking the SHIPPED path in prod rather than assuming the
deploy matched the intent.

1. `home` at the detect_disk call site is the AMUX home (~/.amux), not $HOME --
   the caller passes autofix::amux_home(). Joining ".amux" onto it again wrote
   the cache to ~/.amux/.amux/du-sizes.json. It WORKED, so no test and no log
   line objected; it left a stray nested directory and would send anyone
   looking for the file to the wrong place. Now home.join("du-sizes.json"),
   with a test pinning that no nested .amux is created -- a bug with no symptom
   needs a test, not a log line.

2. PREMISE CORRECTION, carried in the comments so it does not get re-derived.
   The previous commit said ~/.Trash "is permission-denied, not slow" and used
   it as the motivating specimen. That is true of an interactive shell and NOT
   of this server: the launchd-spawned process has disk access the shell lacks,
   so it really does walk .Trash and really does time out. Since deploy, prod
   has logged ZERO "could not be READ at all" lines and .Trash still appears
   among the budget overruns.

   I measured from the producer's vantage and attributed the result to the
   consumer, which is the inversion ethos rule 4 names explicitly. The code is
   unchanged and still correct -- an unreadable path and a slow one genuinely
   need different responses, and the discrimination will fire wherever EPERM
   actually occurs -- but the example was wrong. No test caught it because the
   specimen test asks du whether the case is live and correctly skipped when it
   was not: a test honest about being inapplicable still cannot tell you your
   premise was wrong.

The carry-forward itself is confirmed working in prod: ~/.npm is remembered at
6.92 GB and no longer vanishes on the ticks it blows the budget. It also
surfaced something nobody had measured -- amux's OWN build caches,
rust-build-target-e2e-head at 4.52 GB and rust-build-target at 1.09 GB, i.e.
5.6 GB of amux's own data against 3.7 GB free.

Residual, stated rather than glossed: carry-forward only helps a path sized
successfully at least once. ~/Library/Caches (9.9 GB) has never completed a
walk within budget, so it still has no figure and is still absent. This
converts "sometimes visible" into "always visible", not "never visible" into
visible.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx
