### PR TITLE
fix(build): provenance recorded the sha it was ABOUT to build (AEAB-50)

### DIFF
--- a/scripts/rust-auto-build.sh
+++ b/scripts/rust-auto-build.sh
@@ -122,9 +122,28 @@ built_sha=$(git -C "$REPO" rev-parse HEAD 2>/dev/null || echo "$head")
 # not somewhere anyone looks — a tag in a store the reader never opens is the same
 # failure as no tag. The SessionStart freshness hook reads this and says it at the
 # one moment a session is about to build on it.
-printf '{"sha":"%s","ref":"%s","on_main":"%s","built_at":"%s"}\n' \
-  "$built_sha" "$head_ref" "$on_main" "$(date '+%F %T')" \
-  > "${AMUX_RS_BUILD_PROVENANCE:-$HOME/.amux/rust-build-provenance.json}" 2>/dev/null || true
+#
+# AEAB-50: COMPUTED here, WRITTEN after a successful install. It used to be written
+# right here, before the build, and nowhere else — so it recorded the sha this run
+# was ABOUT TO ATTEMPT, not the one running. Three consequences, and the third is
+# the one that matters:
+#   1. wrong for the whole duration of every build. Every build on this machine is
+#      cold right now (free space sits under the cache threshold), so that window
+#      is ~1.5-2 min out of every 60s tick.
+#   2. observed 2026-08-23: the file read {"sha":"9ef46b1f","on_main":"yes"} while
+#      both servers reported commit 23ddb8d1d91d, an unmerged branch, because the
+#      correcting build was still running. I read it as "the fleet is corrected"
+#      and it was not.
+#   3. a FAILED build left the file permanently asserting a deploy that never
+#      happened, with nothing to correct it. The failure branch below already says
+#      "running server keeps the last good build" — so the file must keep
+#      describing THAT build, and now it does: on failure it is not touched.
+# The freshness hook quotes this as "the RUNNING SERVER is N behind; built <sha>",
+# the line a session uses to decide whether its merge has deployed. That sentence
+# was false whenever the last build failed or was in flight.
+PROV_FILE="${AMUX_RS_BUILD_PROVENANCE:-$HOME/.amux/rust-build-provenance.json}"
+PROV_JSON=$(printf '{"sha":"%s","ref":"%s","on_main":"%s","built_at":"%s"}' \
+  "$built_sha" "$head_ref" "$on_main" "$(date '+%F %T')")
 
 # A seam so the predicate above is TESTABLE against real repos rather than
 # restated in a test that could not notice it changing. Everything before this
@@ -132,6 +151,10 @@ printf '{"sha":"%s","ref":"%s","on_main":"%s","built_at":"%s"}\n' \
 # scripts/test-build-provenance.sh stops here instead of asserting on a copy of
 # the logic.
 if [ "${AMUX_RS_BUILD_PROVENANCE_ONLY:-}" = "1" ]; then
+  # The seam still WRITES, because what it exists to test is the predicate that
+  # produces these fields, and a test that cannot read the output tests nothing.
+  # The real path deliberately does not write here — see AEAB-50 above.
+  printf '%s\n' "$PROV_JSON" > "$PROV_FILE" 2>/dev/null || true
   [ "$on_main" = "yes" ] || echo "OFF-MAIN $head_ref $built_sha"
   exit 0
 fi
@@ -259,6 +282,11 @@ fi
     tail -3 "$BUILD_OUT"
     install -m 0755 "$HOME/.amux/rust-build-target/release/amux-server" "$INSTALL"
     echo "$head" > "$STAMP"
+    # AEAB-50: only NOW is this true. Written after the install so the file means
+    # "what is installed" rather than "what was attempted". On the failure branch
+    # below it is left alone, so it keeps naming the last good build — which is
+    # exactly what that branch says is still running.
+    printf '%s\n' "$PROV_JSON" > "$PROV_FILE" 2>/dev/null || true
     echo "== installed; running server will self-adopt within 5s"
   else
     echo "== BUILD FAILED for $head — running server keeps the last good build"

--- a/scripts/test-build-provenance.sh
+++ b/scripts/test-build-provenance.sh
@@ -77,6 +77,46 @@ is "(d) detached at a main commit -> on_main" "$(field on_main "$p")" "yes"
 grep -q 'OFF-MAIN' "$TMP/feature/out" && PASS=$((PASS+1)) || { FAIL=$((FAIL+1)); echo "FAIL: (e) off-main case printed no OFF-MAIN line"; }
 grep -q 'OFF-MAIN' "$TMP/onmain/out"  && { FAIL=$((FAIL+1)); echo "FAIL: (e) on-main case must stay quiet"; } || PASS=$((PASS+1))
 
+# ── AEAB-50: the file must describe what is INSTALLED, not what was attempted ──
+#
+# It used to be written before the build and nowhere else, so a FAILED build left
+# it permanently asserting a deploy that never happened — and the freshness hook
+# quotes it as "the RUNNING SERVER is N behind; built <sha>", which is the line a
+# session uses to decide whether its merge deployed.
+#
+# This runs the REAL failure path rather than restating it: a repo with no cargo
+# manifest, so `cargo build` fails instantly and cheaply. Every destructive seam
+# is pinned away from real paths (DRYRUN for the disk clear, temp INSTALL/STAMP/
+# LOG/PROVENANCE), which is also why this can run in CI.
+prov_failbuild() {
+  local d="$TMP/failbuild"; rm -rf "$d"; mkdir -p "$d"
+  git init -q -b main "$d/repo"
+  ( cd "$d/repo"
+    mkdir -p scripts crates
+    echo x > crates/keep.txt
+    git add -A; git commit -qm "no cargo manifest here" ) >/dev/null 2>&1
+  printf '%s\n' "$1" > "$d/prov.json"
+  AMUX_REPO="$d/repo" \
+  AMUX_RS_INSTALL="$d/install-bin" \
+  AMUX_RS_BUILD_STAMP="$d/stamp" \
+  AMUX_RS_BUILD_LOG="$d/build.log" \
+  AMUX_RS_BUILD_PROVENANCE="$d/prov.json" \
+  AMUX_RS_DISK_CLEAR_DRYRUN=1 \
+    timeout 120 bash "$BUILDER" >/dev/null 2>&1
+  cat "$d/prov.json"
+}
+
+SENTINEL='{"sha":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef","ref":"main","on_main":"yes","built_at":"LAST GOOD"}'
+got="$(prov_failbuild "$SENTINEL")"
+if [ "$got" = "$SENTINEL" ]; then
+  PASS=$((PASS+1)); echo "  ok   — a FAILED build leaves provenance naming the last good install"
+else
+  FAIL=$((FAIL+1))
+  echo "  FAIL — a failed build overwrote provenance; it now claims a deploy that never happened"
+  echo "         wanted: $SENTINEL"
+  echo "         got:    ${got:-<empty>}"
+fi
+
 echo
 echo "test-build-provenance: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Found 2026-08-23 while cleaning up AEAB-49. A defect in my own instrument chain — AEAB-12 writes this file, AEAB-32 reads it.

`rust-auto-build.sh` wrote `~/.amux/rust-build-provenance.json` at line 127, before the cargo build block at 134, and **nowhere else** in the script. So it recorded the sha the run was *about to attempt*, not the one running.

Three consequences, in increasing severity:

1. **Wrong for the whole duration of every build.** Every build on this machine is cold while free space sits under the cache threshold (AEAB-41), so that window is ~1.5–2 min out of every 60-second tick.
2. **Observed, and it is how I found it.** The file read `{"sha":"9ef46b1f","on_main":"yes"}` while both servers reported `commit: 23ddb8d1d91d` — an unmerged branch — because the correcting build was still running. I read it as "the fleet is corrected" and nearly reported it that way.
3. **A FAILED build left the file permanently asserting a deploy that never happened**, with nothing to correct it. Ethos rule 6: an audit trail claimed rather than real — and worse than no file, because the freshness hook presents it with authority as *"the RUNNING SERVER is N commit(s) behind origin/main; built &lt;sha&gt;"*, which is the line a session uses to decide whether its merge deployed.

### The fix

The failure branch already said "running server keeps the last good build", so the file simply has to keep describing that build. It is now **computed** where it always was — the predicate is cheap, network-free and testable there — and **written after a successful install**. On failure it is not touched.

The `AMUX_RS_BUILD_PROVENANCE_ONLY` seam still writes, because what that seam exists to test is the predicate producing these fields, and a test that cannot read the output tests nothing. Its 8 existing cases pass unchanged.

### The test runs the real failure path

A repo with no cargo manifest, so `cargo build` fails instantly and cheaply — rather than restating the logic in an assertion that could not notice the script changing. Every destructive seam is pinned away from real paths (`AMUX_RS_DISK_CLEAR_DRYRUN=1`, temp `INSTALL`/`STAMP`/`LOG`/`PROVENANCE`), which is also why it is safe in CI.

Mutation confirmed before committing — restoring the pre-build write:

```
FAIL — a failed build overwrote provenance; it now claims a deploy that never happened
       wanted: {"sha":"deadbeef...","built_at":"LAST GOOD"}
       got:    {"sha":"00c5e50a4e7c...","built_at":"2026-08-23 09:49:54"}
```

### Deliberately not here

Having the freshness hook cross-check this against `/health`'s `commit` — which is compiled into the running binary and cannot be stale by construction. That is the half that survives the builder being wrong for a reason nobody predicted, and it is the more valuable one. It lives in the same file as #145 and would conflict; noted on AEAB-50 as the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx