### PR TITLE
fix(freshness): say at SessionStart when the installed git hooks are stale (AEAB-47)

### DIFF
--- a/.claude/session-freshness.sh
+++ b/.claude/session-freshness.sh
@@ -216,6 +216,65 @@ if [ -n "$live_cli" ] && [ -f "$REPO/amux" ]; then
   fi
 fi
 
+# ── Axis 2b: are the INSTALLED GIT HOOKS the ones in this checkout? ──────────
+#
+# Same failure as the CLI axis directly above, one layer down and with worse
+# consequences, because a hook's staleness is INVISIBLE: a missing verb at least
+# prints help, while a missing guard just... does not guard, and looks exactly
+# like nothing being wrong.
+#
+# Measured 2026-08-23. Every checkout on this machine — ~/amux,
+# ~/Developer/amux and ~/Projects/amux-gtm — had `.git/hooks/pre-commit` dated
+# Aug 5, eighteen days old, while `scripts/git-hooks/` was current. `guard_version`
+# appeared 0 times in the installed hooks and 3 times in the repo's. And
+# `.git/hooks/pre-push` never called `append-only-push-guard` at all, so the
+# guard added to stop a stale republish silently reverting pushed entries in
+# frustrations.md (MG-1483, 10 entry-lines lost) had never run here.
+#
+# amux ALREADY KNEW. The server logged
+# "[staged-guard] OUTDATED HOOK: <session> in <repo> sent no guard_version — that
+# hook swallows server errors (`except Exception: return 0`) and printed nothing
+# for the whole 405 window. Reinstall: scripts/install-hooks.sh" — 128 times over
+# 8 days, naming 9 distinct session/repo pairs. Correctly, with the remedy. Into
+# server-rs.log, which nobody tails. That is ethos rule 4's second layer: a tag
+# in a store the reader never opens is the same failure as no tag. This axis
+# moves it to where a session actually looks.
+#
+# CONTENT diff, not `guard_version`, on purpose. The server's detector fires only
+# for hooks too old to send a version at all; a hook that sends one and is
+# otherwise stale is invisible to it. Comparing bytes catches any drift, so this
+# axis is strictly wider than the thing that motivated it rather than a second
+# spelling of it.
+#
+# `git rev-parse --git-path hooks` rather than "$REPO/.git/hooks": in a git
+# WORKTREE `.git` is a file, not a directory, and the naive path does not exist —
+# so a hardcoded one would report nothing in exactly the checkouts AEAB-26 says
+# the guard is already blind in, i.e. it would be silent where it is needed most.
+hooks_dir="$(git -C "$REPO" rev-parse --git-path hooks 2>/dev/null || true)"
+case "$hooks_dir" in /*) : ;; ?*) hooks_dir="$REPO/$hooks_dir" ;; esac
+if [ -n "${hooks_dir:-}" ] && [ -d "$REPO/scripts/git-hooks" ]; then
+  stale_hooks=""
+  for src in "$REPO"/scripts/git-hooks/*; do
+    [ -f "$src" ] || continue
+    name="$(basename "$src")"
+    # post-commit and the shared library are installed under other names or not
+    # at all by install-hooks.sh; only flag what that script actually places, or
+    # this axis nags forever about files it has no remedy for.
+    case "$name" in pre-commit|pre-push|prepare-commit-msg|amux-staged-guard) ;; *) continue ;; esac
+    dst="$hooks_dir/$name"
+    if [ ! -e "$dst" ]; then
+      stale_hooks="${stale_hooks}${stale_hooks:+, }${name} (MISSING)"
+    elif ! diff -q "$src" "$dst" >/dev/null 2>&1; then
+      stale_hooks="${stale_hooks}${stale_hooks:+, }${name}"
+    fi
+  done
+  if [ -n "$stale_hooks" ]; then
+    out+="  - installed git hooks differ from this checkout: ${stale_hooks}"$'\n'
+    out+=$'    a stale guard does not announce itself — it just stops guarding\n'
+    out+="    ./scripts/install-hooks.sh"$'\n'
+  fi
+fi
+
 # The RUNNING server's freshness is the builder's job, not this hook's:
 # com.amux.server-rs-builder rebuilds COMMITTED rust source every 60s and the
 # server self-adopts the new binary. A file diff cannot compare a binary to a

--- a/frustrations.md
+++ b/frustrations.md
@@ -2164,3 +2164,32 @@ FIX: the detection now reaches a session — `.claude/session-freshness.sh` gain
   AEAB-49: amux knows the dangerous fact, computes it correctly, and files it where the
   person who needs it never looks. `install-hooks.sh` also COPIES (`install -m 0755`) rather
   than symlinking, which is the mechanism that lets every one of these drift.
+
+## Developing on branches in the build source put my unreviewed code on the whole fleet
+AREA: cloud
+SEVERITY: blocks
+STATUS: open
+DATE: 2026-08-22
+SESSION: amux-errors-and-bugs
+CARD: AEAB-49
+SYMPTOM: `curl /health` on the live server returned `commit: 5eabfb4dc6cc` — a commit that
+  exists only on my unmerged branch, never reviewed, never merged. `rust-build-provenance.json`
+  said `{"sha":"23ddb8d1...","ref":"fix/push-guard-rebase-false-positive","on_main":"no"}` and
+  a build of that commit was in flight. The auto-builder builds `~/amux` HEAD every 60s, and
+  I had been checking feature branches out in `~/amux` all session.
+COST: the fleet ran unreviewed branch code for at least one build cycle. Nothing broke, and
+  that is luck rather than design — the same mechanism would have shipped a mid-edit tree just
+  as happily. It also churns: putting the checkout back on main makes the next tick rebuild and
+  reinstall, so the fleet takes a second unnecessary swap.
+FIX: the guardrail already exists and it is a log line nobody reads — rust-auto-build.log says
+  "Installing it makes it the live build for the WHOLE FLEET within ~5s, with no CI and no
+  review. Intentional pin? fine. Accident? put ~/amux back on main — develop in a git worktree,
+  not the build source." It printed exactly that, correctly, while installing my branch. A
+  warning that fires as it does the thing is not a guardrail. `on_main:no` is already computed;
+  the builder should either refuse to INSTALL an off-main build unless a flag says the pin is
+  deliberate, or announce it where a session actually looks (a board card or the session
+  banner) rather than only in its own log.
+  The general shape, and it is the third instance today after AEAB-46 and AEAB-47: amux knows
+  the dangerous fact, computes it correctly, and writes it somewhere the person who needs it
+  never opens. Rule 4's second layer — a tag in a store the reader never opens is the same
+  failure as no tag.

--- a/frustrations.md
+++ b/frustrations.md
@@ -2133,3 +2133,34 @@ FIX: two shipped and one general.
       answering confidently from a column that was never there.
 
 ---
+
+## Every checkout's git hooks are 18 days stale, and amux has been saying so into a log for 11
+AREA: instruments
+SEVERITY: blocks
+STATUS: half-fixed — detection reaches a session now; the reinstall is the owner's call
+DATE: 2026-08-23
+SESSION: amux-errors-and-bugs
+CARD: AEAB-47
+SYMPTOM: `.git/hooks/pre-commit` is dated Aug 5 22:39 in ~/amux, ~/Developer/amux AND
+  ~/Projects/amux-gtm, while `scripts/git-hooks/` is current. `grep -c guard_version` returns
+  0 in the installed hooks and 3 in the repo's. `.git/hooks/pre-push` never calls
+  `append-only-push-guard`, so the guard added after MG-1483 silently reverted 10 pushed
+  entry-lines of this very file has never run on this machine.
+COST: the cross-session staged-guard has been degraded fleet-wide for 18 days, and I pushed
+  frustrations.md on 2026-08-22 with the data-loss guard absent without knowing. The detector
+  was never the problem: the server logged "OUTDATED HOOK ... Reinstall:
+  scripts/install-hooks.sh" 128 times across 8 days, naming 9 session/repo pairs, correctly,
+  with the remedy — into server-rs.log, which nobody tails.
+FIX: the detection now reaches a session — `.claude/session-freshness.sh` gains a content
+  diff of the installed hooks at SessionStart. Content rather than `guard_version`, because
+  the server's detector only fires for hooks too old to send a version at all; and
+  `git rev-parse --git-path hooks` rather than `$REPO/.git/hooks`, because in a worktree
+  `.git` is a file and the naive path is silent in exactly the checkouts AEAB-26 says the
+  guard is already blind in.
+  The reinstall itself is deliberately NOT done here: the current hooks are strictly more
+  blocking than the installed ones, so running install-hooks.sh changes push behaviour for
+  every other session on this machine.
+  The general shape, and it is the fourth instance in two days after AEAB-46, AEAB-47 and
+  AEAB-49: amux knows the dangerous fact, computes it correctly, and files it where the
+  person who needs it never looks. `install-hooks.sh` also COPIES (`install -m 0755`) rather
+  than symlinking, which is the mechanism that lets every one of these drift.

--- a/scripts/test-session-freshness.sh
+++ b/scripts/test-session-freshness.sh
@@ -337,6 +337,84 @@ out=$(unknown_run)
 says "$NEVERMARK" "$out"
 lacks "$BEHINDMARK" "$out"
 
+# ── Axis 2b: installed git hooks vs the checkout (2026-08-23) ───────────────
+#
+# The axis exists because amux already detected this and told nobody: the server
+# logged "OUTDATED HOOK ... Reinstall: scripts/install-hooks.sh" 128 times over 8
+# days, naming 9 session/repo pairs, into server-rs.log. Meanwhile every checkout
+# on the machine had .git/hooks/pre-commit dated Aug 5 and the append-only
+# data-loss guard was not installed at all.
+#
+# Case (i) is the load-bearing control. An axis that fires whenever it can see a
+# hooks directory would "pass" every positive case here and be pure noise in
+# practice — and noise in a SessionStart banner is worse than silence, because
+# the banner's whole value is that speaking is rare.
+HOOKMARK="installed git hooks differ from this checkout"
+
+# A repo with scripts/git-hooks and a real .git/hooks, both populated.
+hooks_repo() { # $1 name
+  local d="$TMP/$1"; rm -rf "$d"
+  git init -q -b main "$d/work"
+  ( cd "$d/work"
+    mkdir -p .claude scripts/git-hooks
+    cp "$HOOK" .claude/session-freshness.sh
+    for h in pre-commit pre-push prepare-commit-msg amux-staged-guard; do
+      printf '#!/bin/sh\n# v1 %s\n' "$h" > "scripts/git-hooks/$h"
+      chmod +x "scripts/git-hooks/$h"
+      cp "scripts/git-hooks/$h" ".git/hooks/$h"
+    done
+    echo seed > seed.txt; git add -A; git commit -qm seed ) >/dev/null 2>&1
+  echo "$d/work"
+}
+hooks_run() { ( cd "$1"; AMUX_RS_BUILD_PROVENANCE="$TMP/no-such-provenance.json" \
+                        bash .claude/session-freshness.sh 2>&1 ); }
+
+# (i) CONTROL — installed hooks identical to the checkout: say NOTHING.
+w=$(hooks_repo hk_same)
+out=$(hooks_run "$w")
+lacks "$HOOKMARK" "$out"
+
+# (j) one installed hook DIFFERS — named, and named specifically.
+w=$(hooks_repo hk_diff)
+printf '#!/bin/sh\n# v0 stale\n' > "$w/.git/hooks/pre-commit"
+out=$(hooks_run "$w")
+says "$HOOKMARK" "$out"
+says "pre-commit" "$out"
+
+# (k) an installed hook is MISSING ENTIRELY. This is the append-only-push-guard
+#     case and it is the one a mtime or version comparison cannot express: there
+#     is no file to be old, and "absent" reads identically to "fine" unless it is
+#     said out loud.
+w=$(hooks_repo hk_missing)
+rm -f "$w/.git/hooks/pre-push"
+out=$(hooks_run "$w")
+says "MISSING" "$out"
+
+# (l) a file in scripts/git-hooks that install-hooks.sh does NOT install must be
+#     IGNORED. Without this the axis nags forever about something whose printed
+#     remedy would not fix it — a warning with no honest exit, which is rule 3.
+w=$(hooks_repo hk_extra)
+printf 'not installed anywhere\n' > "$w/scripts/git-hooks/git-shared-guard.py"
+out=$(hooks_run "$w")
+lacks "$HOOKMARK" "$out"
+
+# (m) IN A WORKTREE. `.git` is a FILE there, so "$REPO/.git/hooks" does not
+#     exist and a hardcoded path reports nothing — silent in exactly the
+#     checkouts AEAB-26 says the guard is already blind in. `git rev-parse
+#     --git-path hooks` resolves to the MAIN repo's hooks dir, which is the one
+#     a worktree actually executes.
+w=$(hooks_repo hk_wt)
+( cd "$w" && git worktree add -q "$TMP/hk_wt_linked" -b wtbranch ) >/dev/null 2>&1
+printf '#!/bin/sh\n# v0 stale\n' > "$w/.git/hooks/pre-commit"
+mkdir -p "$TMP/hk_wt_linked/.claude"
+cp "$HOOK" "$TMP/hk_wt_linked/.claude/session-freshness.sh"
+if [ -f "$TMP/hk_wt_linked/.git" ]; then
+  out=$(hooks_run "$TMP/hk_wt_linked")
+  says "$HOOKMARK" "$out"
+else
+  FAIL=$((FAIL+1)); echo "SETUP BROKEN for (m): .git is not a file, so this is not a worktree"
+fi
+
 echo
 echo "test-session-freshness: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Found in the 2026-08-23 daily log review. Ledger LR-59.

`.git/hooks/pre-commit` is dated **Aug 5** in `~/amux`, `~/Developer/amux` **and** `~/Projects/amux-gtm` — 18 days old — while `scripts/git-hooks/` is current. `guard_version` appears **0** times in the installed hooks and **3** in the repo's. And `.git/hooks/pre-push` never calls `append-only-push-guard`, so the guard added after MG-1483 silently reverted 10 pushed entry-lines of `frustrations.md` **has never run on this machine**.

### amux already knew

```
[staged-guard] OUTDATED HOOK: <session> in <repo> sent no guard_version — that hook
swallows server errors (except Exception: return 0) and printed nothing for the whole
405 window. Reinstall: scripts/install-hooks.sh
```

**128 times across 8 days**, naming 9 distinct session/repo pairs — `amux-wexus-gtm`, `amux`, `Amux-gtm`, `amux-errors-and-bugs`, `amux-rothco-gtm` and several worktrees. Correctly, and with the remedy. Into `server-rs.log`, which nobody tails. That is ethos rule 4's second layer: a tag in a store the reader never opens is the same failure as no tag. This moves it to where a session actually looks.

### Two choices worth flagging

- **Content diff, not `guard_version`.** The server's detector only fires for hooks too old to send a version at all; a hook that sends one and is otherwise stale is invisible to it. Bytes catch any drift, so this axis is strictly wider than the thing that motivated it rather than a second spelling of it.
- **`git rev-parse --git-path hooks`, not `$REPO/.git/hooks`.** In a worktree `.git` is a *file*, so the naive path does not exist and a hardcoded one reports nothing — silent in exactly the checkouts AEAB-26 says the guard is already blind in.

Only the four files `install-hooks.sh` actually places are compared. Flagging `git-shared-guard.py` would nag forever about something the printed remedy does not fix — a warning with no honest exit (rule 3).

### Tests: 25 → 32 assertions

Case (i) is the load-bearing control: an axis that fires whenever it can see a hooks directory passes every positive case and is pure noise in a banner whose entire value is that speaking is rare.

| mutation | result |
|---|---|
| delete the axis | 4 assertions fail |
| make it always fire | the control **and** the not-installed-file case fail |
| hardcode `$REPO/.git/hooks` | only the worktree case fails |

### Deliberately not done

Running `install-hooks.sh`. The current hooks are strictly **more** blocking than the installed ones, so reinstalling changes push behaviour for every other session on this machine. That is a deliberate call, not a side effect of a log review.

Also worth noting for whoever picks that up: `install-hooks.sh` uses `install -m 0755` — it **copies**. That is the mechanism that lets all of these drift in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx