### PR TITLE
fix(cli): an unreachable server HANGS the bash CLI instead of failing it — not one of 41 curl sites had a connect timeout (AMUX-40)

### DIFF
--- a/amux
+++ b/amux
@@ -49,6 +49,124 @@ fi
 
 die() { echo "${RED}error:${RESET} $*" >&2; exit 1; }
 
+# ── Every server call goes through _curl ─────────────────────────────────────
+#
+# A CONNECT TIMEOUT, in one place, because a per-call-site flag is a thing every
+# future call site has to remember and not one of the 41 sites did. Re-measured
+# against upstream/main at rebase time: 41 curl invocations, 0 with
+# --connect-timeout, 8 carrying only -m.
+#
+# Without one, an unreachable server does not FAIL — it HANGS, and none of the
+# error handling in this file can run while curl is still waiting. Measured
+# 2026-08-23 (AEAB-46): a dead localhost port on WSL2 drops the SYN instead of
+# refusing it, so `amux board done <id> --outcome ...` sat until its CALLER gave
+# up after two minutes and printed nothing. AEAB-36's "cannot reach the board —
+# NOTHING was applied" die() was already right there and could not fire. Pointed
+# at a host that fails fast (DNS, curl exit 6) the same command printed it
+# correctly — so the instrument could report the shape of failure that was
+# already obvious and not the one that looks like a wedged CLI.
+#
+# `-m`/`--max-time` is a DIFFERENT knob and stays at the call site: it caps the
+# whole transfer, and `peek --live` or `send` may legitimately be slow. The eight
+# sites that already had `-m` still hung for their full budget on a dropped
+# connect, which is why adding more of it was never the fix.
+_curl() {
+  local rc=0
+  command curl --connect-timeout "${AMUX_CURL_CONNECT_TIMEOUT:-5}" "$@" || rc=$?
+  if [[ "$rc" -ne 0 ]]; then _transport_breadcrumb "$rc" "$@"; fi
+  return "$rc"
+}
+
+# The second half of the fix: make the NEXT transport failure self-announcing.
+#
+# A CLI that cannot reach the server also cannot report that it could not reach
+# the server — the request never arrives, so nothing lands in the request log and
+# a sweep of /api/logs/analyze sees a silence identical to "nobody ran anything".
+# So the note is written to disk here and shipped on the next invocation that CAN
+# reach the server (_flush_transport_breadcrumbs).
+#
+# Recorded: the curl exit code, the method, and the URL with its QUERY STRING
+# stripped — so scheme and host and path, not the path alone — never the body and
+# never the headers. A breadcrumb whose own payload leaks an outcome's prose or an
+# auth header into a log the whole fleet reads costs more than the hang did. The
+# host is kept deliberately: AMUX_API pointing somewhere unexpected is one of the
+# things this breadcrumb exists to make visible.
+_transport_breadcrumb() {
+  local rc="$1"; shift
+  local url="" method="GET" prev="" a
+  for a in "$@"; do
+    case "$a" in http://*|https://*) url="$a" ;; esac
+    if [[ "$prev" == "-X" ]]; then method="$a"; fi
+    prev="$a"
+  done
+  printf '{"ts":%s,"curl_exit":%s,"method":"%s","url":"%s","session":"%s","cli":"bash"}\n' \
+    "$(date -u +%s)" "$rc" "$method" "${url%%\?*}" \
+    "${AMUX_SESSION:-${AMUX_WORKER:-}}" \
+    >> "$CC_HOME/cli-transport.jsonl" 2>/dev/null || true
+}
+
+# Ship the backlog to /api/client-debug, which logs the whole payload at INFO in
+# ~/.amux/logs/server-rs.log and serves it back from
+# GET /api/client-debug?kind=cli-transport-failure. That is what turns "my amux
+# command hung once" from a thing one operator saw into a thing a log sweep finds.
+#
+# ALWAYS returns 0: a diagnostic that can break a hot path 48 lanes run is worse
+# than no diagnostic.
+#
+# What it deletes, it delivered. The first version of this function read the
+# NEWEST 200 lines, posted those, and then cleared the WHOLE file — so on a
+# backlog of 201 every older breadcrumb was destroyed unsent, and the truncate
+# reported success. That is the shape this PR fixes one layer up, one layer down:
+# a composite operation taking its success signal from the part that worked. It
+# also raced: ~48 lanes share CC_HOME, so a `>>` landing between the read and the
+# `: >` was lost even inside the window.
+#
+# So the file is ROTATED, not truncated. mv is atomic within the directory: the
+# snapshot is exactly what gets posted, concurrent appends land in a fresh file
+# while it drains, and the snapshot is removed only on a 2xx — any other answer
+# puts it back for the next invocation to retry. There is no per-post row cap
+# because that cap is what ate the evidence; the snapshot can only grow while the
+# server is unreachable, and the first command that reaches it ships all of it.
+_flush_transport_breadcrumbs() {
+  local f="$CC_HOME/cli-transport.jsonl"
+  [[ -s "$f" ]] || return 0
+  local snap="$f.sending.$$"
+  mv "$f" "$snap" 2>/dev/null || return 0
+  local body code
+  body=$(F="$snap" python3 -c '
+import json, os
+rows = []
+with open(os.environ["F"]) as fh:
+    for line in fh.read().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rows.append(json.loads(line))
+        except Exception:
+            pass
+print(json.dumps({"kind": "cli-transport-failure", "n": len(rows), "rows": rows}))
+' 2>/dev/null) || { _restore_transport_snapshot "$snap" "$f"; return 0; }
+  # command curl, NOT _curl: a failed flush must not breadcrumb its own failure,
+  # which would be an unbounded pile of notes about not being able to send notes.
+  code=$(command curl -sk --connect-timeout 3 -m 5 -o /dev/null -w '%{http_code}' \
+    -X POST -H 'Content-Type: application/json' -d "$body" \
+    "${AMUX_API:-https://localhost:8824}/api/client-debug" 2>/dev/null || echo 000)
+  case "$code" in
+    2??) rm -f "$snap" 2>/dev/null || true ;;
+    *) _restore_transport_snapshot "$snap" "$f" ;;
+  esac
+  return 0
+}
+
+# Appended back rather than moved back, because a fresh $f may already exist from
+# a lane that failed while this snapshot was in flight — clobbering it would lose
+# the very breadcrumbs this function exists to keep.
+_restore_transport_snapshot() {
+  cat "$1" >> "$2" 2>/dev/null && rm -f "$1" 2>/dev/null
+  return 0
+}
+
 need_tmux() {
   command -v tmux &>/dev/null || die "tmux is required. Install with: brew install tmux"
 }
@@ -176,7 +294,7 @@ _start_via_api() {
   local name="$1"
   local AMUX_API="${AMUX_API:-https://localhost:8824}"
   local resp
-  resp=$(curl -sk -m 90 -X POST -H "X-Amux-Session: ${AMUX_SESSION:-}" \
+  resp=$(_curl -sk -m 90 -X POST -H "X-Amux-Session: ${AMUX_SESSION:-}" \
     "$AMUX_API/api/sessions/$name/start" 2>/dev/null) || resp=""
   if [[ -z "$resp" ]]; then
     # herdr AND codex/ollama start through the server now (AMUX-3164), so this is
@@ -204,7 +322,7 @@ _stop_via_api() {
   local name="$1"
   local AMUX_API="${AMUX_API:-https://localhost:8824}"
   local resp
-  resp=$(curl -sk -m 15 -X POST -H "X-Amux-Session: ${AMUX_SESSION:-}" \
+  resp=$(_curl -sk -m 15 -X POST -H "X-Amux-Session: ${AMUX_SESSION:-}" \
     "$AMUX_API/api/sessions/$name/stop" 2>/dev/null) || resp=""
   if [[ -z "$resp" ]]; then
     return 1
@@ -909,7 +1027,7 @@ print(json.dumps({
     'ts': (lambda t: int(t) * 1000 if t and int(t) < 100000000000 else t)(d.get('ts')),
     'origin': 'unstamped-fallback from ' + (d.get('from') or 'unknown'),
 }))" 2>/dev/null) || continue
-    if curl -sk -m 10 -X POST -H 'Content-Type: application/json' \
+    if _curl -sk -m 10 -X POST -H 'Content-Type: application/json' \
          -d "$body" "$api/api/history" >/dev/null 2>&1; then
       sent=$((sent+1))
     else
@@ -935,7 +1053,7 @@ d = {'text': os.environ['MSG']}
 if os.environ.get('NB'):
     d['no_board'] = True          # AC-183: server skips autotask card creation
 print(json.dumps(d))")
-  resp=$(curl -sk -m 15 -X POST -H 'Content-Type: application/json' \
+  resp=$(_curl -sk -m 15 -X POST -H 'Content-Type: application/json' \
     -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" \
     -d "$body" "$AMUX_API/api/workers/$name/send" 2>/dev/null) || resp=""
   if [[ -n "$resp" ]]; then
@@ -965,7 +1083,7 @@ PYEOF
   local _retry
   for _retry in 1 2; do
     sleep 2
-    resp=$(curl -sk -m 5 -X POST -H 'Content-Type: application/json' \
+    resp=$(_curl -sk -m 5 -X POST -H 'Content-Type: application/json' \
       -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" \
       -d "$body" "$AMUX_API/api/workers/$name/send" 2>/dev/null) || resp=""
     if [[ -n "$resp" ]]; then
@@ -1381,7 +1499,7 @@ Usage: amux board <status> <ID> [--checked \"crit\" ...] [--ack] [--type T] [--r
   # still lands.
   if [[ -n "$reviewer" ]]; then
     local _rvresp _rvcurl=0
-    _rvresp=$(curl -sk -X PATCH -H 'Content-Type: application/json' \
+    _rvresp=$(_curl -sk -X PATCH -H 'Content-Type: application/json' \
       -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" \
       -d "$(V="$reviewer" python3 -c 'import json,os;print(json.dumps({"reviewer":os.environ["V"]}))')" \
       "${AMUX_API:-https://localhost:8824}/api/board/$id" 2>/dev/null) || _rvcurl=$?
@@ -1437,7 +1555,7 @@ if ign:
     # line from the top of the file, in precisely the case it was designed to
     # survive.
     local _oresp _ocurl=0
-    _oresp=$(curl -sk -X PATCH -H 'Content-Type: application/json' \
+    _oresp=$(_curl -sk -X PATCH -H 'Content-Type: application/json' \
       -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" -d "$_obody" \
       "${AMUX_API:-https://localhost:8824}/api/board/$id" 2>/dev/null) || _ocurl=$?
     if [[ "$_ocurl" -ne 0 ]]; then
@@ -1493,7 +1611,7 @@ print(json.dumps(b))' ${checked[@]+"${checked[@]}"})
   # A dropped connection and a refused transition must never look alike: one
   # means "nothing happened, retry", the other means "the board said no".
   local _tresp _tcurl=0
-  _tresp=$(curl -sk -X PATCH \
+  _tresp=$(_curl -sk -X PATCH \
     -H 'Content-Type: application/json' \
     -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" \
     -d "$body" \
@@ -1527,7 +1645,7 @@ _board_valid_types() {
   # AMUX-3046 stranded-port hunt instead of at a key-path bug one line away.
   # The note above already said confidently wrong help is worse than none; this
   # separates the two failures so the message can keep that promise.
-  _resp=$(curl -sk --max-time 3 -w '\n%{http_code}' "$AMUX_API/api/board/contract" 2>/dev/null)
+  _resp=$(_curl -sk --max-time 3 -w '\n%{http_code}' "$AMUX_API/api/board/contract" 2>/dev/null)
   _code="${_resp##*$'\n'}"
   _body="${_resp%$'\n'*}"
   if [[ "$_code" != "200" ]]; then
@@ -1732,11 +1850,11 @@ For long text use:                amux board progress $id \"\$(cat file)\"" ;;
           esac ;;
       esac
       local cur result
-      cur=$(curl -sk "$AMUX_API/api/board/$id" | python3 -c "import sys,json;d=json.load(sys.stdin);i=d.get('item') or d;print(json.dumps(sorted(set((i.get('tags') or [])+['needs:you']))))" 2>/dev/null)
+      cur=$(_curl -sk "$AMUX_API/api/board/$id" | python3 -c "import sys,json;d=json.load(sys.stdin);i=d.get('item') or d;print(json.dumps(sorted(set((i.get('tags') or [])+['needs:you']))))" 2>/dev/null)
       [[ -n "$cur" ]] || die "card $id not found"
       local body
       body=$(TAGS="$cur" ASK="$ask" python3 -c "import os,json; b={'tags':json.loads(os.environ['TAGS'])}; a=os.environ['ASK'].strip(); b['desc_append']=('NEEDS-YOU: '+a) if a else b.get('desc_append'); print(json.dumps({k:v for k,v in b.items() if v is not None}))")
-      result=$(curl -sk -X PATCH -H 'Content-Type: application/json' -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" \
+      result=$(_curl -sk -X PATCH -H 'Content-Type: application/json' -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" \
         -d "$body" "$AMUX_API/api/board/$id")
       # Label it as the TAG write it is. Without this the printer rendered the
       # card's unchanged status ("AC-221 -> todo"), which reads as a failed
@@ -1835,7 +1953,7 @@ types: $(_board_valid_types)"
       fi
       local result
       result=$(T="$new_type" python3 -c 'import json,os;print(json.dumps({"type":os.environ["T"]}))' \
-        | curl -sk -X PATCH -H 'Content-Type: application/json' \
+        | _curl -sk -X PATCH -H 'Content-Type: application/json' \
             -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" -d @- "$AMUX_API/api/board/$id")
       # Label it as the TYPE write it is. Argument-less, _board_outcome renders
       # the card's CURRENT status, so retyping a card printed "AMUX-2394 → doing"
@@ -1867,7 +1985,7 @@ unarchive brings it back — this is the un-do that did not exist before AMUX-24
 b={"archived": int(os.environ["A"])}
 if os.environ.get("W"): b["authorized_by"]=os.environ["W"]
 print(json.dumps(b))' \
-        | curl -sk -X PATCH -H 'Content-Type: application/json' \
+        | _curl -sk -X PATCH -H 'Content-Type: application/json' \
             -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" -d @- "$AMUX_API/api/board/$id")
       echo "$result" | _board_outcome "$id" "" "${subcmd}d"
       return $?
@@ -1889,7 +2007,7 @@ Sets the session whose sign-off is required for review -> done."
       [[ "$who" == "none" ]] && who=""
       local result
       result=$(R="$who" python3 -c 'import json,os;print(json.dumps({"reviewer":os.environ["R"]}))' \
-        | curl -sk -X PATCH -H 'Content-Type: application/json' \
+        | _curl -sk -X PATCH -H 'Content-Type: application/json' \
             -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" -d @- "$AMUX_API/api/board/$id")
       echo "$result" | _board_outcome "$id" "" "reviewer set to ${who:-none}"
       return $?
@@ -1906,7 +2024,7 @@ Sets the session whose sign-off is required for review -> done."
       local id="${1:-}"
       _board_id_guard "show" "$id"
       [[ -n "$id" ]] || die "Usage: amux board show <ISSUE-ID>"
-      curl -sk "$AMUX_API/api/board/$id" | python3 -c '
+      _curl -sk "$AMUX_API/api/board/$id" | python3 -c '
 import json, sys
 raw = sys.stdin.read()
 try:
@@ -1990,7 +2108,7 @@ if t: b["title"]=t
 # appending to it — the whole point is that the original text lacked context.
 if d.strip(): b["desc"]=d; b["desc_append"]=False
 print(json.dumps(b))' \
-        | curl -sk -X PATCH -H 'Content-Type: application/json' \
+        | _curl -sk -X PATCH -H 'Content-Type: application/json' \
             -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" -d @- "$AMUX_API/api/board/$id")
       local _what="title rewritten"
       [[ -n "$new_desc" && -n "$new_title" ]] && _what="title + desc rewritten"
@@ -2053,7 +2171,7 @@ if d.strip(): b["desc"] = d
 t = os.environ.get("TY", "").strip()
 if t: b["type"] = t
 print(json.dumps(b))')
-      result=$(curl -sk -X POST \
+      result=$(_curl -sk -X POST \
         -H 'Content-Type: application/json' \
         -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" \
         -d "$body" \
@@ -2068,7 +2186,7 @@ print(json.dumps(b))')
       shift 2>/dev/null || true
       local q="$*" body result
       body=$(Q="$q" python3 -c "import os,json;print(json.dumps({'question':os.environ['Q'].strip()}))")
-      result=$(curl -sk -X POST -H 'Content-Type: application/json' -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" \
+      result=$(_curl -sk -X POST -H 'Content-Type: application/json' -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" \
         -d "$body" "$AMUX_API/api/board/$id/status-request")
       echo "$result" | python3 -c "import sys,json;d=json.load(sys.stdin);print(d.get('message') or d.get('reason') or json.dumps(d)); sys.exit(0 if d.get('delivered') else 1)"
       return $?
@@ -2111,7 +2229,7 @@ status-CHANGE verbs (done, verified, review, backlog), not on this one." ;;
       [[ -n "$text" ]] || die "status text required"
       local body result
       body=$(T="$text" python3 -c "import os,json;print(json.dumps({'text':os.environ['T'].strip()}))")
-      result=$(curl -sk -X POST -H 'Content-Type: application/json' -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" \
+      result=$(_curl -sk -X POST -H 'Content-Type: application/json' -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" \
         -d "$body" "$AMUX_API/api/board/$id/status-update")
       # Same shape as the needsyou path: posting a status-UPDATE does not move
       # the card, so printing its current status behind an arrow invites the
@@ -2124,7 +2242,7 @@ status-CHANGE verbs (done, verified, review, backlog), not on this one." ;;
       local id="${1:-}"; [[ -n "$id" ]] || die "Usage: amux board claim <ISSUE-ID>"
       _board_id_guard "claim" "$id"
       local result
-      result=$(curl -sk -X POST \
+      result=$(_curl -sk -X POST \
         -H 'Content-Type: application/json' \
         -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" \
         -d "{\"session\":\"${AMUX_SESSION:-}\"}" \
@@ -2142,7 +2260,7 @@ status-CHANGE verbs (done, verified, review, backlog), not on this one." ;;
       [[ -n "$id" && -n "$who" ]] || die "Usage: amux board assign <ISSUE-ID> <worker>"
       _board_id_guard "assign" "$id"
       local result
-      result=$(curl -sk -X PATCH -H 'Content-Type: application/json' \
+      result=$(_curl -sk -X PATCH -H 'Content-Type: application/json' \
         -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" \
         -d "{\"session\":\"$who\"}" \
         "$AMUX_API/api/board/$id")
@@ -2358,7 +2476,7 @@ Supported:  amux board progress $id --stdin <<'EOF'   (heredoc; backticks stay l
       # was found. The whole reason sessions are told to use `amux board` rather
       # than raw curl is that it supplies attribution for you; a write verb that
       # silently does not is the sanctioned-instruction-is-the-theatre shape.
-      curl -sk -X PATCH \
+      _curl -sk -X PATCH \
         -H 'Content-Type: application/json' \
         -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" \
         -d "{\"desc_append\":$(python3 -c "import json,sys; print(json.dumps(sys.argv[1]))" "$msg")}" \
@@ -2400,7 +2518,7 @@ else:
       local task_json
       # Point read (AMUX-2223). This pulled the ENTIRE board — 4.7MB across
       # 1624 cards — to find one card by id.
-      task_json=$(curl -sk "$AMUX_API/api/board/$id" 2>/dev/null)
+      task_json=$(_curl -sk "$AMUX_API/api/board/$id" 2>/dev/null)
       if [[ -n "$task_json" ]]; then
         local gh_tag
         gh_tag=$(echo "$task_json" | python3 -c "
@@ -2445,7 +2563,7 @@ for tag in item.get('tags',[]):
       # second layer: a tag in a store the reader never opens. So read them
       # here and print one line, in the place the reader is already looking.
       local _hdr; _hdr=$(mktemp)
-      curl -sk -D "$_hdr" "$AMUX_API/api/board?$_lsq" | python3 -c "
+      _curl -sk -D "$_hdr" "$AMUX_API/api/board?$_lsq" | python3 -c "
 import sys,json
 items=json.load(sys.stdin)
 for i in sorted(items, key=lambda x: x.get('updated',0), reverse=True):
@@ -2616,7 +2734,7 @@ cmd_config() {
   local sub="${1:-}"; shift || true
   case "$sub" in
     export)
-      curl -sk "${AMUX_API:-https://localhost:8824}/api/config/export" \
+      _curl -sk "${AMUX_API:-https://localhost:8824}/api/config/export" \
       | python3 -c '
 import sys, json, yaml
 d = json.load(sys.stdin)
@@ -2636,7 +2754,7 @@ if not isinstance(doc, dict):
     sys.stderr.write("config must be a YAML mapping (got %s)\n" % type(doc).__name__); sys.exit(2)
 print(json.dumps(doc))
 ' "$f") || die "could not parse $f as YAML"
-      curl -sk -X PUT -H 'Content-Type: application/json' -d "$body" \
+      _curl -sk -X PUT -H 'Content-Type: application/json' -d "$body" \
         "${AMUX_API:-https://localhost:8824}/api/config/apply" \
       | python3 -c '
 import sys, json
@@ -2656,7 +2774,7 @@ sys.exit(1 if errs else 0)
     skin)
       # What a given worker actually renders with, after the layer merge.
       local w="${1:-}"
-      curl -sk "${AMUX_API:-https://localhost:8824}/api/skin?worker=${w}" \
+      _curl -sk "${AMUX_API:-https://localhost:8824}/api/skin?worker=${w}" \
       | python3 -c '
 import sys, json, yaml
 d = json.load(sys.stdin)
@@ -2711,7 +2829,7 @@ print(json.dumps(fields))' "$@"
     add)
       [ $# -gt 0 ] || die "Usage: amux crm add \"Name\" [company=X] [email=Y] [role=Z] [phone=P]"
       local json; json=$(_crm_json "$@")
-      curl -sk -X POST -H 'Content-Type: application/json' \
+      _curl -sk -X POST -H 'Content-Type: application/json' \
         -H "X-Amux-Session: ${AMUX_SESSION:-}" \
         -d "$json" "$AMUX_API/api/crm/contacts" | python3 -c '
 import json, sys
@@ -2724,7 +2842,7 @@ print(d.get("id", "?"), "created")'
       shift 2>/dev/null || true
       [ $# -gt 0 ] || die "amux crm update: nothing to set. Give key=value pairs."
       local json; json=$(_crm_json "$@")
-      curl -sk -X PATCH -H 'Content-Type: application/json' \
+      _curl -sk -X PATCH -H 'Content-Type: application/json' \
         -H "X-Amux-Session: ${AMUX_SESSION:-}" \
         -d "$json" "$AMUX_API/api/crm/contacts/$cid" | python3 -c '
 import json, sys
@@ -2734,7 +2852,7 @@ print("updated")'
       ;;
     get|show)
       local cid="${1:-}"; [ -n "$cid" ] || die "Usage: amux crm get PPL-1"
-      curl -sk "$AMUX_API/api/crm/contacts/$cid" | python3 -c '
+      _curl -sk "$AMUX_API/api/crm/contacts/$cid" | python3 -c '
 import json, sys
 c = json.load(sys.stdin)
 if c.get("error"): print("error:", c["error"], file=sys.stderr); sys.exit(1)
@@ -2759,7 +2877,7 @@ for a in sys.argv[1:]:
         notes.append(a)
 if notes: fields["notes"] = " ".join(notes)
 print(json.dumps(fields))' "$@")
-      curl -sk -X POST -H 'Content-Type: application/json' \
+      _curl -sk -X POST -H 'Content-Type: application/json' \
         -H "X-Amux-Session: ${AMUX_SESSION:-}" \
         -d "$json" "$AMUX_API/api/crm/contacts/$cid/interactions" | python3 -c '
 import json, sys
@@ -2775,7 +2893,7 @@ print("logged", d.get("id", ""))'
       # AEAB-37: this is NOT the AEAB-36 silent-abort shape, which is what that
       # card originally claimed; it is a smaller instrument defect in the same
       # family. See the card for the correction.
-      curl -sk "$AMUX_API/api/crm/followups" | python3 -c '
+      _curl -sk "$AMUX_API/api/crm/followups" | python3 -c '
 import json, sys
 raw = sys.stdin.read()
 try: items = json.loads(raw)
@@ -2786,7 +2904,7 @@ for i in items:
     print(i.get("follow_up_date", ""), i.get("name", ""), "-", i.get("follow_up_note", ""))'
       ;;
     list|ls|"")
-      curl -sk "$AMUX_API/api/crm/contacts$([ -n "${1:-}" ] && printf '?q=%s' "$1")" | python3 -c '
+      _curl -sk "$AMUX_API/api/crm/contacts$([ -n "${1:-}" ] && printf '?q=%s' "$1")" | python3 -c '
 import json, sys
 raw = sys.stdin.read()
 try: cs = json.loads(raw)
@@ -2937,7 +3055,7 @@ cmd_tunnel() {
   # all 7 call sites; nothing else could see it, because a CLI that exits 0 is
   # invisible to every check that looks at exit codes.
   local _tunnel_code
-  _tunnel_code=$(curl -sk -o /dev/null -w '%{http_code}' "$AMUX_API/api/tunnel/status" 2>/dev/null || echo 000)
+  _tunnel_code=$(_curl -sk -o /dev/null -w '%{http_code}' "$AMUX_API/api/tunnel/status" 2>/dev/null || echo 000)
   if [[ "$_tunnel_code" == "404" ]]; then
     echo "amux tunnel: not available in this server build (HTTP 404 -- /api/tunnel/* is not routed)." >&2
     echo "  The verb exists in this CLI but the endpoints were never ported to the rust server." >&2
@@ -2951,7 +3069,7 @@ cmd_tunnel() {
       local port="${1:-}"
       local payload='{}'
       [[ -n "$port" ]] && payload="{\"port\":$port}"
-      curl -sk -X POST -H 'Content-Type: application/json' -d "$payload" \
+      _curl -sk -X POST -H 'Content-Type: application/json' -d "$payload" \
         "$AMUX_API/api/tunnel/start" | python3 -c "
 import sys, json
 raw = sys.stdin.read()
@@ -2970,7 +3088,7 @@ print(('already running → ' if d.get('already') else 'tunnel up → ') + (d.ge
       # unless -f is passed, which is how this printed "tunnel stopped" against
       # a route that does not exist (AF-63).
       local _stop_code
-      _stop_code=$(curl -sk -o /dev/null -w '%{http_code}' -X POST "$AMUX_API/api/tunnel/stop" 2>/dev/null || echo 000)
+      _stop_code=$(_curl -sk -o /dev/null -w '%{http_code}' -X POST "$AMUX_API/api/tunnel/stop" 2>/dev/null || echo 000)
       if [[ "$_stop_code" == 2* ]]; then
         echo "tunnel stopped"
       else
@@ -2979,7 +3097,7 @@ print(('already running → ' if d.get('already') else 'tunnel up → ') + (d.ge
       fi
       ;;
     status|"")
-      curl -sk "$AMUX_API/api/tunnel/status" | python3 -c "
+      _curl -sk "$AMUX_API/api/tunnel/status" | python3 -c "
 import sys, json
 raw = sys.stdin.read()
 try:
@@ -2998,7 +3116,7 @@ if d.get('error'): print('error   :', d['error'])
 "
       ;;
     url)
-      curl -sk "$AMUX_API/api/tunnel/status" | python3 -c "
+      _curl -sk "$AMUX_API/api/tunnel/status" | python3 -c "
 import sys, json
 raw = sys.stdin.read()
 try:
@@ -3059,7 +3177,7 @@ This is a FIRE ALARM — only for things that need the owner immediately
   # Pass X-Amux-Session so the server stamps the TRUE origin (from the tmux
   # identity) into the owner_alerts ledger — the body 'session' is only a CLAIM.
   # This is what makes a safety-critical alert first-hand verifiable (AMUX-1795).
-  curl -sk -X POST -H 'Content-Type: application/json' \
+  _curl -sk -X POST -H 'Content-Type: application/json' \
     -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" \
     -d "$(python3 -c 'import json,sys; print(json.dumps({"message":sys.argv[1],"reason":sys.argv[2],"session":sys.argv[3]}))' "$msg" "$reason" "$sess")" \
     "$AMUX_API/api/alert/owner" | python3 -c "
@@ -3161,7 +3279,7 @@ cmd_url() {
     # A dead port returns an EMPTY body, not a connection refusal, so liveness
     # asserts the /health body looks like an amux server — not merely that the
     # socket answered (something else may have grabbed the port).
-    if curl -sk -m 3 "$resolved/health" 2>/dev/null | grep -q '"server"'; then
+    if _curl -sk -m 3 "$resolved/health" 2>/dev/null | grep -q '"server"'; then
       printf 'amux url: %s (via %s) — /health responds as an amux server\n' "$resolved" "$src" >&2
       return 0
     fi
@@ -3193,7 +3311,7 @@ _warn_stale_amux_url() {
   if [ -z "$url" ] || [ "$url" = "$api" ]; then return 0; fi
   local marker="${TMPDIR:-/tmp}/amux-url-warn-${AMUX_SESSION:-unknown}"
   if [ -f "$marker" ]; then return 0; fi
-  if curl -sk -m 2 -o /dev/null "$url/health" 2>/dev/null; then return 0; fi
+  if _curl -sk -m 2 -o /dev/null "$url/health" 2>/dev/null; then return 0; fi
   touch "$marker" 2>/dev/null || true
   {
     echo "amux: WARNING — \$AMUX_URL ($url) does not answer; this CLI is fine (it uses $api)."
@@ -3206,6 +3324,9 @@ _warn_stale_amux_url() {
 if [[ "${BASH_SOURCE[0]:-$0}" == "${0}" ]]; then
   ensure_dirs
   _warn_stale_amux_url
+  # Ship any transport failures the PREVIOUS invocations could not report,
+  # before doing this one's work. No-op (one file test) when there are none.
+  _flush_transport_breadcrumbs
 
   case "${1:-}" in
     register|reg)     shift; cmd_register "$@" ;;

--- a/crates/amux-server/tests/cli_curl_timeout_guard.rs
+++ b/crates/amux-server/tests/cli_curl_timeout_guard.rs
@@ -1,0 +1,117 @@
+//! Every server call in the bash CLI must be unable to HANG (2026-08-23, AEAB-46).
+//!
+//! `set -euo pipefail` and a `die` that names both lost facts (AEAB-36) are
+//! already in `amux`, and neither of them can fire while curl is still waiting:
+//! without `--connect-timeout`, an unreachable server does not fail, it hangs.
+//! Measured on this machine — a dead localhost port drops the SYN rather than
+//! refusing it, so `amux board done <id> --outcome ...` sat until its CALLER
+//! timed out (2 minutes) and printed nothing at all. The same command against a
+//! host that fails FAST (DNS, curl exit 6) printed AEAB-36's message correctly.
+//! One instrument, two shapes of unreachable server, and it could only report
+//! the shape that was already easy to see.
+//!
+//! Not one of the CLI's 41 curl call sites carried a connect timeout; 33 carried
+//! no timeout of any kind and 8 carried only `-m`. That count is the reason this
+//! is a guard and not 41 edits: a per-call-site flag is a thing every future call
+//! site has to remember, and the record is that 41 of 41 did not remember it. So
+//! the rule is structural — a curl invocation either goes through
+//! `_curl` (which injects the connect timeout and breadcrumbs the failure), or
+//! it names `--connect-timeout` itself on the same line.
+//!
+//! `-m`/`--max-time` deliberately does NOT satisfy this guard. It caps the whole
+//! transfer, so it is the wrong knob for "the server is not there" and the right
+//! one for "this response is slow": `amux peek --live` and `amux send` may
+//! legitimately take a while, and the eight sites that already had `-m` still
+//! hung for their full budget on a dropped connect.
+
+use std::path::PathBuf;
+
+fn repo_root() -> PathBuf {
+    // tests/ -> amux-server/ -> crates/ -> repo root
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("repo root above crates/amux-server")
+        .to_path_buf()
+}
+
+/// A `curl` token that is a real invocation, as opposed to the word appearing in
+/// prose or inside a string the CLI prints as a recipe.
+///
+/// The discriminator is the character immediately before the token: a command
+/// starts a line or follows a shell operator. `_curl` is excluded because the
+/// preceding character is a word character — that is the wrapper, which is the
+/// whole point of the fix.
+fn is_invocation(line: &str, at: usize) -> bool {
+    let before = line[..at].trim_end();
+    match before.chars().last() {
+        None => true,
+        Some('(' | '|' | '&' | ';' | '{' | '!') => true,
+        // A shell keyword can precede a command too, and `if curl ...` is where
+        // three of the eight pre-existing `-m` sites live — a guard that missed
+        // them would have reported the file as clean while the `if` form went on
+        // being written without a connect timeout.
+        _ => matches!(
+            before.rsplit([' ', '\t']).next().unwrap_or(""),
+            "if" | "elif" | "while" | "until" | "then" | "else" | "do" | "command"
+        ),
+    }
+}
+
+#[test]
+fn every_curl_in_the_bash_cli_cannot_hang_on_connect() {
+    let path = repo_root().join("amux");
+    let src = std::fs::read_to_string(&path).expect("read the bash CLI");
+
+    let mut offenders: Vec<(usize, String)> = Vec::new();
+    let mut wrapper_calls = 0usize;
+
+    for (i, raw) in src.lines().enumerate() {
+        let lineno = i + 1;
+        let trimmed = raw.trim_start();
+        // Comments are prose ABOUT curl. There is a lot of it in this file and
+        // it is history, not traffic — guarding it would make the guard noise.
+        if trimmed.starts_with('#') {
+            continue;
+        }
+        // Lines that PRINT a recipe (`echo "  curl -sk ..."`) are documentation
+        // handed to a human, not a call this CLI makes.
+        if trimmed.starts_with("echo ")
+            || trimmed.starts_with("printf ")
+            || trimmed.starts_with("die ")
+        {
+            continue;
+        }
+        if raw.contains("_curl ") {
+            wrapper_calls += 1;
+        }
+        for (at, _) in raw.match_indices("curl ") {
+            if !is_invocation(raw, at) {
+                continue;
+            }
+            // `command curl` is the sanctioned escape from the wrapper (the
+            // wrapper itself, and the breadcrumb flush, which must not
+            // breadcrumb its own failure). It pays the flag explicitly.
+            if raw.contains("--connect-timeout") {
+                continue;
+            }
+            offenders.push((lineno, raw.trim().to_string()));
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "curl invocations that can hang forever on an unreachable server \
+         (route them through _curl, or pass --connect-timeout on the line):\n{}",
+        offenders
+            .iter()
+            .map(|(n, l)| format!("  amux:{n}: {l}"))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+    assert!(
+        wrapper_calls > 20,
+        "expected the CLI's server calls to go through _curl; found {wrapper_calls} \
+         — did the wrapper get reverted, or did this guard stop matching it?"
+    );
+}

--- a/frustrations.md
+++ b/frustrations.md
@@ -2941,3 +2941,53 @@ NOTE: The generalisable part is not "index your subqueries". It is that CORRECTN
   only after watching the outage begin. For any migration that touches the live board,
   the cheap precondition is: how many rows does this scan, and is there an index for the
   predicate it scans on.
+
+## `amux board done` printed nothing for two minutes: an unreachable server HANGS the CLI instead of failing it
+AREA: cli
+SEVERITY: blocks
+STATUS: fixed
+DATE: 2026-08-23
+SESSION: tsukimiya (WSL2)
+CARD: AMUX-40
+SYMPTOM: verifying that the freshly-installed bash CLI carried AEAB-36's fix, I ran
+  `AMUX_API=https://localhost:1 amux board done <id> --outcome "probe"` — the exact recipe
+  AEAB-36's own comment names as its deterministic reproduction ("Reproduced deterministically
+  with AMUX_API pointed at a dead port: one warning line, exit 7, no transition"). It printed
+  no warning and no error. It printed nothing at all, for the full 2 minutes until the calling
+  harness SIGTERMed it (exit 143). `bash -x` put it on the connect: `curl -sk -X PATCH ...
+  https://localhost:1/api/board/<id>` and no further trace. Re-run against an unresolvable
+  HOST (`https://amux-probe.invalid`, curl exit 6) the AEAB-36 die() fired perfectly, naming
+  both lost facts. Two shapes of "server unreachable", and the CLI could only report the one
+  that fails fast: on this machine a dead localhost port DROPS the SYN rather than refusing it
+  (`curl --max-time 5` → exit 28 on both :1 and :8899), and not one of the CLI's 41 curl call
+  sites had a `--connect-timeout` — 33 carried no timeout at all and 8 carried only `-m`, which
+  still hung for its whole budget because `-m` caps the transfer and is not the connect knob.
+COST: ~15 minutes chasing a "the fix did not install" theory against a CLI that was byte-identical
+  to the checkout, and the wrong conclusion was one step away: the probe AEAB-36 documents as its
+  own reproduction was the probe that silently failed to reproduce it. The general shape is worse
+  than the minutes — the failure mode this hides is exactly the one AEAB-36 was written for
+  ("the server happened to be restarting to adopt a new build"), i.e. every lane in the fleet
+  during every builder swap, and what they see is not an error but a wedged terminal.
+FIX: shipped on this branch. Two halves, because a fast failure that nothing records is still
+  invisible fleet-wide:
+  1. One `_curl` wrapper injects `--connect-timeout` (default 5s, `AMUX_CURL_CONNECT_TIMEOUT`)
+     and every call site routes through it. Not 41 edits: 41 of 41 sites forgot the flag, so the
+     rule has to be structural, and `tests/cli_curl_timeout_guard.rs` fails the build when a
+     curl invocation neither goes through `_curl` nor names the flag itself. The guard was run
+     against the UNFIXED file first and listed all 41 invocation sites — a guard that has never
+     failed is a guard nobody has checked.
+  2. On a transport failure `_curl` writes a breadcrumb (curl exit, method, and the URL with its
+     query string stripped — scheme, host and path, never the body, never the headers) and the
+     next invocation that CAN reach the server POSTs the backlog
+     to `/api/client-debug?kind=cli-transport-failure`. This is the only way the class becomes
+     sweepable: a request that never arrives cannot appear in the request log, so
+     `/api/logs/analyze` sees a hang and "nobody ran anything" as the same silence. Verified
+     end-to-end — 4.7s failure with AEAB-36's message, breadcrumb written, flushed on the next
+     command, readable back from `GET /api/client-debug` and durable as the INFO line in
+     server-rs.log. The flush ROTATES the file (`mv`) and deletes the snapshot only on a 2xx, so
+     what it deletes is exactly what it delivered. The first cut of it did not: it posted the
+     newest 200 lines and then cleared the whole file, so a backlog of 250 lost rows 1-50 unsent
+     while the truncate reported success — this same class one layer down, caught in review by
+     esteininger. Measured both ways against a local collector: old = server saw 200 of 250 and
+     the file was emptied; new = server saw 250 of 250, and on a non-2xx the snapshot goes back
+     with nothing delivered and nothing lost.


### PR DESCRIPTION
## What & why

**Not one of the bash CLI's 41 curl call sites carried a `--connect-timeout`** (33 carried no timeout at all, 8 carried only `-m`). On a host where a dead port DROPS the SYN rather than refusing it, an unreachable server therefore does not *fail* — it **hangs**, and none of the error handling in the file can run while curl is still waiting.

Found while verifying that a freshly installed CLI carried AEAB-36's fix. I ran the recipe AEAB-36's own comment names as its deterministic reproduction:

```console
$ AMUX_API=https://localhost:1 amux board done <id> --outcome "probe"
   # ...nothing. For 2 minutes, until the calling harness SIGTERMed it (exit 143).
$ bash -x   # last trace: curl -sk -X PATCH ... https://localhost:1/api/board/<id>
```

The same command against an unresolvable **host** (`https://amux-probe.invalid`, curl exit 6 — fast) printed AEAB-36's message perfectly:

```
error: cannot reach the board at https://amux-probe.invalid (curl exit 6).
NOTHING was applied — not the outcome, and not the 'done' transition.
```

Two shapes of "server unreachable", and the instrument could only report the one that was already obvious. On this machine `curl --max-time 5` exits **28** against both `:1` and `:8899` — the connect is dropped, not refused. The shape it could not report is the one AEAB-36 was *written for* ("the server happened to be restarting to adopt a new build"), i.e. every lane during every builder swap; what they see is not an error but a wedged terminal.

**This is structural, not 41 edits.** 41 of 41 sites forgot the flag, so a per-call-site flag is not a rule — it is a thing every future call site has to remember, and the record says they will not.

1. **One `_curl` wrapper** injects `--connect-timeout` (`AMUX_CURL_CONNECT_TIMEOUT`, default 5) and every invocation routes through it. `-m`/`--max-time` deliberately stays at the call site: it caps the whole transfer, and `peek --live` / `send` may legitimately be slow. It is also **not this bug's knob** — the 8 sites that already had `-m` still hung for their full budget on a dropped connect.

2. **The failure now surfaces in what amux already records.** A transport failure is invisible to the server by construction — the request never arrives, so nothing lands in the request log and `/api/logs/analyze` sees a hang and "nobody ran anything" as the same silence. So `_curl` writes a breadcrumb on transport failure and the next invocation that CAN reach the server POSTs the backlog to `POST /api/client-debug` (`kind=cli-transport-failure`), which logs the whole payload at INFO in `server-rs.log` and serves it back over HTTP. The breadcrumb records **the curl exit code, the method, and the URL with its query string stripped — scheme, host and path, never the body, never the headers**: a note whose own payload leaks an outcome's prose or an auth header into a log the fleet reads costs more than the hang did. The flush uses `command curl`, not `_curl`, so a failed flush cannot breadcrumb its own failure into an unbounded pile of notes about not being able to send notes.

3. **`tests/cli_curl_timeout_guard.rs` closes the class**: a curl invocation must either route through `_curl` or name `--connect-timeout` itself.

Card: AMUX-40. `frustrations.md` entry included — the pattern is worth more than the fix: a documented reproduction recipe that silently stops reproducing is the loud-wrong-probe shape (ethos rule 7), and the natural next step from "hang, no output" is *"the fix did not install"* — against a CLI that was byte-identical to the checkout.

## Changed since the last review

**1. @esteininger's blocker — the flush discarded evidence and reported success. Fixed, and it was real.**

The first cut of `_flush_transport_breadcrumbs` read the **newest 200** lines, posted those, and then cleared the **whole** file. Everything older was destroyed unsent while the truncate reported success — the same composite-operation-takes-its-success-signal-from-the-part-that-worked shape this PR fixes one layer up. It was also racy: ~48 lanes share `CC_HOME`, so a `>>` landing between the read and the `: >` was gone too.

The file is now **rotated, not truncated**: `mv` is atomic within the directory, so the snapshot is exactly what gets posted while concurrent appends land in a fresh file. The snapshot is removed **only on a 2xx**; any other answer appends it back for the next invocation to retry. The per-post row cap is gone, because that cap is what ate the evidence.

Measured both ways against a local collector, 250 breadcrumbs on disk:

```console
$ bash ab.sh old        # the reviewed version
[old] rows before=250  rows left in file after flush=0
received n=200 rows=200 ts_min=51 ts_max=250     # rows 1-50 destroyed, exit 0

$ bash ab.sh new        # this push
[new] rows before=250  rows left in file after flush=0
received n=250 rows=250 ts_min=1 ts_max=250      # what it deleted, it delivered
```

And the non-2xx path, with nothing listening on the collector port:

```console
flush rc=0
rows still in file: 5      # nothing delivered, nothing lost
after 2nd attempt: 6 rows, snapshots left=0      # no stranded .sending file
```

**2. @Copilot's wording — the comment said "URL path", the code records the full URL minus the query.** Corrected in `amux` and in the `frustrations.md` entry: it is `${url%%\?*}`, i.e. scheme + host + path. The host is kept deliberately — `AMUX_API` pointing somewhere unexpected is one of the things this breadcrumb exists to make visible.

**3. Rebased onto current `main` (`a7f0ad19`), and the counts are re-measured.** One new curl site arrived from `e83c9a73` (`--reviewer` pre-write) and **it failed my own guard** — routed through `_curl`. The "36 of 43" in the old title and body was measured on the older file; against current `main` the guard's own definition of an invocation counts **41 sites, 0 with `--connect-timeout`, 8 with only `-m`** — which is also what @esteininger's independent check reported (40/40 on `origin/main`). All count claims in the commit message, the guard's doc comment, `amux` and `frustrations.md` now say that.

**4. The e2e red was not this diff, and it is fixed upstream.** I reported on 08-22 that the failure was the three targets self-adopting each other's builds mid-suite; `d0576a7e` (#150, @Dygreens) confirmed it with per-port exec counts and added `AMUX_NO_SELF_ADOPT`. That fix is in this rebase, so e2e should now run clean here.

Also dropped from this body: the old **Base** note claiming a `workflow` OAuth scope blocked pushing a branch based on current `main`. That was wrong — this fork pushes over SSH, where the `workflow` scope does not apply.

## How I tested

**The guard was run against the UNFIXED file first**, where it listed all 41 invocation sites and no prose. A guard that has never failed is a guard nobody has checked; it also caught the new site this rebase brought in, which is the only reason I looked at `e83c9a73` at all.

**Before / after, same command, same dropping port:**

| | patched | previous |
|---|---|---|
| `AMUX_API=https://localhost:8899 amux board done <id> --outcome …` | **4.7s**, AEAB-36's "NOTHING was applied" | hung until the caller gave up (2 min), **no output at all** |

**The breadcrumb, end to end** — no hand-written files, this is the real path:

```console
$ cat $CC_HOME/cli-transport.jsonl
{"ts":1787413687,"curl_exit":28,"method":"PATCH","url":"https://localhost:8899/api/board/ZZZ-NOPE","session":"","cli":"bash"}

$ amux url            # next invocation that CAN reach the server
https://localhost:8824
$ ls $CC_HOME/cli-transport.jsonl*
# gone — the snapshot was removed because the POST was 2xx

$ curl -sk "https://localhost:8824/api/client-debug?kind=cli-transport-failure&limit=5"
{"beacons":[{"body":{"kind":"cli-transport-failure","n":1,"rows":[{"cli":"bash","curl_exit":28,
 "method":"PATCH","session":"","ts":1787413687,"url":"https://localhost:8899/api/board/ZZZ-NOPE"}]},
 "kind":"cli-transport-failure","ts":1787413695,"ua":"curl/8.5.0"}],"held":1,"matched":1, ...}

$ grep -c 'cli-transport-failure' ~/.amux/logs/server-rs.log
1                      # the durable copy
```

Local gates on the rebased head:

```console
$ bash -n amux                                                    # clean
$ shellcheck -S warning -e SC1090,SC2016,SC2221,SC2222,SC2015,SC1039 amux
$ echo $?
0
$ cargo test -p amux-server --test cli_curl_timeout_guard
test every_curl_in_the_bash_cli_cannot_hang_on_connect ... ok
$ python3 scripts/frustrations_audit.py >/dev/null; echo $?
0
$ bash scripts/test-frustrations-audit.sh | tail -1
test-frustrations-audit: 16 passed, 0 failed
$ bash scripts/test-cli-status-update-flags.sh | tail -1
  9 passed, 0 failed
```

`scripts/test-cli-launch-unbound.sh` fails on this machine (`session 'af78smoke' not found`) — **including on an untouched `upstream/main` checkout**, so it is environmental here (tmux stub) and not this diff. I state it rather than omit it.

## Notes for review

- **`--connect-timeout 5` is the default, and it is a knob** (`AMUX_CURL_CONNECT_TIMEOUT`) rather than a literal, so a slow link does not need a code change. Picking a number at all is the tell that it is a guess — but the failure mode it replaces is unbounded, and the honest alternative (never time out) is what this PR is fixing.
- **The flush runs at startup**, gated on the breadcrumb file being non-empty, so the common case is one `[[ -s ]]` test and no network call. It always returns 0 and cannot break a hot path 48 lanes run.
- **The breadcrumb file is bounded by the outage, not by a cap.** It can only grow while the server is unreachable, and the first invocation that reaches the server ships all of it. I deliberately did not re-add a cap: a cap on the post is what silently ate rows the first time, and a cap at record time would be a breadcrumb we refuse to write about not being able to write breadcrumbs.
- **`/api/client-debug` is reached unauthenticated** by locality (`auth.rs` rule 2, localhost peers pass) — the same basis every other call in this CLI relies on.
- **The guard skips comments and `echo`/`printf`/`die` lines**, because this file contains a lot of prose about curl (including recipes it prints for a human to run raw), and guarding prose is how a guard becomes noise nobody reads.
- **Not exercised:** a *transient* transport failure mid-fleet — I reproduced with a dead port, not with a real builder swap. The 28-exit path is identical either way, but I would rather state it than imply I caught it in the wild.
- **New routes: 0. Auth/guard lines removed: 0. Dependency changes: 0** (no `Cargo.toml`). No credentials. User input reaches curl as argv elements, never through shell interpolation.
- `frustrations.md` is a union-append — one entry added (updated with the flush correction), none of the peer entries touched.

## Checklist

- [x] **One focused change** — the bash CLI plus one guard test
- [x] **Tests pass** — the guard test green; `shellcheck` and `bash -n` clean; `frustrations_audit.py` 0 and its own suite 16/16. The one failing CLI smoke is pre-existing on this machine (shown above, reproduced on untouched `upstream/main`)
- [x] **Client change?** — n/a, no `crates/amux-dashboard/static/` change, so `APP_VER`/`CACHE` untouched
- [x] **Tested end-to-end** — drove the CLI against a dropping port, a refusing host and the live server; see above
- [x] **Rebased** — onto `a7f0ad19`, with the one new curl site from `e83c9a73` routed through `_curl`
