### PR TITLE
fix(board): main is red — `slim_omits` is documented as a filter but is not one (AF-161 follow-up)

### DIFF
--- a/crates/amux-server/src/api/board.rs
+++ b/crates/amux-server/src/api/board.rs
@@ -199,13 +199,21 @@ async fn get_contract(
                         prose) — the DEFAULT shape since AMUX-3496. Slim rows carry \
                         \"slim\": 1 so a consumer can tell a dropped field from an empty one \
                         (AF-161: a census read absence as emptiness and was 100% wrong)",
-                "slim_omits": ["desc", "log", "source_ref", "last_verified_at", "due_time", "gate"],
                 "full": "1 = full prose bodies (desc + log). The default list is slim; a \
                          reader that needs desc/log must ask (slim=0 also honored)",
                 "quota": "1 = per-status terminal quotas (verified floor 300; done/discarded \
                           share done_limit) instead of the lumped cap — the dashboard poll's \
                           shape (AMUX-3503)",
             },
+            // NOT a filter — descriptive metadata about what `slim` DROPS, so it
+            // lives outside `filters`. It sat inside `filters` from 64a9cb7d until
+            // this commit and turned `check` red on main: board_contract_filters
+            // asserts every key in `filters` is a real `ListParams` field, and a
+            // descriptive key can never be one. Adding it to `ListParams` would have
+            // gone green and been WRONG — it would document a query param that does
+            // not exist and that axum silently drops, which is the exact defect that
+            // test was written to catch. Keep `filters` strictly name -> description.
+            "slim_omits": ["desc", "log", "source_ref", "last_verified_at", "due_time", "gate"],
             "not_a_filter": {
                 "q / query / search": "REFUSED with 400 — /api/board does not search, it would \
                                        return the entire board. Use /api/search?q=",

--- a/crates/amux-server/tests/board_contract_filters.rs
+++ b/crates/amux-server/tests/board_contract_filters.rs
@@ -69,6 +69,24 @@ async fn the_contract_documents_every_real_list_filter() {
     let filters = list["filters"].as_object().expect("filters object");
     let refused = list["not_a_filter"].as_object().expect("refused params named too");
 
+    // Every entry in `filters` must be name -> DESCRIPTION. This is what keeps
+    // the two assertions below meaningful: they treat each key as a real query
+    // param, so a descriptive key smuggled in here fails them for a reason that
+    // reads like a missing field. AF-161's follow-up put `slim_omits` (an array
+    // of the fields slim drops) inside `filters` and turned main red with
+    // "ListParams has no such field" — which points at adding the field, the one
+    // fix that would be wrong. Fail here first, and say where such a key goes.
+    for (k, v) in filters.iter() {
+        assert!(
+            v.is_string(),
+            "contract filter `{k}` is not a description string ({v}) — `filters` is \
+             strictly query-param -> description. Metadata ABOUT a filter (what it \
+             omits, what it defaults to) belongs beside `filters`, not inside it; see \
+             `slim_omits`. Leaving it here makes the next assertion demand a \
+             `ListParams` field that must not exist."
+        );
+    }
+
     let documented: Vec<String> = filters
         .keys()
         .cloned()


### PR DESCRIPTION
**main's `check` has been red since 64a9cb7d (14:24Z).** This unblocks it.

### The failure
```
crates/amux-server/tests/board_contract_filters.rs:96
the_contract_documents_every_real_list_filter FAILED
contract documents `slim_omits` but ListParams has no such field —
a param axum will silently drop.
```

### Cause
64a9cb7d added `slim_omits` inside the contract's `list.filters` object to record which fields the slim list drops. It is documentation *about* `slim`, not a query parameter — and that test asserts every key in `filters` is a real `ListParams` field.

Reported by **amux-errors-and-bugs** on AEAB-53, who also named the fix that must **not** be made: adding `slim_omits` to `ListParams` turns the test green by documenting a query param that does not exist and that axum silently drops — exactly the defect the test was written to catch. Their diagnosis was correct in every particular.

### The fix
Move `slim_omits` out of `filters` to a sibling key under `list`. The contract still publishes it; it is just no longer claimed to be a parameter. `slim_omits` appears exactly once in the repo (added earlier today), so nothing depends on the old position.

### So the next one fails at its cause
`filters` is now asserted to be strictly name → description **string**, checked *before* the param comparison. `slim_omits` was an array among strings, so the shape was already the discriminator — the test just couldn't see it and reported a missing field instead. That message points at the wrong repair, which is the part worth preventing.

### Verification
**Not verified locally**, stated plainly rather than implied: the build died with `rustc-LLVM ERROR: IO failure on output stream: No space left on device`. The volume is at 100% (~1.5Gi free after I reclaimed 1.4G of my own scratch artifacts). **CI's `check` job is the verification here** — it is the same job currently red on main. Do not merge on a red or missing run.

Separately: the host disk being at 100% is its own incident and is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)