### PR TITLE
fix(build): split the fleet floor from the build's own cache threshold (AEAB-35)

### DIFF
--- a/frustrations.md
+++ b/frustrations.md
@@ -3267,3 +3267,38 @@ FIX: `df -Pk` and `du -sk` with the GB conversion in awk — POSIX, and already 
   the branch with a huge floor, so an unparsed figure still reaches the loop and the
   regression is caught only by luck. Mutation-checked: restoring a bad df flag fails case
   (f) specifically, not just the ordering cases.
+
+---
+## I wrote a keep-warm branch that could never execute, hours after writing about that exact failure mode
+AREA: instruments
+SEVERITY: annoys
+STATUS: fixed
+DATE: 2026-08-19
+SESSION: amux-errors-and-bugs
+CARD: AEAB-35
+SYMPTOM: AEAB-34's fix added an early exit to the builder's disk guard — reclaim the idle
+  cache, and if free space is back above the floor, keep the shared cache so the build
+  stays warm. The branch fired ZERO times and could not: it tested against
+  `AMUX_BUILD_MIN_FREE_GB` (25GB) on a volume with 4GB free, so after reclaiming the idle
+  cache the condition was still false and the shared cache was destroyed anyway.
+  `grep -c "reclaimed to" rust-auto-build.log` -> 0.
+COST: Half a fix presented as a whole one. The card AEAB-34 is titled "so every build is
+  cold" and every build stayed cold; only prod verification caught it, and only because I
+  looked for the branch's OUTPUT rather than re-reading the code. Had I not, the card would
+  have closed claiming a result it did not deliver.
+FIX: Two thresholds, because there are two questions —
+  `AMUX_BUILD_MIN_FREE_GB` (25) asks "is the FLEET at ENOSPC risk", which is what decides
+  whether to reclaim at all; `AMUX_BUILD_SACRIFICE_CACHE_BELOW_GB` (8) asks "can THIS BUILD
+  proceed while keeping its cache". Between them, reclaim the idle caches and stay warm.
+  Two test cases that EXECUTE the branch, driving the shipped script with a fake `df`
+  placed in `$HOME/.cargo/bin` — the script exports its own minimal PATH whose first entry
+  is exactly that, so no test-only branch is added to production code. Mutation-checked:
+  restoring the single threshold fails the keep-warm case specifically.
+WHY IT IS WORTH AN ENTRY EVEN THOUGH I FIXED IT: the ethos file records "a threshold below
+  the baseline is not a detector", and this is its mirror — a stop condition ABOVE the
+  achievable maximum is not a stop condition. I had cited that rule in a commit message the
+  same morning. Authoring a rule does not install the habit; that is the third instance of
+  that sentence being true in this session, and the pattern is only visible because the
+  earlier two were also written down. The generalisable check: when adding an early exit,
+  state the RANGE OF INPUTS under which it fires, and confirm the live system produces
+  values in that range.

--- a/scripts/rust-auto-build.sh
+++ b/scripts/rust-auto-build.sh
@@ -180,25 +180,54 @@ fi
   # Caught by scripts/test-build-disk-clear.sh on its first CI run; the Rust side
   # already had it right (storage::disk_free_bytes uses `df -Pk`), so this was
   # one convention drifting from another inside the same codebase.
+  # TWO THRESHOLDS, BECAUSE THERE ARE TWO QUESTIONS (AEAB-35). The first cut of
+  # this used one number for both and the keep-warm exit below became DEAD CODE:
+  # it fired only once free space reached AMUX_BUILD_MIN_FREE_GB (25GB), on a
+  # volume sitting at 4GB, so after reclaiming the idle cache the condition was
+  # still false and the shared cache was destroyed anyway. Measured: zero
+  # "reclaimed to" lines, ever. A stop condition above the achievable maximum is
+  # not a stop condition — the mirror of "a threshold below the baseline is not a
+  # detector", and it reads perfectly sensibly in review.
+  #
+  #   AMUX_BUILD_MIN_FREE_GB (25)             — is the FLEET at ENOSPC risk?
+  #                                             Right number for that; AMUX-2754
+  #                                             is 741MB free with lanes failing
+  #                                             to write. It decides whether to
+  #                                             reclaim AT ALL.
+  #   AMUX_BUILD_SACRIFICE_CACHE_BELOW_GB (8) — can THIS BUILD proceed while
+  #                                             keeping its cache? A cargo build
+  #                                             plus a ~5GB target dir needs
+  #                                             single-digit GB, not 25.
+  #
+  # Between the two, reclaim the idle caches and let the build stay warm. Below
+  # the lower one, the shared cache genuinely is worth a cold build.
   FREE_GB=$(df -Pk "$HOME" | awk 'NR==2{print int($4/1048576)}')
   if [ "${FREE_GB:-999}" -lt "${AMUX_BUILD_MIN_FREE_GB:-25}" ]; then
     for cand in "$HOME/.amux/rust-build-target-e2e-head" "$HOME/.amux/rust-build-target"; do
       [ -d "$cand" ] || continue
+      if [ "$cand" = "$HOME/.amux/rust-build-target" ]; then
+        # LAST RESORT. Only sacrifice the cache this build needs when free space
+        # is below the level at which the build could keep it.
+        if [ "${FREE_GB:-0}" -ge "${AMUX_BUILD_SACRIFICE_CACHE_BELOW_GB:-8}" ]; then
+          echo "== reclaimed to ${FREE_GB}GB free (>= ${AMUX_BUILD_SACRIFICE_CACHE_BELOW_GB:-8}GB) — keeping the shared target dir, so this build stays warm."
+          break
+        fi
+      fi
       CAND_GB=$(du -sk "$cand" 2>/dev/null | awk '{print int($1/1048576)}')
       if [ "$cand" = "$HOME/.amux/rust-build-target" ]; then
-        echo "== DISK LOW: ${FREE_GB}GB free. Clearing the ${CAND_GB:-?}GB SHARED target dir — this build goes cold."
+        echo "== DISK LOW: ${FREE_GB}GB free (< ${AMUX_BUILD_SACRIFICE_CACHE_BELOW_GB:-8}GB). Clearing the ${CAND_GB:-?}GB SHARED target dir — this build goes cold."
       else
         echo "== DISK LOW: ${FREE_GB}GB free. Clearing the ${CAND_GB:-?}GB idle e2e target dir first (this build does not need it)."
       fi
       # A seam so the ORDERING is testable without a 4GB fixture or a real build.
       [ "${AMUX_RS_DISK_CLEAR_DRYRUN:-}" = "1" ] || rm -rf "$cand"
-      # Re-measure: if the idle cache was enough, never touch the one this build
-      # is about to use. Under dry-run there is nothing to re-measure, so keep
-      # listing candidates to show the full order.
+      # Re-measure between candidates: what the idle cache freed is what decides
+      # whether the shared one survives. Under dry-run there is nothing to
+      # re-measure, so keep listing candidates to show the full order.
       if [ "${AMUX_RS_DISK_CLEAR_DRYRUN:-}" != "1" ]; then
         FREE_GB=$(df -Pk "$HOME" | awk 'NR==2{print int($4/1048576)}')
         if [ "${FREE_GB:-999}" -ge "${AMUX_BUILD_MIN_FREE_GB:-25}" ]; then
-          echo "== reclaimed to ${FREE_GB}GB free — the shared target dir is untouched, so this build stays warm."
+          echo "== reclaimed to ${FREE_GB}GB free — above the fleet floor, nothing further to clear."
           break
         fi
       fi

--- a/scripts/test-build-disk-clear.sh
+++ b/scripts/test-build-disk-clear.sh
@@ -24,11 +24,20 @@ TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
 # seam for that. Getting this wrong the first time made every case report
 # "<empty>", which looked like the script doing nothing rather than the harness
 # reading the wrong stream.
+# BOTH thresholds are pinned, never inherited. AMUX_BUILD_SACRIFICE_CACHE_BELOW_GB
+# defaults to 8, so with only the fleet floor forced these ordering cases would
+# pass on a nearly-full dev machine (4GB free -> below 8 -> shared dir cleared)
+# and FAIL on a CI runner with tens of GB free, where the keep-warm branch fires
+# and the shared dir is spared. That is the same host-dependence that made an
+# earlier suite in this repo green locally and red in CI. Pin it high so these
+# cases exercise the sacrifice path deterministically; the keep-warm path gets
+# its own cases below.
 run() { # $1 = fake HOME
   local lg="$1/build.log"
   HOME="$1" \
   AMUX_RS_BUILD_LOG="$lg" \
   AMUX_BUILD_MIN_FREE_GB=999999 \
+  AMUX_BUILD_SACRIFICE_CACHE_BELOW_GB=999999 \
   AMUX_RS_DISK_CLEAR_DRYRUN=1 \
   AMUX_RS_DISK_CLEAR_ONLY=1 \
     bash "$SCRIPT" >/dev/null 2>&1
@@ -66,6 +75,7 @@ else ok; fi
 #     above — and would delete both caches on every 60s tick forever.
 H3="$TMP/plenty"; mkdir -p "$H3/.amux/rust-build-target" "$H3/.amux/rust-build-target-e2e-head"
 out3=$(HOME="$H3" AMUX_RS_BUILD_LOG="$H3/build.log" AMUX_BUILD_MIN_FREE_GB=0 \
+  AMUX_BUILD_SACRIFICE_CACHE_BELOW_GB=0 \
   AMUX_RS_DISK_CLEAR_DRYRUN=1 AMUX_RS_DISK_CLEAR_ONLY=1 bash "$SCRIPT" >/dev/null 2>&1; cat "$H3/build.log" 2>/dev/null)
 if printf '%s\n' "$out3" | grep -qE "DISK LOW"; then
   bad "(d) with free space above the floor nothing may be cleared" "$out3"
@@ -94,6 +104,69 @@ else bad "(g) the candidate size must parse to a number (du -sk, not the BSD-onl
 #     (a) would still pass — so this is what makes the others trustworthy.
 if [ -d "$H/.amux/rust-build-target" ] && [ -d "$H/.amux/rust-build-target-e2e-head" ]; then ok
 else bad "(e) dry-run must not remove anything" "dirs were deleted"; fi
+
+# ---------------------------------------------------------------------------
+# (h)(i) AEAB-35 — the KEEP-WARM branch must actually EXECUTE.
+#
+# The version this replaces had that branch present, sensible-looking, and DEAD:
+# it exited early only once free space reached the FLEET floor (25GB) on a volume
+# sitting at 4GB, so the shared cache was destroyed every single time. Zero
+# "reclaimed to" lines, ever. A stop condition above the achievable maximum is
+# not a stop condition, and every test above passes with it dead — they assert
+# ordering and parsing, not that the exit is reachable.
+#
+# So these drive the script with a FAKE `df` earlier in PATH, reporting a value
+# BETWEEN the two thresholds. No test-only branch is added to the script itself:
+# it calls `df` unqualified, so a shim is enough, and the shipped code path is
+# what runs. Dry-run is OFF here because the decision depends on re-measuring
+# after a real delete — which is exactly the interaction that was broken.
+# ---------------------------------------------------------------------------
+shim() { # $1 = fake HOME, $2 = GB the fake df should report
+  # The script EXPORTS its own minimal PATH (line 17) — correct for launchd, and
+  # it means prepending to PATH from here has no effect. But that PATH starts
+  # with "$HOME/.cargo/bin", and $HOME is already faked for these cases, so the
+  # shim goes there and is found first. No test-only branch in the shipped code:
+  # the script calls `df` unqualified and the real code path runs.
+  mkdir -p "$1/.cargo/bin"
+  {
+    echo '#!/bin/sh'
+    echo '# Fake df in the -Pk shape the script parses.'
+    echo 'echo "Filesystem 1024-blocks Used Available Capacity Mounted on"'
+    echo "echo \"/dev/fake 100000000 0 $(( $2 * 1048576 )) 1% /\""
+  } > "$1/.cargo/bin/df"
+  chmod +x "$1/.cargo/bin/df"
+}
+
+keepwarm_run() { # $1 name  $2 reported free GB
+  local d="$TMP/$1"; rm -rf "$d"
+  mkdir -p "$d/.amux/rust-build-target" "$d/.amux/rust-build-target-e2e-head"
+  echo x > "$d/.amux/rust-build-target/marker"
+  shim "$d" "$2"
+  PATH="$d/bin:$PATH" HOME="$d" AMUX_RS_BUILD_LOG="$d/build.log" \
+    AMUX_BUILD_MIN_FREE_GB=25 AMUX_BUILD_SACRIFICE_CACHE_BELOW_GB=8 \
+    AMUX_RS_DISK_CLEAR_ONLY=1 bash "$SCRIPT" >/dev/null 2>&1
+  cat "$d/build.log" 2>/dev/null
+}
+
+# (h) 12GB free: under the fleet floor (25) but ABOVE the sacrifice line (8).
+#     Reclaim the idle cache, KEEP the shared one, and the build stays warm.
+out4=$(keepwarm_run keepwarm 12)
+if printf '%s\n' "$out4" | grep -q "stays warm"; then ok
+else bad "(h) between the thresholds the keep-warm branch must FIRE" "$out4"; fi
+if [ -f "$TMP/keepwarm/.amux/rust-build-target/marker" ]; then ok
+else bad "(h) the shared target dir must SURVIVE between the thresholds" "$out4"; fi
+if [ -d "$TMP/keepwarm/.amux/rust-build-target-e2e-head" ]; then
+  bad "(h) the idle cache must still have been cleared" "$out4"
+else ok; fi
+
+# (i) 3GB free: below BOTH. The shared cache is genuinely worth sacrificing, or
+#     the fix would have traded dead code for a guard that never protects.
+out5=$(keepwarm_run sacrifice 3)
+if printf '%s\n' "$out5" | grep -q "SHARED target dir"; then ok
+else bad "(i) below the sacrifice line the shared dir must still be cleared" "$out5"; fi
+if [ -f "$TMP/sacrifice/.amux/rust-build-target/marker" ]; then
+  bad "(i) the shared target dir should have been deleted below the sacrifice line" "$out5"
+else ok; fi
 
 echo
 echo "test-build-disk-clear: $PASS passed, $FAIL failed"


### PR DESCRIPTION
The keep-warm exit added yesterday was DEAD CODE. It spared the shared cargo
cache only once free space reached AMUX_BUILD_MIN_FREE_GB (25GB), on a volume
sitting at 4GB -- so after reclaiming the idle cache the condition was still
false and the cache this build needs was destroyed every time. Zero "reclaimed
to" lines, ever.

One number was answering two different questions:

  AMUX_BUILD_MIN_FREE_GB (25)              is the FLEET at ENOSPC risk? The
                                           right number for that -- AMUX-2754
                                           is 741MB free with lanes failing to
                                           write. Decides whether to reclaim
                                           at all.
  AMUX_BUILD_SACRIFICE_CACHE_BELOW_GB (8)  can THIS BUILD proceed while keeping
                                           its cache? A cargo build plus a ~5GB
                                           target dir needs single-digit GB.

Between them: reclaim the idle caches, keep the shared one, build stays warm.
Below the lower one the cache genuinely is worth a cold build, so the guard
still protects the fleet -- a fix that simply never cleared it would have
traded dead code for a guard that never fires, and case (i) pins that.

This is the mirror of the ethos file's "a threshold below the baseline is not
a detector": a stop condition ABOVE the achievable maximum is not a stop
condition. It reads perfectly sensibly in review, and every existing test
passed with it dead -- they assert ordering and parsing, not reachability.

So the two new cases EXECUTE the branch. They drive the shipped script with a
fake `df` in $HOME/.cargo/bin, because the script exports its own minimal PATH
whose first entry is exactly that -- no test-only branch is added to
production code, and `df` stays unqualified. Mutation-checked: restoring the
single threshold fails the keep-warm case specifically.

Honest about the local effect: this machine has 4GB free, below the sacrifice
line, so builds here stay cold until disk is freed. The fix makes the branch
reachable, not the machine healthy.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx

Amux-Session: amux-errors-and-bugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx