### PR TITLE
fix(instruments): a per-run dedupe is not a dedupe when the run is on a timer (AEAB-45)

### DIFF
--- a/crates/amux-server/src/api/session_verbs.rs
+++ b/crates/amux-server/src/api/session_verbs.rs
@@ -8330,20 +8330,13 @@ fn steer_skips() -> &'static std::sync::Mutex<BTreeMap<String, SkipRecord>> {
 /// cadence: two spellings of "the same stall" would drift, and the whole defect
 /// is that one surface deduped and the other did not.
 ///
-/// In-process, not durable, and that is the right trade here: the event idem is
-/// DB-backed because a missed notification is lost, whereas re-stating an
-/// ongoing problem once per server start is useful rather than noisy. Entries
-/// from past buckets are pruned so the set cannot grow without bound.
+/// The MECHANISM now lives in `crate::log_dedupe` for the same reason, one level
+/// up: AEAB-45 found the identical shape in the disk-ranking warning (1,336
+/// identical lines in 24h, 77% of the window), and copying this function there
+/// would have been the second spelling this comment warns about. See that module
+/// for why the cadence is hourly rather than once-ever.
 fn stall_log_first_this_bucket(key: &str, bucket: i64) -> bool {
-    static M: std::sync::OnceLock<std::sync::Mutex<(i64, std::collections::BTreeSet<String>)>> =
-        std::sync::OnceLock::new();
-    let m = M.get_or_init(|| std::sync::Mutex::new((i64::MIN, std::collections::BTreeSet::new())));
-    let Ok(mut g) = m.lock() else { return true };   // fail OPEN: log rather than swallow
-    if g.0 != bucket {
-        g.0 = bucket;
-        g.1.clear();
-    }
-    g.1.insert(key.to_string())
+    crate::log_dedupe::first_this_bucket(key, bucket)
 }
 
 fn skip(session: &str, id: &str, reason: &str) {
@@ -8391,7 +8384,7 @@ async fn warn_on_stalled_lanes(state: &AppState) {
         // line can share the event path's dedupe key. Same call, same frequency —
         // only the order moved.
         let blocked = lane_block_reason(&session).await;
-        let bucket = (now / 3600.0) as i64;
+        let bucket = crate::log_dedupe::hour_bucket(now);
         let cond = blocked.unwrap_or("busy-past-deadline");
         if stall_log_first_this_bucket(&format!("{session}:{cond}"), bucket) {
             tracing::warn!(
@@ -16905,47 +16898,25 @@ mod refusal_status_tests {
 
 #[cfg(test)]
 mod stall_log_dedupe_tests {
-    use super::*;
-
     /// AEAB-13. The stall warning fired every tick with no memory: 921 of 1004
     /// log lines since one restart, 3570 across the preceding 24 hours, all for
     /// ONE undeliverable message to a lane dead six days. It buried a
     /// first-ever `database is locked` line and two false scheduler warnings
     /// during a log review that existed to find exactly those.
     ///
-    /// Each assertion below is a property the fix must hold, and two of them are
-    /// the ones a naive "just log less" would break.
+    /// The hourly-dedupe properties MOVED to `crate::log_dedupe::tests` when
+    /// AEAB-45 gave the helper a second caller — they are properties of the
+    /// mechanism, not of steering, and duplicating them here would let the two
+    /// copies drift exactly as the two spellings of the mechanism would have.
+    /// What remains here is the wiring: this lane's key shape.
     #[test]
-    fn a_stall_logs_once_per_lane_condition_and_hour() {
-        let b = 1_000_000i64;
-
-        // 1. First occurrence logs; the identical repeat does not. This is the
-        //    921-lines-per-restart case.
-        assert!(stall_log_first_this_bucket("Amux-gtm:not-running", b));
-        assert!(!stall_log_first_this_bucket("Amux-gtm:not-running", b));
-        assert!(!stall_log_first_this_bucket("Amux-gtm:not-running", b));
-
-        // 2. A DIFFERENT CONDITION on the same lane still logs. `not-running`
-        //    and `no-env-file` are actionable and completely different; the
-        //    surrounding code says collapsing them is what made this invisible,
-        //    so the dedupe must not collapse them either.
-        assert!(stall_log_first_this_bucket("Amux-gtm:no-env-file", b));
-
-        // 3. A different LANE still logs — dedupe is per lane, not global. A
-        //    global gate would silence a real second outage.
-        assert!(stall_log_first_this_bucket("other-lane:not-running", b));
-
-        // 4. THE NEXT HOUR logs again. This is the load-bearing one: a permanent
-        //    idem would fire once and then stay silent forever, so an ongoing
-        //    stall would vanish from the log entirely and the fix would be worse
-        //    than the bug. The surrounding event path makes exactly this point.
-        assert!(stall_log_first_this_bucket("Amux-gtm:not-running", b + 1));
-        assert!(!stall_log_first_this_bucket("Amux-gtm:not-running", b + 1));
-
-        // 5. Rolling the bucket must not leak memory: entries from the previous
-        //    hour are dropped, which is observable as the old key logging again
-        //    rather than being remembered.
-        assert!(stall_log_first_this_bucket("other-lane:not-running", b + 1));
+    fn the_stall_key_is_per_lane_and_per_condition() {
+        // The key must carry BOTH, because `not-running` and `no-env-file` on
+        // the same lane are separately actionable — collapsing them is what made
+        // the second one invisible in the first place.
+        let k = |session: &str, cond: &str| format!("{session}:{cond}");
+        assert_ne!(k("Amux-gtm", "not-running"), k("Amux-gtm", "no-env-file"));
+        assert_ne!(k("Amux-gtm", "not-running"), k("other-lane", "not-running"));
     }
 }
 

--- a/crates/amux-server/src/lib.rs
+++ b/crates/amux-server/src/lib.rs
@@ -8,6 +8,7 @@ pub mod api;
 pub mod backend;
 pub mod config;
 pub mod legacy_port;
+pub mod log_dedupe;
 pub mod db;
 pub mod integrations;
 pub mod invariants;

--- a/crates/amux-server/src/log_dedupe.rs
+++ b/crates/amux-server/src/log_dedupe.rs
@@ -1,0 +1,150 @@
+//! Hourly, per-key de-duplication for log lines that restate an unchanging fact.
+//!
+//! Extracted from `api::session_verbs` (AEAB-13) so a second surface could use
+//! it WITHOUT a second spelling of it (AEAB-45). Two spellings of "the same
+//! condition, again" drift, and the whole defect both cards describe is one
+//! surface deduping while another does not.
+//!
+//! ## Why this exists at all
+//!
+//! AEAB-13: `warn_on_stalled_lanes` emitted its `tracing::warn!` on every tick
+//! with no memory, while the `emit_event` calls immediately below it were
+//! already deduped hourly, per lane, per condition — with a comment naming the
+//! exact hazard: "no idem at all fires every tick, which is the nag AC-310 was
+//! filed about." The event path was fixed; the log line was left behind. One
+//! undeliverable message to a lane that had been dead six days produced 921 of
+//! the 1004 log lines since the last restart — 92% of the log — and buried a
+//! first-ever `database is locked` line during a log review that existed to
+//! find exactly that.
+//!
+//! AEAB-45 is the same shape from the other side. The disk-ranking warning was
+//! moved from once-per-ATTEMPT to once-per-RUN and its own comment says the
+//! per-attempt spelling "drowned the log it shares with real faults" — but the
+//! run is on a two-minute timer, so it still emitted 1,336 identical lines in
+//! 24h naming `~/.Trash`, a condition that cannot change. 77% of the window.
+//! **A per-run dedupe is not a dedupe when the run is on a timer.**
+//!
+//! ## The cadence, and why it is not "log once"
+//!
+//! First occurrence in a bucket logs; repeats in the same bucket do not; the
+//! next bucket logs again. The re-statement is deliberate. A permanent idem
+//! would fire once and then stay silent forever, so an ONGOING problem would
+//! vanish from the log entirely and the fix would be worse than the bug.
+//!
+//! In-process and not durable, which is the right trade: re-stating an ongoing
+//! problem once per server start is useful rather than noisy, whereas a missed
+//! NOTIFICATION is lost, which is why the event-side idem is DB-backed.
+//!
+//! ## Choosing a key
+//!
+//! Key on everything a reader would act on differently. `session_verbs` keys on
+//! `{lane}:{condition}` because those two are separately actionable. `autofix`
+//! keys on the joined PATH LIST, so a skip set that CHANGES reports immediately
+//! inside the same hour rather than hiding behind the previous hour's entry —
+//! the set is the whole content of the message. Namespace your keys; the map is
+//! shared across callers.
+
+/// True the first time this key is seen in this bucket, false afterwards.
+///
+/// Entries from previous buckets are dropped when the bucket rolls, so the set
+/// cannot grow without bound. On a poisoned lock this fails OPEN — it returns
+/// true and logs, because swallowing a line to protect a de-duplicator inverts
+/// the priority.
+pub(crate) fn first_this_bucket(key: &str, bucket: i64) -> bool {
+    static M: std::sync::OnceLock<std::sync::Mutex<(i64, std::collections::BTreeSet<String>)>> =
+        std::sync::OnceLock::new();
+    let m = M.get_or_init(|| std::sync::Mutex::new((i64::MIN, std::collections::BTreeSet::new())));
+    let Ok(mut g) = m.lock() else { return true };
+    if g.0 != bucket {
+        g.0 = bucket;
+        g.1.clear();
+    }
+    g.1.insert(key.to_string())
+}
+
+/// The hour containing `now` (unix seconds). Callers share one spelling so two
+/// surfaces cannot disagree about when an hour starts.
+pub(crate) fn hour_bucket(now: f64) -> i64 {
+    (now / 3600.0) as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Moved verbatim in intent from `session_verbs` (AEAB-13), because the
+    /// properties belong to the helper rather than to its first caller.
+    ///
+    /// Keys are namespaced per case so this test cannot interfere with the
+    /// AEAB-45 case below — the map is process-global and cargo runs tests in
+    /// parallel, which has already bitten this repo once (the du budget env
+    /// vars, AEAB-33).
+    #[test]
+    fn a_key_logs_once_per_bucket_and_again_in_the_next() {
+        let b = 1_000_000i64;
+
+        // 1. First occurrence logs; the identical repeat does not. This is the
+        //    921-lines-per-restart case, and the 1,336-lines-per-day one.
+        assert!(first_this_bucket("t1:Amux-gtm:not-running", b));
+        assert!(!first_this_bucket("t1:Amux-gtm:not-running", b));
+        assert!(!first_this_bucket("t1:Amux-gtm:not-running", b));
+
+        // 2. A DIFFERENT CONDITION on the same lane still logs. `not-running`
+        //    and `no-env-file` are actionable and completely different.
+        assert!(first_this_bucket("t1:Amux-gtm:no-env-file", b));
+
+        // 3. A different LANE still logs — dedupe is per key, not global. A
+        //    global gate would silence a real second outage.
+        assert!(first_this_bucket("t1:other-lane:not-running", b));
+
+        // 4. THE NEXT HOUR logs again. This is the load-bearing one: a
+        //    permanent idem would fire once and then stay silent forever, so an
+        //    ongoing stall would vanish from the log entirely.
+        assert!(first_this_bucket("t1:Amux-gtm:not-running", b + 1));
+        assert!(!first_this_bucket("t1:Amux-gtm:not-running", b + 1));
+
+        // 5. Rolling the bucket must not leak memory: entries from the previous
+        //    hour are dropped, which is observable as the old key logging again
+        //    rather than being remembered.
+        assert!(first_this_bucket("t1:other-lane:not-running", b + 1));
+    }
+
+    /// AEAB-45's specific property, and the one nothing tested before: when the
+    /// CONTENT of the message changes, it must be reported in the SAME hour and
+    /// not hidden behind the previous content's entry.
+    ///
+    /// This is the case that distinguishes keying on content from keying on a
+    /// lane name, and it is why the disk warnings key on the joined path list.
+    /// A skip set growing from `.Trash` to `.Trash, Library/Caches` is new
+    /// information about the disk; silencing it for up to an hour would
+    /// reproduce the incomplete-ranking blindness AEAB-33 was filed about.
+    #[test]
+    fn changed_content_logs_immediately_within_the_same_bucket() {
+        let b = 2_000_000i64;
+        let one = "t2:disk-unreadable:/Users/x/.Trash";
+        let two = "t2:disk-unreadable:/Users/x/.Trash, /Users/x/Library/Caches";
+
+        assert!(first_this_bucket(one, b), "first sighting always logs");
+        assert!(!first_this_bucket(one, b), "unchanged set stays quiet");
+        assert!(
+            first_this_bucket(two, b),
+            "a CHANGED skip set must log at once, not wait for the next hour"
+        );
+        assert!(!first_this_bucket(two, b), "…and then it too goes quiet");
+        assert!(
+            !first_this_bucket(one, b),
+            "reverting to the earlier set inside the same hour is not news"
+        );
+    }
+
+    /// The bucket is a pure function of the clock, and both callers must agree
+    /// on it — a helper that computed its own hour differently per call site
+    /// would silently give one surface a shorter cadence than the other.
+    #[test]
+    fn hour_bucket_is_whole_hours_and_shared() {
+        assert_eq!(hour_bucket(0.0), 0);
+        assert_eq!(hour_bucket(3599.9), 0);
+        assert_eq!(hour_bucket(3600.0), 1);
+        assert_eq!(hour_bucket(7200.5), 2);
+    }
+}

--- a/crates/amux-server/src/runtime_jobs/autofix.rs
+++ b/crates/amux-server/src/runtime_jobs/autofix.rs
@@ -1566,9 +1566,11 @@ fn du_top(
     // complete one. Whoever acts on this report must see that paths are missing
     // — AND why, since the two reasons have different fixes.
     //
-    // It says it ONCE per run, naming the paths, rather than once per attempt:
-    // the per-attempt spelling reported the same unchanging path thousands of
-    // times and drowned the log it shares with real faults.
+    // It says it once per SKIP SET per hour, naming the paths. It was first
+    // written to say it once per RUN rather than once per attempt, because the
+    // per-attempt spelling reported the same unchanging path thousands of times
+    // and drowned the log it shares with real faults — see the AEAB-45 note
+    // below for why that was only half the fix.
     //
     // The known bias is stated in the message itself rather than left for the
     // reader to infer: `du` time scales with directory size, so the paths that
@@ -1577,23 +1579,43 @@ fn du_top(
     // 3.7G free while the ranking that DID emerge listed only the also-rans. A
     // report saying merely "incomplete" reads as "here are the big ones plus a
     // few we missed", which is closer to the inverse of the truth.
+    // AEAB-45: "once per run" is not a dedupe when the run is on a two-minute
+    // timer. The paragraph above was written when this warning moved from
+    // once-per-ATTEMPT to once-per-RUN, and the inner loop was the only half
+    // that got fixed: the outer one emitted 1,336 identical lines in 24h naming
+    // `~/.Trash (du exit 1)`, a condition that CANNOT change — 77% of the whole
+    // log, competing with three real findings in the same window. AEAB-13
+    // recorded the identical shape at the identical ratio one subsystem over,
+    // which is why the mechanism is shared rather than re-spelled here.
+    //
+    // Keyed on the PATH LIST, not on a bare "disk warned" flag, so a skip set
+    // that GROWS is new information and reports at once inside the same hour.
+    // Keyed separately per REASON, because a budget timeout and a permission
+    // refusal have different fixes and the message says so.
+    let bucket = crate::log_dedupe::hour_bucket(now);
     if !timed_out.is_empty() {
-        tracing::warn!(
-            skipped = timed_out.len(),
-            paths = %timed_out.join(", "),
-            "disk: size ranking is INCOMPLETE — these paths exceeded the du budget. \
-             du time scales with size, so the paths missing here are LIKELIER TO BE \
-             THE LARGEST than the ones ranked below"
-        );
+        let paths = timed_out.join(", ");
+        if crate::log_dedupe::first_this_bucket(&format!("disk-du-budget:{paths}"), bucket) {
+            tracing::warn!(
+                skipped = timed_out.len(),
+                paths = %paths,
+                "disk: size ranking is INCOMPLETE — these paths exceeded the du budget. \
+                 du time scales with size, so the paths missing here are LIKELIER TO BE \
+                 THE LARGEST than the ones ranked below"
+            );
+        }
     }
     if !unreadable.is_empty() {
-        tracing::warn!(
-            skipped = unreadable.len(),
-            paths = %unreadable.join(", "),
-            "disk: size ranking is INCOMPLETE — these paths could not be READ at all \
-             (permissions, e.g. macOS TCC on ~/.Trash). This is NOT a budget problem \
-             and no timeout increase will fix it"
-        );
+        let paths = unreadable.join(", ");
+        if crate::log_dedupe::first_this_bucket(&format!("disk-unreadable:{paths}"), bucket) {
+            tracing::warn!(
+                skipped = unreadable.len(),
+                paths = %paths,
+                "disk: size ranking is INCOMPLETE — these paths could not be READ at all \
+                 (permissions, e.g. macOS TCC on ~/.Trash). This is NOT a budget problem \
+                 and no timeout increase will fix it"
+            );
+        }
     }
     sized.sort_by_key(|r| std::cmp::Reverse(r.bytes));
     sized.truncate(limit);


### PR DESCRIPTION
Found in the 2026-08-22 daily log review. Card AEAB-45, ledger LR-52.

**1,336 of 1,726 lines** in the 24h window were one sentence naming `~/.Trash (du exit 1)` — a condition that cannot change — emitted every autofix tick on each of two servers. 77% of the log, competing with three real findings (AEAB-41, AEAB-42, AEAB-43) in the same window.

I wrote that warning in AEAB-33, and its own comment says it now fires "ONCE per run … rather than once per attempt" because the per-attempt spelling "drowned the log it shares with real faults." **I fixed the inner loop and left the outer one.** The run is on a two-minute timer.

AEAB-13 already solved this exact shape for the steering stall warning — 921 of 1004 lines, 92%, burying a first-ever `database is locked` line during a log review that existed to find exactly that. So the mechanism moves to `crate::log_dedupe` and gains a second caller rather than a second spelling; its own comment warns that two spellings of "the same condition, again" drift, which is the defect both cards describe.

The disk warnings key on the joined **path list** and on the reason, so a skip set that GROWS still reports at once inside the same hour, and a budget timeout stays distinguishable from a permission refusal.

### Tests, and evidence they can fail

The hourly properties move with the mechanism. `session_verbs` keeps the one property that is genuinely its own (the key carries lane AND condition). New case for the property nothing tested before: changed content must log immediately within the same bucket.

Mutation-checked rather than assumed:

| mutation | result |
|---|---|
| remove the dedupe (always return true) | 2 of 3 fail |
| never clear on bucket roll (permanent idem) | 1 of 3 fails |

### Note on local verification

Not compiled locally. The volume is at 2.2 GB free / 99% used and the auto-builder is already clearing its 1 GB target cache on every run — a concurrent cargo build is how the machine reaches zero. `log_dedupe.rs` was compiled and its tests run standalone with `rustc --test`; the rest is on CI, which is the honest place for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx