### PR TITLE
fix(build): the low-disk clear deleted the cache it was about to fill (AEAB-34)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -151,8 +151,15 @@ jobs:
       # unconditionally would pass the incident case while being pure noise, and
       # the hook's own header names silence-when-current as the reason it gets
       # read at all.
-      - name: SessionStart freshness hook (AEAB-18) + build provenance (AEAB-12)
+      # The disk-clear case is ORDERING, not behaviour: the builder used to delete
+      # the cache it was about to fill while a 4x larger idle one sat beside it,
+      # so it burned a cold build every 60s and never relieved the pressure.
+      # Its control (nothing cleared above the floor) and its last-resort case
+      # (the shared dir must STILL be reachable) are what stop the fix becoming
+      # either a no-op or a reintroduction of the disk-full outage.
+      - name: SessionStart freshness hook (AEAB-18) + build provenance (AEAB-12) + disk clear (AEAB-34)
         run: |
           set -uo pipefail
           ./scripts/test-session-freshness.sh
           ./scripts/test-build-provenance.sh
+          ./scripts/test-build-disk-clear.sh

--- a/crates/amux-server/src/api/reclaim.rs
+++ b/crates/amux-server/src/api/reclaim.rs
@@ -201,6 +201,21 @@ fn devtool_roots() -> Vec<(PathBuf, &'static str, &'static str)> {
             "build",
             "Shared cargo target dir",
         ),
+        // The BIGGER sibling, and it was missing from this list for as long as
+        // it has existed. Measured 2026-08-19: 4.2GB here against 1.0GB in the
+        // shared dir, on a machine that had reached 1GB free — so the tool whose
+        // whole job is finding reclaimable space was blind to the largest
+        // reclaimable directory amux owns.
+        //
+        // This is the hand-maintained-list failure: the list agrees with reality
+        // until something new appears, and the day it disagrees is the day it is
+        // needed. Written by e2e/serve-head.sh (a debug-profile build), so it is
+        // fully regenerable and costs one cold e2e run.
+        (
+            home.join(".amux/rust-build-target-e2e-head"),
+            "build",
+            "e2e head-build cargo target dir",
+        ),
     ]
 }
 
@@ -1581,6 +1596,7 @@ mod tests {
         let home = home_dir();
         let must_allow: Vec<PathBuf> = vec![
             home.join(".amux/rust-build-target"),
+            home.join(".amux/rust-build-target-e2e-head"),
             home.join("Library/Caches"),
             home.join("Library/Developer/Xcode/DerivedData"),
             home.join(".ollama/models"),

--- a/crates/amux-server/src/runtime_jobs/autofix.rs
+++ b/crates/amux-server/src/runtime_jobs/autofix.rs
@@ -1679,7 +1679,12 @@ pub fn detect_disk(now: f64, home: &std::path::Path) -> (Vec<Finding>, Vec<Suppr
 
     // Only now pay for `du` — a directory walk on every tick would be a
     // detector whose cost lands on the resource it is watching.
-    let du_cache = home.join(".amux").join("du-sizes.json");
+    // `home` here is the AMUX home (`~/.amux`), NOT `$HOME` — see the call site,
+    // which passes `autofix::amux_home()`. Joining ".amux" again wrote the cache
+    // to `~/.amux/.amux/du-sizes.json`, which worked but left a stray nested
+    // directory and would confuse anyone looking for it. Caught only by checking
+    // the shipped path in prod rather than assuming the deploy matched intent.
+    let du_cache = home.join("du-sizes.json");
     let top = du_top(&disk_candidates(home), 8, Some(&du_cache));
     // A carried-forward figure is LABELLED, never presented as a fresh
     // measurement. The whole value of keeping it is that the reader can weigh
@@ -3365,6 +3370,27 @@ mod tests {
         assert!(
             reloaded.contains_key(&dir.path().display().to_string()),
             "a fresh process must be able to read back what this one measured: {reloaded:?}"
+        );
+    }
+
+    /// Pins WHERE the cache lives, because the name `home` at the detect_disk
+    /// call site is the AMUX home (`~/.amux`), not `$HOME` — and the first cut of
+    /// this joined ".amux" again, writing to `~/.amux/.amux/du-sizes.json`. It
+    /// worked, so no test and no log line objected; it was found by looking at
+    /// the shipped filesystem after the deploy. This asserts the file lands
+    /// directly in the directory it is given.
+    #[test]
+    fn the_size_cache_lands_directly_in_the_amux_home_not_a_nested_one() {
+        let _g = du_env_lock();
+        let fake_amux_home = tempfile::tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("f"), vec![0u8; 32 * 1024]).unwrap();
+        let cf = fake_amux_home.path().join("du-sizes.json");
+        let _ = du_top(&[dir.path().to_path_buf()], 8, Some(&cf));
+        assert!(cf.exists(), "cache must be written at the path given");
+        assert!(
+            !fake_amux_home.path().join(".amux").exists(),
+            "no nested .amux directory may be created"
         );
     }
 

--- a/frustrations.md
+++ b/frustrations.md
@@ -3204,3 +3204,38 @@ FIX: `du_one` now returns a typed `DuOutcome` — `Sized` / `TimedOut` /
   never been visible because the budgets in play were large enough not to break a
   neighbour. A new case using a 1ms budget broke one, and the failure appeared in a test
   with nothing wrong in it. All seven now take a shared lock.
+
+---
+## The low-disk emergency clear deleted the cache it was about to fill, and spared a 4x larger idle one
+AREA: instruments
+SEVERITY: slows
+STATUS: fixed
+DATE: 2026-08-19
+SESSION: amux-errors-and-bugs
+CARD: AEAB-34
+SYMPTOM: `scripts/rust-auto-build.sh` cleared `~/.amux/rust-build-target` unconditionally
+  when free space fell below its floor — the cache filled by the very next line of the
+  same script — while `~/.amux/rust-build-target-e2e-head` sat untouched beside it at
+  4.2 GB. From the builder's own log: fired 16 times, free space still reached 1 GB, and
+  each pass freed ~2 GB that the immediately-following cold build put straight back.
+  Separately, `api/reclaim.rs` — the subsystem whose whole job is finding reclaimable
+  space — had `rust-build-target` in its candidate list and not `-e2e-head`, so it was
+  blind to the largest reclaimable directory amux owns.
+COST: Every build on this machine today was cold (~1m40s instead of ~15s incremental),
+  16 times over, and the pressure was never relieved — the volume still reached 1 GB free.
+  The guard was doing the maximum possible damage per byte reclaimed: the most expensive
+  cache to lose, the least space freed, and it regrew immediately. It also masked the real
+  answer, since a "DISK LOW, clearing the target dir" line reads like the guard working.
+FIX: Clear candidates in order of what the current build does NOT need — idle e2e cache
+  first, re-measure, and touch the shared target dir only if still under the floor. Moved
+  ahead of the worktree checkout, because that writes 1000+ files and freeing space after
+  consuming it is the wrong order on a nearly-full volume. `-e2e-head` added to reclaim's
+  candidates and its allow-list guard test.
+  `scripts/test-build-disk-clear.sh` (6 cases, wired into checks.yml) runs the SHIPPED
+  script through a dry-run seam and asserts ORDERING, which is the whole fix.
+  Mutation-checked three ways: shared-only fails the ordering case, unconditional clearing
+  fails the above-the-floor control, and never-clearing-the-shared-dir fails the
+  last-resort case — that last mutation passes the ordering test while reintroducing the
+  disk-full outage the guard exists to prevent, which is exactly why that case is there.
+  The hand-maintained candidate list is the deeper issue and is NOT fixed: it will go stale
+  again the next time a directory appears. Noted on AEAB-34 rather than papered over.

--- a/frustrations.md
+++ b/frustrations.md
@@ -3239,3 +3239,31 @@ FIX: Clear candidates in order of what the current build does NOT need — idle 
   disk-full outage the guard exists to prevent, which is exactly why that case is there.
   The hand-maintained candidate list is the deeper issue and is NOT fixed: it will go stale
   again the next time a directory appears. Noted on AEAB-34 rather than papered over.
+
+---
+## The build-disk guard used a BSD-only `df -g`, so it was a silent no-op on Linux
+AREA: instruments
+SEVERITY: slows
+STATUS: fixed
+DATE: 2026-08-19
+SESSION: amux-errors-and-bugs
+CARD: AEAB-34
+SYMPTOM: `scripts/rust-auto-build.sh` measured free space with `df -g` and candidate
+  sizes with `du -sg`. Both flags are BSD-only. On GNU coreutils: `df: invalid option --
+  'g'`, so `FREE_GB` comes back EMPTY, `${FREE_GB:-999}` substitutes 999, and the disk
+  guard never fires — while printing nothing that says it did not run.
+COST: Zero on this machine (macOS, where the flags work), which is exactly why it went
+  unnoticed. The cost is latent and it is the shape that matters: a guard whose failure
+  mode is "silently does not run" on any Linux host, in a repo whose single-codebase rule
+  says the same code must work in both places. Found ONLY because a new test ran it in CI
+  — and even then the ordering assertions caught it INCIDENTALLY, because the script died
+  rather than because anything asserted the number.
+FIX: `df -Pk` and `du -sk` with the GB conversion in awk — POSIX, and already the
+  convention on the Rust side (`storage::disk_free_bytes` has used `df -Pk` all along).
+  So this was one convention inside the codebase drifting from another, not an oversight
+  about portability in general.
+  Two new assertions in `scripts/test-build-disk-clear.sh` check that the free-space and
+  candidate-size figures PARSE TO A NUMBER, because the ordering cases cannot: they force
+  the branch with a huge floor, so an unparsed figure still reaches the loop and the
+  regression is caught only by luck. Mutation-checked: restoring a bad df flag fails case
+  (f) specifically, not just the ordering cases.

--- a/frustrations.md
+++ b/frustrations.md
@@ -3157,9 +3157,18 @@ SYMPTOM: `disk: size ranking is INCOMPLETE — these paths exceeded the du budge
   Measured by hand with `du` unbounded, those paths hold 9.9G + 6.4G, against 3.7G free.
   `du` time scales with size, so the budget skips the LARGEST directories by
   construction: the ranking that survives lists the also-rans as the top consumers. And
-  `~/.Trash` never times out at all — `du` returns "Operation not permitted" (macOS TCC)
-  — but a failure and a timeout both returned `None` and were reported under the same
-  "exceeded the du budget" message, which is false for that path and always will be.
+  a failure and a timeout both returned `None` and were reported under the same "exceeded
+  the du budget" message, so an unreadable path was indistinguishable from a slow one.
+  CORRECTION, measured in prod AFTER the fix shipped and recorded here rather than left
+  standing: I claimed `~/.Trash` was the specimen — "Operation not permitted, not slow".
+  That is true of MY SHELL and NOT of the server. The launchd-spawned server has the
+  access my interactive shell lacks, so it really does walk `.Trash` and really does time
+  out; prod has logged ZERO "could not be READ" lines since deploy and `.Trash` still
+  appears in the timed-out list. I measured from the producer's vantage and attributed it
+  to the consumer, which is the exact inversion ethos rule 4 warns about. The code change
+  is still correct — an unreadable path and a timeout genuinely need different responses —
+  but the motivating example was wrong, and no test would have caught that because the
+  test asks `du` itself whether the case is live and correctly skipped when it was not.
 COST: The auto-filed card AMUX-30 ("disk: 4.2 GB free, below the 50 GB floor") says of
   itself "It is a REPORT, not a diagnosis: the evidence below is computed, the cause is
   not." The cause was missing because this ranker skipped it — so the one card raised

--- a/scripts/rust-auto-build.sh
+++ b/scripts/rust-auto-build.sh
@@ -172,11 +172,19 @@ fi
   # stop as soon as the floor is cleared. `-e2e-head` belongs to e2e/serve-head.sh
   # and is regenerable; clearing it costs a cold e2e build the next time someone
   # runs e2e locally, which is far rarer than this 60s tick.
-  FREE_GB=$(df -g "$HOME" | awk 'NR==2{print $4}')
+  # `df -Pk` / `du -sk`, NOT `df -g` / `du -sg`. The -g forms are BSD-only: GNU
+  # coreutils rejects them with "df: invalid option -- 'g'", FREE_GB comes back
+  # EMPTY, `${FREE_GB:-999}` substitutes 999, and the guard silently never fires.
+  # A disk guard that is a no-op on Linux while reporting nothing is the shape
+  # this repo keeps finding — it does not fail, it just quietly does not run.
+  # Caught by scripts/test-build-disk-clear.sh on its first CI run; the Rust side
+  # already had it right (storage::disk_free_bytes uses `df -Pk`), so this was
+  # one convention drifting from another inside the same codebase.
+  FREE_GB=$(df -Pk "$HOME" | awk 'NR==2{print int($4/1048576)}')
   if [ "${FREE_GB:-999}" -lt "${AMUX_BUILD_MIN_FREE_GB:-25}" ]; then
     for cand in "$HOME/.amux/rust-build-target-e2e-head" "$HOME/.amux/rust-build-target"; do
       [ -d "$cand" ] || continue
-      CAND_GB=$(du -sg "$cand" 2>/dev/null | awk '{print $1}')
+      CAND_GB=$(du -sk "$cand" 2>/dev/null | awk '{print int($1/1048576)}')
       if [ "$cand" = "$HOME/.amux/rust-build-target" ]; then
         echo "== DISK LOW: ${FREE_GB}GB free. Clearing the ${CAND_GB:-?}GB SHARED target dir — this build goes cold."
       else
@@ -188,7 +196,7 @@ fi
       # is about to use. Under dry-run there is nothing to re-measure, so keep
       # listing candidates to show the full order.
       if [ "${AMUX_RS_DISK_CLEAR_DRYRUN:-}" != "1" ]; then
-        FREE_GB=$(df -g "$HOME" | awk 'NR==2{print $4}')
+        FREE_GB=$(df -Pk "$HOME" | awk 'NR==2{print int($4/1048576)}')
         if [ "${FREE_GB:-999}" -ge "${AMUX_BUILD_MIN_FREE_GB:-25}" ]; then
           echo "== reclaimed to ${FREE_GB}GB free — the shared target dir is untouched, so this build stays warm."
           break

--- a/scripts/rust-auto-build.sh
+++ b/scripts/rust-auto-build.sh
@@ -144,11 +144,9 @@ fi
     echo "==    with no CI and no review. Intentional pin? fine. Accident? put"
     echo "==    $REPO back on main — develop in a git worktree, not the build source."
   fi
-  # Build from a clean, committed snapshot: a worktree of HEAD, so nobody's
-  # uncommitted edits (or a mid-edit broken tree) can poison the deploy.
-  WORK=$(mktemp -d /tmp/amux-rs-build.XXXXXX)
-  git -C "$REPO" worktree add --detach "$WORK" "$(git -C "$REPO" rev-parse HEAD)" >/dev/null
-  # DISK GUARD (AMUX-2754). The shared target dir has no GC — cargo never
+  # DISK GUARD (AMUX-2754). Runs BEFORE the worktree checkout below, because
+  # that checkout writes 1000+ files — freeing space after consuming it is the
+  # wrong order when the whole point is that the volume is nearly full. The shared target dir has no GC — cargo never
   # reclaims — so it grows without bound, and on 2026-08-10 the volume hit
   # 741MB free with a 50-session fleet and writes failing with ENOSPC.
   #
@@ -161,12 +159,49 @@ fi
   # Clearing the cache costs one cold build (~3min, once). That is the cheap
   # side of this trade by a wide margin: the expensive side is every lane
   # failing to write.
+  # CLEAR THE IDLE CACHE FIRST, AND THE ONE THIS BUILD NEEDS ONLY AS A LAST
+  # RESORT. Until 2026-08-19 this deleted `rust-build-target` unconditionally —
+  # the cache it was ABOUT TO FILL on the very next line — while
+  # `rust-build-target-e2e-head` sat untouched beside it at 4.2GB. Measured that
+  # day: the clear fired 16 times, free space still reached 1GB, and each pass
+  # freed ~2GB that the immediately-following cold build put straight back. A
+  # treadmill that burns a cold build every 60s and never relieves the pressure,
+  # while four times as much reclaimable space sat one directory over.
+  #
+  # So: order by what this build does NOT need, re-measure between steps, and
+  # stop as soon as the floor is cleared. `-e2e-head` belongs to e2e/serve-head.sh
+  # and is regenerable; clearing it costs a cold e2e build the next time someone
+  # runs e2e locally, which is far rarer than this 60s tick.
   FREE_GB=$(df -g "$HOME" | awk 'NR==2{print $4}')
   if [ "${FREE_GB:-999}" -lt "${AMUX_BUILD_MIN_FREE_GB:-25}" ]; then
-    TGT_GB=$(du -sg "$HOME/.amux/rust-build-target" 2>/dev/null | awk '{print $1}')
-    echo "== DISK LOW: ${FREE_GB}GB free (< ${AMUX_BUILD_MIN_FREE_GB:-25}GB). Clearing the ${TGT_GB:-?}GB shared target dir; next build is cold."
-    rm -rf "$HOME/.amux/rust-build-target"
+    for cand in "$HOME/.amux/rust-build-target-e2e-head" "$HOME/.amux/rust-build-target"; do
+      [ -d "$cand" ] || continue
+      CAND_GB=$(du -sg "$cand" 2>/dev/null | awk '{print $1}')
+      if [ "$cand" = "$HOME/.amux/rust-build-target" ]; then
+        echo "== DISK LOW: ${FREE_GB}GB free. Clearing the ${CAND_GB:-?}GB SHARED target dir — this build goes cold."
+      else
+        echo "== DISK LOW: ${FREE_GB}GB free. Clearing the ${CAND_GB:-?}GB idle e2e target dir first (this build does not need it)."
+      fi
+      # A seam so the ORDERING is testable without a 4GB fixture or a real build.
+      [ "${AMUX_RS_DISK_CLEAR_DRYRUN:-}" = "1" ] || rm -rf "$cand"
+      # Re-measure: if the idle cache was enough, never touch the one this build
+      # is about to use. Under dry-run there is nothing to re-measure, so keep
+      # listing candidates to show the full order.
+      if [ "${AMUX_RS_DISK_CLEAR_DRYRUN:-}" != "1" ]; then
+        FREE_GB=$(df -g "$HOME" | awk 'NR==2{print $4}')
+        if [ "${FREE_GB:-999}" -ge "${AMUX_BUILD_MIN_FREE_GB:-25}" ]; then
+          echo "== reclaimed to ${FREE_GB}GB free — the shared target dir is untouched, so this build stays warm."
+          break
+        fi
+      fi
+    done
   fi
+  if [ "${AMUX_RS_DISK_CLEAR_ONLY:-}" = "1" ]; then exit 0; fi
+
+  # Build from a clean, committed snapshot: a worktree of HEAD, so nobody's
+  # uncommitted edits (or a mid-edit broken tree) can poison the deploy.
+  WORK=$(mktemp -d /tmp/amux-rs-build.XXXXXX)
+  git -C "$REPO" worktree add --detach "$WORK" "$(git -C "$REPO" rev-parse HEAD)" >/dev/null
   # Shared target dir: incremental rebuilds (~15s) instead of cold ones
   # (~3min) — the worktree isolates SOURCE, the cache is content-keyed.
   # CAPTURE THE WHOLE BUILD, THEN DECIDE WHAT TO KEEP (AMUX-2927).

--- a/scripts/test-build-disk-clear.sh
+++ b/scripts/test-build-disk-clear.sh
@@ -71,6 +71,24 @@ if printf '%s\n' "$out3" | grep -qE "DISK LOW"; then
   bad "(d) with free space above the floor nothing may be cleared" "$out3"
 else ok; fi
 
+# --- (f) the free-space figure must actually PARSE -------------------------
+#     This is why (a)-(c) failed on their first CI run, and they failed only
+#     INCIDENTALLY: the script used `df -g`, which is BSD-only, so GNU coreutils
+#     printed "df: invalid option -- 'g'", FREE_GB came back empty and the guard
+#     silently never fired. A disk guard that is a no-op on Linux while reporting
+#     nothing is exactly the shape this repo keeps finding.
+#
+#     Ordering assertions cannot catch that on their own — they force the branch
+#     with a huge floor, so an unparsed figure still reaches the loop. Assert the
+#     NUMBER, or the portability regression is only ever caught by luck.
+if printf '%s\n' "$out" | grep -qE "DISK LOW: [0-9]+GB free"; then ok
+else bad "(f) the free-space figure must parse to a number (df -Pk, not the BSD-only df -g)" "$out"; fi
+
+# --- (g) the per-candidate size must parse too -----------------------------
+#     Same defect one line over: `du -sg` is BSD-only in the same way.
+if printf '%s\n' "$out" | grep -qE "Clearing the [0-9]+GB"; then ok
+else bad "(g) the candidate size must parse to a number (du -sk, not the BSD-only du -sg)" "$out"; fi
+
 # --- (e) the dry-run seam must not actually delete -------------------------
 #     If it deleted, every case above would be testing a destroyed fixture and
 #     (a) would still pass — so this is what makes the others trustworthy.

--- a/scripts/test-build-disk-clear.sh
+++ b/scripts/test-build-disk-clear.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# AEAB-34 — the auto-builder's low-disk clear must free the IDLE cache before
+# the one the build it is about to run depends on.
+#
+# The bug this pins: until 2026-08-19 the clear deleted `rust-build-target`
+# unconditionally — the cache filled by the very next line — while
+# `rust-build-target-e2e-head` sat untouched at 4.2GB. Measured that day: it
+# fired 16 times, free space still reached 1GB, and each pass freed ~2GB that
+# the following cold build put straight back. A treadmill costing a cold build
+# every 60s while four times the space sat one directory over.
+#
+# Ordering is the whole fix, so ordering is what this asserts. It runs the
+# SHIPPED script through its dry-run seam rather than restating the logic.
+#
+# Exit 0 = all pass, 1 = a failure. Wired into .github/workflows/checks.yml.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+SCRIPT="$(pwd)/scripts/rust-auto-build.sh"
+PASS=0; FAIL=0
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+
+# The script redirects its whole build block to $LOG, so stdout is empty by
+# design — read the log it actually writes. AMUX_RS_BUILD_LOG is the existing
+# seam for that. Getting this wrong the first time made every case report
+# "<empty>", which looked like the script doing nothing rather than the harness
+# reading the wrong stream.
+run() { # $1 = fake HOME
+  local lg="$1/build.log"
+  HOME="$1" \
+  AMUX_RS_BUILD_LOG="$lg" \
+  AMUX_BUILD_MIN_FREE_GB=999999 \
+  AMUX_RS_DISK_CLEAR_DRYRUN=1 \
+  AMUX_RS_DISK_CLEAR_ONLY=1 \
+    bash "$SCRIPT" >/dev/null 2>&1
+  cat "$lg" 2>/dev/null
+}
+
+ok()   { PASS=$((PASS+1)); }
+bad()  { FAIL=$((FAIL+1)); echo "FAIL: $1"; echo "  got: ${2:-<empty>}"; }
+
+# --- (a) both caches present: the IDLE one must be named FIRST -------------
+H="$TMP/both"; mkdir -p "$H/.amux/rust-build-target" "$H/.amux/rust-build-target-e2e-head"
+out=$(run "$H")
+idle_line=$(printf '%s\n' "$out" | grep -n "idle e2e target dir" | head -1 | cut -d: -f1)
+shared_line=$(printf '%s\n' "$out" | grep -n "SHARED target dir" | head -1 | cut -d: -f1)
+if [ -n "$idle_line" ] && [ -n "$shared_line" ] && [ "$idle_line" -lt "$shared_line" ]; then ok
+else bad "(a) the idle e2e cache must be cleared BEFORE the shared one" "$out"; fi
+
+# --- (b) the shared dir must still be reachable as a LAST resort -----------
+#     A fix that simply never touched it would pass (a) while reintroducing the
+#     original disk-full outage this clear exists to prevent.
+if printf '%s\n' "$out" | grep -q "SHARED target dir"; then ok
+else bad "(b) the shared dir must remain a last-resort candidate" "$out"; fi
+
+# --- (c) the shared dir alone: it is still cleared, not skipped ------------
+H2="$TMP/sharedonly"; mkdir -p "$H2/.amux/rust-build-target"
+out2=$(run "$H2")
+if printf '%s\n' "$out2" | grep -q "SHARED target dir"; then ok
+else bad "(c) with only the shared dir present it must still be cleared" "$out2"; fi
+if printf '%s\n' "$out2" | grep -q "idle e2e target dir"; then
+  bad "(c) must not claim to clear an e2e dir that does not exist" "$out2"
+else ok; fi
+
+# --- (d) CONTROL: above the floor, clear NOTHING ---------------------------
+#     Without this, a script that cleared unconditionally passes every case
+#     above — and would delete both caches on every 60s tick forever.
+H3="$TMP/plenty"; mkdir -p "$H3/.amux/rust-build-target" "$H3/.amux/rust-build-target-e2e-head"
+out3=$(HOME="$H3" AMUX_RS_BUILD_LOG="$H3/build.log" AMUX_BUILD_MIN_FREE_GB=0 \
+  AMUX_RS_DISK_CLEAR_DRYRUN=1 AMUX_RS_DISK_CLEAR_ONLY=1 bash "$SCRIPT" >/dev/null 2>&1; cat "$H3/build.log" 2>/dev/null)
+if printf '%s\n' "$out3" | grep -qE "DISK LOW"; then
+  bad "(d) with free space above the floor nothing may be cleared" "$out3"
+else ok; fi
+
+# --- (e) the dry-run seam must not actually delete -------------------------
+#     If it deleted, every case above would be testing a destroyed fixture and
+#     (a) would still pass — so this is what makes the others trustworthy.
+if [ -d "$H/.amux/rust-build-target" ] && [ -d "$H/.amux/rust-build-target-e2e-head" ]; then ok
+else bad "(e) dry-run must not remove anything" "dirs were deleted"; fi
+
+echo
+echo "test-build-disk-clear: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
rust-auto-build.sh cleared ~/.amux/rust-build-target unconditionally when free
space fell below its floor -- the cache filled by the very next line of the
same script -- while ~/.amux/rust-build-target-e2e-head sat untouched beside
it at 4.2GB.

From the builder's own log: it fired 16 times, free space still reached 1GB,
and each pass freed ~2GB that the immediately-following cold build put
straight back. Maximum damage per byte reclaimed: the most expensive cache to
lose, the least space freed, and it regrew at once. It also masked the real
answer, because "DISK LOW, clearing the target dir" reads like the guard
working. This is why every build on this machine today was cold (~1m40s rather
than ~15s incremental) -- not that the cache was too big, but that the clear
kept deleting the one thing the build needed.

The clear now orders candidates by what the CURRENT BUILD DOES NOT NEED: idle
e2e cache first, re-measure, and touch the shared target dir only if still
under the floor. The shared dir remains reachable as a last resort, because a
fix that simply never touched it would reintroduce the disk-full outage this
guard exists to prevent (AMUX-2754: 741MB free with a 50-session fleet and
writes failing with ENOSPC).

Moved ahead of the worktree checkout. That checkout writes 1000+ files, and
freeing space after consuming it is the wrong order when the premise is that
the volume is nearly full.

Second defect, same root: api/reclaim.rs -- the subsystem whose entire job is
finding reclaimable space -- listed .amux/rust-build-target and not -e2e-head,
so it was blind to the largest reclaimable directory amux owns. Added, with
its allow-list guard test. The hand-maintained list is the deeper problem and
is NOT fixed here: it agrees with reality until something new appears, and the
day it disagrees is the day it is needed. Named on the card rather than
papered over.

scripts/test-build-disk-clear.sh (6 cases, wired into checks.yml) runs the
SHIPPED script through a dry-run seam and asserts ORDERING, which is the whole
fix. Mutation-checked three ways, each caught by the case built for it:
shared-only fails the ordering case; clearing unconditionally fails the
above-the-floor control; never clearing the shared dir fails the last-resort
case -- that mutation passes the ordering test while reintroducing the outage,
which is precisely why that case exists.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx
