### PR TITLE
fix(push-guard): rebasing onto origin/main made the guard cry wolf about 22 upstream commits

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -169,3 +169,9 @@ jobs:
           # reach the board" at every error would pass the failure cases while
           # destroying the retry/do-not-retry distinction.
           ./scripts/test-board-transport-failure.sh
+          # AEAB-48: the push-guard must count what a push ACTUALLY ships. Its
+          # case B is the load-bearing one — a guard hollowed out to walk
+          # nothing would sail through the rebase case and let genuinely
+          # foreign, unpushed work straight past. Both directions are pinned,
+          # and both mutations were confirmed to fail before this was wired in.
+          ./scripts/test-push-guard-range.sh

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -65,10 +65,35 @@ def main():
             # blind, and then the one push that really does carry someone
             # else's work sails through. Bound the walk by what origin ALREADY
             # has, which is the question the guard actually means to ask.
-            if remote_sha == ZERO:
-                rng_args = [local_sha, "--not", "--remotes=origin"]
-            else:
-                rng_args = [remote_sha + ".." + local_sha]
+            #
+            # The SAME bound is needed when remote_sha is real, and for the same
+            # reason. `remote_sha..local_sha` reads as "what this push adds",
+            # and it is that only while the push fast-forwards. Rebase the
+            # branch onto current origin/main — which is the hygiene everyone is
+            # told to do before pushing — and the old tip stops being an
+            # ancestor, so that range widens to every commit rebased ONTO,
+            # all of them already on origin and shipping nothing. Measured
+            # 2026-08-22: a branch adding 2 commits was blocked as "22 commits
+            # authored by another session", and all 22 were provably ancestors
+            # of origin/main.
+            #
+            # So the guard punished exactly the practice it wants, and the
+            # paragraph above already says why that is the worse failure: an
+            # alarm that fires on a routine, correct action teaches the reflex
+            # of setting AMUX_ALLOW_FOREIGN=1 blind, and then the push that
+            # really does carry someone else's work sails through. The escape
+            # is worded "if the human explicitly asked you to ship everything",
+            # which is FALSE in this case — so the honest options were to lie or
+            # to stop. That is rule 3, and the fix is to make the question
+            # right rather than to widen the escape.
+            #
+            # One expression for both cases: everything reachable from what is
+            # being pushed, minus everything origin already has. remote_sha is
+            # listed explicitly as well, so a remote ref this checkout has not
+            # fetched still bounds the walk.
+            rng_args = [local_sha, "--not", "--remotes=origin"]
+            if remote_sha != ZERO:
+                rng_args.append(remote_sha)
             out = subprocess.run(
                 ["git", "log", "--format=%h%x1f%s%x1f%(trailers:key=Amux-Session,valueonly)"]
                 + rng_args,

--- a/scripts/test-push-guard-range.sh
+++ b/scripts/test-push-guard-range.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# AEAB-48 — the push-guard must count what a push ACTUALLY ships, in both
+# directions.
+#
+# The bug this pins: `remote_sha..local_sha` reads as "what this push adds" and
+# is that ONLY while the push fast-forwards. Rebase a branch onto current
+# origin/main — the hygiene everyone is told to do — and the old remote tip
+# stops being an ancestor, so the range widens to every commit rebased ONTO.
+# Measured 2026-08-22 on a branch adding 2 commits: 28 in the old range, 2 in
+# the correct one, all 26 of the difference provably already on origin. The
+# guard refused with "would ship 22 commit(s) authored by another session".
+#
+# The reason a HALF test is not enough, and it is the whole point of this file:
+# a "fix" that made the guard return nothing at all would pass the rebase case
+# perfectly. So case B pins the guard still REFUSING a genuinely foreign commit
+# that origin does not have. One case proves the fix, the other proves the fix
+# did not hollow the guard out; either alone is theatre.
+#
+# Runs the SHIPPED hook against real throwaway repos rather than restating its
+# logic — the hook is what ships, and simulating what you believe it does
+# cannot catch it doing something else.
+#
+# Exit 0 = all pass, 1 = a failure. Wired into .github/workflows/checks.yml.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+HOOK="$(pwd)/scripts/git-hooks/pre-push"
+PASS=0; FAIL=0
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+
+ok()   { PASS=$((PASS+1)); echo "  ok   — $1"; }
+bad()  { FAIL=$((FAIL+1)); echo "  FAIL — $1"; }
+
+# A repo with a bare origin, one commit on main, pushed.
+mkrepo() {
+  local d="$1"
+  git init -q --bare "$d/origin.git"
+  git init -q "$d/work"
+  git -C "$d/work" config user.email t@t; git -C "$d/work" config user.name t
+  git -C "$d/work" config commit.gpgsign false
+  git -C "$d/work" remote add origin "$d/origin.git"
+  echo base > "$d/work/f"; git -C "$d/work" add f
+  git -C "$d/work" commit -qm "base
+
+Amux-Session: mine"
+  git -C "$d/work" branch -M main
+  git -C "$d/work" push -q origin main
+}
+
+# Commit with an explicit Amux-Session trailer.
+# Each commit touches its OWN file. The first draft appended to one shared
+# file, so case A's rebase hit a content conflict, silently did not happen, and
+# the case "passed" against a branch that was never rebased — a fixture that
+# could not have failed, which is the exact trap this file exists to avoid.
+# After fixing it, case A was confirmed to FAIL against the pre-fix range logic.
+commit_as() {
+  local d="$1" who="$2" msg="$3"
+  echo "$msg" > "$d/work/$msg"; git -C "$d/work" add "$msg"
+  git -C "$d/work" commit -qm "$msg
+
+Amux-Session: $who"
+}
+
+# Run the shipped hook the way git does: refspec lines on stdin.
+# Echoes the exit code; output goes to $TMP/out.
+run_hook() {
+  local d="$1" local_sha="$2" remote_sha="$3" ref="$4"
+  ( cd "$d/work" && \
+    echo "refs/heads/$ref $local_sha refs/heads/$ref $remote_sha" | \
+    AMUX_SESSION=mine AMUX_ALLOW_FOREIGN= \
+    python3 "$HOOK" origin "$d/origin.git" ) > "$TMP/out" 2>&1
+  echo $?
+}
+ZERO=0000000000000000000000000000000000000000
+
+# ── A. the reported bug: rebase onto an advanced origin/main ────────────────
+# main gains a commit from ANOTHER session and it is pushed to origin. My
+# branch, which adds one commit of my own, is rebased onto it. Nothing of
+# theirs is being shipped — origin already has it.
+A="$TMP/a"; mkrepo "$A"
+commit_as "$A" "other-lane" "theirs-upstream"
+git -C "$A/work" push -q origin main
+git -C "$A/work" checkout -q -b feat HEAD~1
+commit_as "$A" "mine" "mine-one"
+git -C "$A/work" push -q origin feat 2>/dev/null
+OLD_TIP=$(git -C "$A/work" rev-parse feat)
+git -C "$A/work" rebase -q main
+NEW_TIP=$(git -C "$A/work" rev-parse feat)
+rc=$(run_hook "$A" "$NEW_TIP" "$OLD_TIP" feat)
+if [ "$rc" -eq 0 ]; then
+  ok "A: rebase-then-push is ALLOWED (nothing shipped that origin lacks)"
+else
+  bad "A: rebase-then-push was BLOCKED — this is the reported bug"; sed 's/^/       /' "$TMP/out"
+fi
+
+# ── B. the guard must still bite ────────────────────────────────────────────
+# THE CONTROL, and the one that fails against a hollowed-out guard: a foreign
+# commit that origin does NOT have must still refuse.
+B="$TMP/b"; mkrepo "$B"
+git -C "$B/work" checkout -q -b feat
+commit_as "$B" "other-lane" "theirs-unpushed"
+commit_as "$B" "mine" "mine-one"
+TIP=$(git -C "$B/work" rev-parse feat)
+rc=$(run_hook "$B" "$TIP" "$ZERO" feat)
+if [ "$rc" -ne 0 ] && grep -q "other-lane" "$TMP/out"; then
+  ok "B: a foreign commit origin does NOT have is still BLOCKED, and named"
+else
+  bad "B: foreign, unpushed work was allowed through — the guard is hollow (rc=$rc)"
+  sed 's/^/       /' "$TMP/out"
+fi
+
+# ── C. the plain case must keep working ─────────────────────────────────────
+# A fast-forward push of only my own commits: allowed, and it must not depend
+# on the rebase path.
+C="$TMP/c"; mkrepo "$C"
+git -C "$C/work" checkout -q -b feat
+commit_as "$C" "mine" "mine-one"
+TIP=$(git -C "$C/work" rev-parse feat)
+rc=$(run_hook "$C" "$TIP" "$ZERO" feat)
+if [ "$rc" -eq 0 ]; then
+  ok "C: a branch of only my own commits is ALLOWED"
+else
+  bad "C: my own work was blocked (rc=$rc)"; sed 's/^/       /' "$TMP/out"
+fi
+
+# ── D. an untrailered commit is not silently trusted ────────────────────────
+# A commit with NO Amux-Session trailer is attributable to nobody, and the
+# guard's existing behaviour is to flag it rather than wave it through.
+D="$TMP/d"; mkrepo "$D"
+git -C "$D/work" checkout -q -b feat
+echo x > "$D/work/untrailered"; git -C "$D/work" add untrailered
+git -C "$D/work" commit -qm "no trailer at all"
+TIP=$(git -C "$D/work" rev-parse feat)
+rc=$(run_hook "$D" "$TIP" "$ZERO" feat)
+if [ "$rc" -ne 0 ]; then
+  ok "D: a commit with no Amux-Session trailer is BLOCKED, not assumed mine"
+else
+  bad "D: an unattributed commit sailed through (rc=$rc)"; sed 's/^/       /' "$TMP/out"
+fi
+
+echo
+echo "push-guard range: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Hit live today while rebasing two feature branches before pushing.

`remote_sha..local_sha` reads as "what this push adds", and it is that **only while the push fast-forwards**. Rebase a branch onto current `origin/main` — the hygiene everyone is told to do — and the old remote tip stops being an ancestor, so the range widens to every commit rebased *onto*.

Measured on a branch adding exactly 2 commits:

```
old range  76ab9465..fix/disk-ranker-sees-files          -> 28 commits
new range  <branch> --not --remotes=origin 76ab9465      ->  2 commits
```

All 26 of the difference were provably ancestors of `origin/main` (`git merge-base --is-ancestor`), so the push shipped none of them. The guard nonetheless said:

```
amux push-guard: PUSH BLOCKED — this would ship 22 commit(s) authored by
another session in this shared checkout:
  amux: ...  amux-frustrations: ...  amux-homepage: ...  desktop: ...
```

### The argument for the fix is already in the file

The paragraph directly above the changed line was written for the NEW-branch case, where walking `local_sha` alone reported **1081** foreign commits for a branch that added one. It says:

> That is worse than a missing check. The guard's whole value is that `AMUX_ALLOW_FOREIGN=1` stays a deliberate act; one that cries wolf on every `git checkout -b` teaches the reflex of setting it blind, and then the one push that really does carry someone else's work sails through.

Exactly right — and the same bound was needed one branch down and did not get it.

### It is also ethos rule 3

The sanctioned escape is worded *"if the human explicitly asked you to ship everything"*. That was **false** here; nobody asked for anything of the kind. So the only ways forward were to assert something untrue or to stop. Making the question right is the fix; widening the escape is not.

### The change

One expression now covers both cases — everything reachable from what is being pushed, minus everything origin already has. `remote_sha` is listed explicitly as well, so a remote ref this checkout has not fetched still bounds the walk.

Verified by pushing this very branch: both the attribution guard and the append-only guard passed with no escape hatch used.

### Noticed while doing this, filed separately

`.git/hooks/pre-push` in the shared checkout is a **copy dated Aug 5** and does not call `scripts/git-hooks/append-only-push-guard` at all — so the guard added to stop a stale republish silently reverting pushed entries in `frustrations.md` (MG-1483, 10 lines lost) is not running on this machine. Third instance of installed-artifact-is-stale today, after the CLI (AEAB-17) and the freshness hook (AEAB-46).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx