### PR TITLE
fix(freshness): say when provenance and the RUNNING SERVER disagree (AEAB-50 follow-up)

### DIFF
--- a/.claude/session-freshness.sh
+++ b/.claude/session-freshness.sh
@@ -290,10 +290,51 @@ fi
 # server self-adopts the new binary. A file diff cannot compare a binary to a
 # source tree, but /health's `build` hash names exactly which build answers —
 # so report only when the running server looks stale relative to the checkout.
+#
+# AMUX_HEALTH_URL is a seam, not test-only scaffolding: a dev server on another
+# port is a real case, and it is also what lets the cross-check below be tested
+# against a `file://` fixture instead of whatever happens to be listening on the
+# machine running the suite. A check whose verdict depends on the host's state is
+# not testing the hook (the mistake test-session-freshness.sh already made once).
+HEALTH_URL="${AMUX_HEALTH_URL:-https://localhost:8824/health}"
 if command -v curl >/dev/null 2>&1; then
-  hs="$(timeout 5 curl -sk https://localhost:8824/health 2>/dev/null || true)"
+  hs="$(timeout 5 curl -sk "$HEALTH_URL" 2>/dev/null || true)"
   if [ -n "$hs" ] && ! printf '%s' "$hs" | grep -q '"server":"amux-rust"'; then
-    out+="  - https://localhost:8824/health is answering but not as amux-rust — check com.amux.server-rs"$'\n'
+    out+="  - ${HEALTH_URL} is answering but not as amux-rust — check com.amux.server-rs"$'\n'
+  fi
+
+  # ── Axis 1e (AEAB-50 follow-up): does provenance agree with what is RUNNING? ─
+  #
+  # Everything above about the running build reads rust-build-provenance.json,
+  # which is a CLAIM the builder makes. /health's `commit` is compiled into the
+  # binary that answered, so it cannot be stale by construction. That asymmetry
+  # is the whole point: this axis makes the reader independent of the builder
+  # being honest.
+  #
+  # AEAB-50 fixed the builder — the file used to be written BEFORE the build and
+  # nowhere else, so a failed build left it permanently asserting a deploy that
+  # never happened. This catches the same shape from the other side, and it keeps
+  # working for causes nobody predicted: a binary installed by hand, a file
+  # edited, a future regression of exactly that bug. On 2026-08-23 provenance read
+  # 9ef46b1f while both servers answered 23ddb8d1d91d, and nothing said so.
+  #
+  # PREFIX match anchored on the HEALTH value's length, because the two fields are
+  # different widths — /health `commit` is 12 hex, provenance `sha` is 40. An
+  # equality test would report a disagreement on literally every call: a detector
+  # that always fires, which is the same defect as one that never can. A hardcoded
+  # 12 would break silently the day the server widens the field, so the length
+  # comes from the value itself.
+  health_commit=$(printf '%s' "$hs" | sed -n 's/.*"commit":"\([0-9a-f]*\)".*/\1/p')
+  if [ -n "${prov_sha:-}" ] && [ -n "$health_commit" ]; then
+    case "$prov_sha" in
+      "$health_commit"*) : ;;   # agree — say nothing
+      *)
+        out+="  - provenance and the RUNNING SERVER disagree about what is deployed"$'\n'
+        out+="    provenance says ${prov_sha:0:12}; ${HEALTH_URL} answers ${health_commit}"$'\n'
+        out+=$'    /health is compiled into the running binary and cannot be stale — believe it\n'
+        out+=$'    provenance is a claim about the build; a build may be in flight or have failed\n'
+        ;;
+    esac
   fi
 fi
 

--- a/scripts/test-session-freshness.sh
+++ b/scripts/test-session-freshness.sh
@@ -415,6 +415,73 @@ else
   FAIL=$((FAIL+1)); echo "SETUP BROKEN for (m): .git is not a file, so this is not a worktree"
 fi
 
+# ── Axis 1e: provenance vs what the RUNNING SERVER answers (AEAB-50 follow-up) ─
+#
+# Everything else about the running build reads rust-build-provenance.json, which
+# is a CLAIM. /health's `commit` is compiled into the binary that answered and
+# cannot be stale by construction. This axis exists so the reader does not depend
+# on the builder being honest.
+#
+# Driven through AMUX_HEALTH_URL against `file://` fixtures rather than whatever
+# is listening on the machine running the suite — a test whose verdict depends on
+# the host's state is not testing the hook, which this file has already learned
+# once the hard way.
+XMARK="disagree about what is deployed"
+
+xcheck_run() { # $1 prov sha  $2 health json
+  local d="$TMP/xcheck"; rm -rf "$d"; mkdir -p "$d"
+  git init -q --bare -b main "$d/origin.git"
+  git clone -q "$d/origin.git" "$d/work" 2>/dev/null
+  ( cd "$d/work"
+    git checkout -q -B main
+    mkdir -p .claude; cp "$HOOK" .claude/session-freshness.sh
+    echo seed > seed.txt; git add -A; git commit -qm seed
+    git push -q -u origin main ) >/dev/null 2>&1
+  printf '{"sha":"%s","ref":"main","on_main":"yes","built_at":"x"}\n' "$1" > "$d/prov.json"
+  printf '%s\n' "$2" > "$d/health.json"
+  ( cd "$d/work"
+    AMUX_RS_BUILD_PROVENANCE="$d/prov.json" AMUX_HEALTH_URL="file://$d/health.json" \
+      bash .claude/session-freshness.sh 2>&1 )
+}
+
+FULLSHA=0123456789abcdef0123456789abcdef01234567
+
+# (n) THE CONTROL, and the one a wrong comparison fails. /health returns 12 hex
+#     and provenance 40, so an EQUALITY test would fire here — on every real call,
+#     forever. A detector that always fires is the same defect as one that never
+#     can, so this case is the reason the match is a prefix.
+out=$(xcheck_run "$FULLSHA" '{"commit":"0123456789ab","server":"amux-rust"}')
+lacks "$XMARK" "$out"
+
+# (o) genuine disagreement — say so, and name BOTH values. Naming only one leaves
+#     the reader to go find the other, which is the trip this axis exists to save.
+out=$(xcheck_run "$FULLSHA" '{"commit":"deadbeef1234","server":"amux-rust"}')
+says "$XMARK" "$out"
+says "deadbeef1234" "$out"
+says "0123456789ab" "$out"
+
+# (p) no server answering: SILENT. Fails open like everything else here — a
+#     freshness check that shouts because the machine is offline gets deleted.
+out=$(xcheck_run "$FULLSHA" '')
+lacks "$XMARK" "$out"
+
+# (q) WAS an assertion that an absent `commit` field stays silent. REMOVED, and
+#     the reason is worth more than the assertion was: with a prefix match an
+#     empty health value expands to the pattern `*`, which matches everything, so
+#     that case is silent BY CONSTRUCTION and no wrong implementation reachable
+#     from here can make it fire. Mutation-checked — dropping the `-n
+#     "$health_commit"` guard changed nothing, 39 passed. It read as coverage and
+#     was theatre, which rule 7 says is worse than no check because it confers
+#     false confidence. The guard stays in the hook because it states the intent;
+#     the assertion goes because it could not fail. Case (n) already covers the
+#     comparison being wrong.
+
+# (r) a SHORTER health value must still match — the length comes from the health
+#     value, not a hardcoded 12, so the day the server widens or narrows that
+#     field this keeps working instead of failing silently.
+out=$(xcheck_run "$FULLSHA" '{"commit":"0123456","server":"amux-rust"}')
+lacks "$XMARK" "$out"
+
 echo
 echo "test-session-freshness: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
Follow-up to #146, which is merged. Named on AEAB-50 as the more valuable half.

Everything else the hook says about the running build reads `rust-build-provenance.json`, which is a **claim** the builder makes. `/health`'s `commit` is compiled into the binary that answered, so it **cannot be stale by construction**. This axis makes the reader independent of the builder being honest at all.

#146 fixed the builder — the file used to be written *before* the build and nowhere else, so a failed build left it permanently asserting a deploy that never happened. This catches the same shape from the other side, and keeps working for causes nobody predicted: a binary installed by hand, a file edited, a future regression of that exact bug. On 2026-08-23 provenance read `9ef46b1f` while both servers answered `23ddb8d1d91d`, and nothing said so.

### The comparison is the whole design

```
/health .commit  -> "9ef46b1fdf34"                              (12 hex)
provenance .sha  -> "9ef46b1fdf341dc44b2bf5f307f88fdc6c6a2edb"  (40 hex)
```

**Prefix match anchored on the health value's length.** Equality would report a disagreement on literally every call — a detector that always fires, which is the same defect as one that never can. A hardcoded 12 would break silently the day that field changes width, so the length comes from the value itself.

`AMUX_HEALTH_URL` is a real seam, not test scaffolding: a dev server on another port is an actual case, and it is what lets this be tested against a `file://` fixture instead of whatever happens to be listening on the machine running the suite.

### Tests 32 → 38, mutations confirmed before committing

| mutation | result |
|---|---|
| equality instead of prefix | 2 fail |
| delete the axis | 3 fail |
| hardcode 12 on both sides | 1 fails — the short-health case, verified by **reading the failure**, not the count |

### One case was removed for being theatre

It asserted that an absent `commit` field stays silent. But with a prefix match an empty health value expands to the pattern `*`, which matches everything — so that case is silent **by construction**, and no wrong implementation reachable from here can make it fire. Dropping the `-n "$health_commit"` guard changed nothing: 39 passed.

It read as coverage and could not fail, which rule 7 says is worse than no check because it confers false confidence. The guard stays in the hook because it states the intent; the assertion goes, and the reasoning is recorded where the assertion was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx