### PR TITLE
fix(freshness): the hook says when IT is not the current one (AEAB-46)

### DIFF
--- a/.claude/session-freshness.sh
+++ b/.claude/session-freshness.sh
@@ -290,10 +290,51 @@ fi
 # server self-adopts the new binary. A file diff cannot compare a binary to a
 # source tree, but /health's `build` hash names exactly which build answers —
 # so report only when the running server looks stale relative to the checkout.
+#
+# AMUX_HEALTH_URL is a seam, not test-only scaffolding: a dev server on another
+# port is a real case, and it is also what lets the cross-check below be tested
+# against a `file://` fixture instead of whatever happens to be listening on the
+# machine running the suite. A check whose verdict depends on the host's state is
+# not testing the hook (the mistake test-session-freshness.sh already made once).
+HEALTH_URL="${AMUX_HEALTH_URL:-https://localhost:8824/health}"
 if command -v curl >/dev/null 2>&1; then
-  hs="$(timeout 5 curl -sk https://localhost:8824/health 2>/dev/null || true)"
+  hs="$(timeout 5 curl -sk "$HEALTH_URL" 2>/dev/null || true)"
   if [ -n "$hs" ] && ! printf '%s' "$hs" | grep -q '"server":"amux-rust"'; then
-    out+="  - https://localhost:8824/health is answering but not as amux-rust — check com.amux.server-rs"$'\n'
+    out+="  - ${HEALTH_URL} is answering but not as amux-rust — check com.amux.server-rs"$'\n'
+  fi
+
+  # ── Axis 1e (AEAB-50 follow-up): does provenance agree with what is RUNNING? ─
+  #
+  # Everything above about the running build reads rust-build-provenance.json,
+  # which is a CLAIM the builder makes. /health's `commit` is compiled into the
+  # binary that answered, so it cannot be stale by construction. That asymmetry
+  # is the whole point: this axis makes the reader independent of the builder
+  # being honest.
+  #
+  # AEAB-50 fixed the builder — the file used to be written BEFORE the build and
+  # nowhere else, so a failed build left it permanently asserting a deploy that
+  # never happened. This catches the same shape from the other side, and it keeps
+  # working for causes nobody predicted: a binary installed by hand, a file
+  # edited, a future regression of exactly that bug. On 2026-08-23 provenance read
+  # 9ef46b1f while both servers answered 23ddb8d1d91d, and nothing said so.
+  #
+  # PREFIX match anchored on the HEALTH value's length, because the two fields are
+  # different widths — /health `commit` is 12 hex, provenance `sha` is 40. An
+  # equality test would report a disagreement on literally every call: a detector
+  # that always fires, which is the same defect as one that never can. A hardcoded
+  # 12 would break silently the day the server widens the field, so the length
+  # comes from the value itself.
+  health_commit=$(printf '%s' "$hs" | sed -n 's/.*"commit":"\([0-9a-f]*\)".*/\1/p')
+  if [ -n "${prov_sha:-}" ] && [ -n "$health_commit" ]; then
+    case "$prov_sha" in
+      "$health_commit"*) : ;;   # agree — say nothing
+      *)
+        out+="  - provenance and the RUNNING SERVER disagree about what is deployed"$'\n'
+        out+="    provenance says ${prov_sha:0:12}; ${HEALTH_URL} answers ${health_commit}"$'\n'
+        out+=$'    /health is compiled into the running binary and cannot be stale — believe it\n'
+        out+=$'    provenance is a claim about the build; a build may be in flight or have failed\n'
+        ;;
+    esac
   fi
 fi
 

--- a/.claude/session-freshness.sh
+++ b/.claude/session-freshness.sh
@@ -338,8 +338,47 @@ if command -v curl >/dev/null 2>&1; then
   fi
 fi
 
+# ── Axis 3: is THIS HOOK the current one? (AEAB-46) ─────────────────────────
+#
+# Every axis above lives inside the file most likely to be stale, and this hook
+# is LOADED FROM THE CHECKOUT IT REPORTS ON — so the staler that checkout is, the
+# less this can say about it, and a MISSING axis is indistinguishable from an
+# axis that found nothing. The instrument is subject to the condition it measures.
+#
+# Not hypothetical. On 2026-08-22 a session started in ~/Developer/amux, 1278
+# commits behind, and ran the Aug 5 copy of this file: `grep -c "RUNNING SERVER
+# is"` returns 0 there, so the deploy axis did not exist and the banner never
+# mentioned that the fleet was 23 commits behind. That was found by hand, four
+# hours and five merged PRs into the session. Every axis added since makes it
+# worse, because there is more that can be silently absent.
+#
+# The fetch above already happened, so comparing this file against origin's copy
+# costs nothing extra. Content, not a commit count: a file can be stale without
+# any commit touching it in this checkout's history, and bytes are what decide
+# whether an axis is present.
+self_path="${BASH_SOURCE[0]}"
+if [ -r "$self_path" ] && git -C "$REPO" rev-parse --verify -q origin/main >/dev/null 2>&1; then
+  if upstream_hook="$(git -C "$REPO" show origin/main:.claude/session-freshness.sh 2>/dev/null)" \
+     && [ -n "$upstream_hook" ]; then
+    if ! printf '%s\n' "$upstream_hook" | diff -q - "$self_path" >/dev/null 2>&1; then
+      out+="  - THIS FRESHNESS HOOK is not the one on origin/main"$'\n'
+      out+=$'    axes it does not have cannot warn you, and a missing axis is SILENT —\n'
+      out+=$'    treat everything above as possibly incomplete rather than as all-clear\n'
+      out+="    git -C $REPO diff origin/main -- .claude/session-freshness.sh"$'\n'
+    fi
+  fi
+fi
+
 [ -z "$out" ] && exit 0
 
 printf 'amux freshness — this session may be building on something stale:\n\n%s\n' "$out"
 printf 'Reconcile before starting work, or say so in your first message if you are deliberately not.\n'
+# PROVENANCE FOOTER, printed only when the banner is ALREADY speaking. Silence
+# stays silence — that is the whole reason this hook is worth reading — but any
+# banner now names WHICH copy produced it, so a reader who sees three axes where
+# the current hook has six can tell. That is rule 7's precondition applied to the
+# instrument itself: before believing a negative, confirm the probe could have
+# produced a positive. It also covers the case the axis above cannot: no origin
+# to compare against, offline, or a detached checkout.
+printf '(from %s)\n' "$self_path"
 exit 0

--- a/scripts/test-session-freshness.sh
+++ b/scripts/test-session-freshness.sh
@@ -415,6 +415,73 @@ else
   FAIL=$((FAIL+1)); echo "SETUP BROKEN for (m): .git is not a file, so this is not a worktree"
 fi
 
+# ── Axis 1e: provenance vs what the RUNNING SERVER answers (AEAB-50 follow-up) ─
+#
+# Everything else about the running build reads rust-build-provenance.json, which
+# is a CLAIM. /health's `commit` is compiled into the binary that answered and
+# cannot be stale by construction. This axis exists so the reader does not depend
+# on the builder being honest.
+#
+# Driven through AMUX_HEALTH_URL against `file://` fixtures rather than whatever
+# is listening on the machine running the suite — a test whose verdict depends on
+# the host's state is not testing the hook, which this file has already learned
+# once the hard way.
+XMARK="disagree about what is deployed"
+
+xcheck_run() { # $1 prov sha  $2 health json
+  local d="$TMP/xcheck"; rm -rf "$d"; mkdir -p "$d"
+  git init -q --bare -b main "$d/origin.git"
+  git clone -q "$d/origin.git" "$d/work" 2>/dev/null
+  ( cd "$d/work"
+    git checkout -q -B main
+    mkdir -p .claude; cp "$HOOK" .claude/session-freshness.sh
+    echo seed > seed.txt; git add -A; git commit -qm seed
+    git push -q -u origin main ) >/dev/null 2>&1
+  printf '{"sha":"%s","ref":"main","on_main":"yes","built_at":"x"}\n' "$1" > "$d/prov.json"
+  printf '%s\n' "$2" > "$d/health.json"
+  ( cd "$d/work"
+    AMUX_RS_BUILD_PROVENANCE="$d/prov.json" AMUX_HEALTH_URL="file://$d/health.json" \
+      bash .claude/session-freshness.sh 2>&1 )
+}
+
+FULLSHA=0123456789abcdef0123456789abcdef01234567
+
+# (n) THE CONTROL, and the one a wrong comparison fails. /health returns 12 hex
+#     and provenance 40, so an EQUALITY test would fire here — on every real call,
+#     forever. A detector that always fires is the same defect as one that never
+#     can, so this case is the reason the match is a prefix.
+out=$(xcheck_run "$FULLSHA" '{"commit":"0123456789ab","server":"amux-rust"}')
+lacks "$XMARK" "$out"
+
+# (o) genuine disagreement — say so, and name BOTH values. Naming only one leaves
+#     the reader to go find the other, which is the trip this axis exists to save.
+out=$(xcheck_run "$FULLSHA" '{"commit":"deadbeef1234","server":"amux-rust"}')
+says "$XMARK" "$out"
+says "deadbeef1234" "$out"
+says "0123456789ab" "$out"
+
+# (p) no server answering: SILENT. Fails open like everything else here — a
+#     freshness check that shouts because the machine is offline gets deleted.
+out=$(xcheck_run "$FULLSHA" '')
+lacks "$XMARK" "$out"
+
+# (q) WAS an assertion that an absent `commit` field stays silent. REMOVED, and
+#     the reason is worth more than the assertion was: with a prefix match an
+#     empty health value expands to the pattern `*`, which matches everything, so
+#     that case is silent BY CONSTRUCTION and no wrong implementation reachable
+#     from here can make it fire. Mutation-checked — dropping the `-n
+#     "$health_commit"` guard changed nothing, 39 passed. It read as coverage and
+#     was theatre, which rule 7 says is worse than no check because it confers
+#     false confidence. The guard stays in the hook because it states the intent;
+#     the assertion goes because it could not fail. Case (n) already covers the
+#     comparison being wrong.
+
+# (r) a SHORTER health value must still match — the length comes from the health
+#     value, not a hardcoded 12, so the day the server widens or narrows that
+#     field this keeps working instead of failing silently.
+out=$(xcheck_run "$FULLSHA" '{"commit":"0123456","server":"amux-rust"}')
+lacks "$XMARK" "$out"
+
 echo
 echo "test-session-freshness: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/scripts/test-session-freshness.sh
+++ b/scripts/test-session-freshness.sh
@@ -482,6 +482,63 @@ lacks "$XMARK" "$out"
 out=$(xcheck_run "$FULLSHA" '{"commit":"0123456","server":"amux-rust"}')
 lacks "$XMARK" "$out"
 
+# ── Axis 3: does the hook notice that IT is not the current one? (AEAB-46) ────
+#
+# Every other axis lives inside this file, so when the file is old a missing axis
+# is indistinguishable from an axis that found nothing. On 2026-08-22 a session
+# ran the Aug 5 copy — `grep -c "RUNNING SERVER is"` returns 0 there — and was
+# never told the fleet was 23 commits behind.
+SELFMARK="THIS FRESHNESS HOOK is not the one on origin/main"
+FOOTMARK="(from "
+
+# A clone whose hook is on origin/main, optionally modified locally afterwards.
+self_run() { # $1 name  $2 "modify" to diverge the local copy
+  local d="$TMP/$1"; rm -rf "$d"
+  git init -q --bare -b main "$d/origin.git"
+  git clone -q "$d/origin.git" "$d/work" 2>/dev/null
+  ( cd "$d/work"
+    git checkout -q -B main
+    mkdir -p .claude; cp "$HOOK" .claude/session-freshness.sh
+    echo seed > seed.txt; git add -A; git commit -qm seed
+    git push -q -u origin main ) >/dev/null 2>&1
+  if [ "${2:-}" = "modify" ]; then
+    printf '\n# a local edit that origin does not have\n' >> "$d/work/.claude/session-freshness.sh"
+  fi
+  ( cd "$d/work"
+    AMUX_RS_BUILD_PROVENANCE="$TMP/no-such-provenance.json" \
+    AMUX_HEALTH_URL="file://$TMP/no-such-health.json" \
+      bash .claude/session-freshness.sh 2>&1 )
+}
+
+# (s) THE CONTROL. Hook identical to origin's: say nothing about itself. An axis
+#     that fires on a current checkout is noise in a banner whose entire value is
+#     that speaking is rare — and it would fire on every session, forever.
+out=$(self_run self_same)
+lacks "$SELFMARK" "$out"
+
+# (t) local copy differs from origin's: say so. This is the Aug-5-copy case, and
+#     the wording has to say that the ABSENCE of axes is the danger, not just
+#     that the file differs.
+out=$(self_run self_diff modify)
+says "$SELFMARK" "$out"
+
+# (u) THE SILENCE PROPERTY, and the one the provenance footer could most easily
+#     break. When nothing is wrong the hook must print NOTHING AT ALL — not even
+#     a footer saying which copy stayed quiet. A SessionStart banner that always
+#     prints one line is a banner people stop reading, which costs every axis
+#     above it.
+out=$(self_run self_silent)
+lacks "$FOOTMARK" "$out"
+if [ -z "$out" ]; then PASS=$((PASS+1)); else
+  FAIL=$((FAIL+1)); echo "FAIL: a fully current checkout must print nothing; got: $out"
+fi
+
+# (v) when the banner DOES speak, it names which copy spoke — so a reader seeing
+#     three axes where the current hook has six can tell the difference between
+#     "all clear" and "this copy has nothing to say about that".
+out=$(self_run self_foot modify)
+says "$FOOTMARK" "$out"
+
 echo
 echo "test-session-freshness: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
**Stacked on #147** (same file). Once that merges this reduces to one commit.

Every axis in `.claude/session-freshness.sh` lives inside the file most likely to be stale, and the hook is **loaded from the checkout it reports on** — so the staler that checkout is, the less it can say, and a *missing* axis is indistinguishable from an axis that found nothing. The instrument is subject to the condition it measures.

Not hypothetical. On 2026-08-22 a session started in `~/Developer/amux`, 1278 commits behind, and ran the Aug 5 copy:

```
grep -c "RUNNING SERVER is" ~/Developer/amux/.claude/session-freshness.sh   ->  0
```

The deploy axis did not exist there, so the banner never mentioned that the fleet was 23 commits behind. That was found by hand, four hours and five merged PRs into the session. **Every axis added since — 2b for git hooks (#145), 1e for provenance vs `/health` (#147) — makes it worse**, because there is more that can be silently absent.

### Two parts, and the second covers what the first cannot

- **Axis 3** compares this file against `origin/main`'s copy. The fetch already happened above, so it costs nothing extra. **Content, not a commit count**: a file can be stale without any commit touching it in this checkout's history, and bytes are what decide whether an axis is present.
- **A provenance footer** naming which copy spoke, printed *only when the banner is already speaking*. That covers what axis 3 cannot — no origin to compare against, offline, detached — and it is what lets a reader seeing three axes where the current hook has six tell "all clear" from "this copy has nothing to say about that". Rule 7's precondition applied to the instrument itself.

### The silence property is the constraint

The footer is exactly what could break it. When nothing is wrong the hook must print **nothing** — not even a line saying which copy stayed quiet. A SessionStart banner that always prints gets skimmed, which costs every axis above it. There is now an explicit assertion for that, not merely an absence check.

### Tests 38 → 43, mutations confirmed before committing

| mutation | result |
|---|---|
| delete axis 3 | 2 fail (both positive cases) |
| print the footer always | 3 fail, including "must print nothing" |
| fire the axis unconditionally | 4 fail (the control and the silence case) |

Verified live: run from a worktree whose hook differs from `origin/main` it says so and names the diff command; run from a current clone it is silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx