### PR TITLE
fix(e2e): stop the test servers hot-swapping themselves mid-suite (AEAB-52)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -217,3 +217,8 @@ jobs:
           # foreign, unpushed work straight past. Both directions are pinned,
           # and both mutations were confirmed to fail before this was wired in.
           ./scripts/test-push-guard-range.sh
+          # AEAB-52: the e2e harness must SET the seam it depends on. The Rust
+          # half is unit-tested; this pins the half that rots silently — a seam
+          # nobody sets is decoration (ethos rule 1), and an export placed after
+          # serve-head.sh's `exec` would look correct in a diff and never run.
+          ./scripts/test-e2e-no-self-adopt.sh

--- a/crates/amux-server/src/lib.rs
+++ b/crates/amux-server/src/lib.rs
@@ -9,6 +9,62 @@ pub mod backend;
 pub mod config;
 pub mod legacy_port;
 pub mod log_dedupe;
+
+/// Should this process exec itself when its binary changes on disk? (AEAB-52)
+///
+/// Opt-OUT: absent or empty means YES, so production keeps today's behaviour with
+/// no configuration and only a caller that KNOWS it pinned a build has to say so.
+/// The accepted spellings mirror the rest of amux's boolean env vars, and `0` /
+/// `false` / `off` / `no` explicitly re-ENABLE — a var that disabled on any value
+/// would make `AMUX_NO_SELF_ADOPT=0` mean the opposite of what it reads like,
+/// which is the kind of surprise that gets discovered during an incident.
+///
+/// A free function rather than an inline `env::var` so the predicate can be
+/// tested both ways. Inline, the only way to exercise it would be to boot a
+/// server and touch its binary.
+pub(crate) fn self_adopt_enabled() -> bool {
+    match std::env::var("AMUX_NO_SELF_ADOPT") {
+        Err(_) => true,
+        Ok(v) => matches!(v.trim().to_ascii_lowercase().as_str(), "" | "0" | "false" | "off" | "no"),
+    }
+}
+
+#[cfg(test)]
+mod self_adopt_tests {
+    use super::self_adopt_enabled;
+
+    /// The env var is process-global and cargo runs tests in parallel, so this
+    /// takes a lock — the du-budget tests in autofix.rs were already bitten by
+    /// exactly that (AEAB-33).
+    fn lock() -> std::sync::MutexGuard<'static, ()> {
+        static L: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        L.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// BOTH directions. A seam that disabled self-adoption unconditionally would
+    /// pass any "does not exec" assertion perfectly while silently turning the
+    /// feature off for the whole fleet — the default case is the one that
+    /// protects production, so it is asserted first.
+    #[test]
+    fn self_adoption_is_on_by_default_and_off_only_when_asked() {
+        let _g = lock();
+        std::env::remove_var("AMUX_NO_SELF_ADOPT");
+        assert!(self_adopt_enabled(), "absent must mean ENABLED — production sets nothing");
+
+        for on in ["1", "true", "yes", "TRUE", " 1 "] {
+            std::env::set_var("AMUX_NO_SELF_ADOPT", on);
+            assert!(!self_adopt_enabled(), "AMUX_NO_SELF_ADOPT={on:?} must disable");
+        }
+        // The reading-comprehension case: `=0` must NOT disable. A var whose name
+        // is a negative and whose value is a negative is where an operator gets
+        // it backwards, so it is pinned rather than left to intuition.
+        for off in ["0", "false", "off", "no", ""] {
+            std::env::set_var("AMUX_NO_SELF_ADOPT", off);
+            assert!(self_adopt_enabled(), "AMUX_NO_SELF_ADOPT={off:?} must leave it ENABLED");
+        }
+        std::env::remove_var("AMUX_NO_SELF_ADOPT");
+    }
+}
 pub mod db;
 pub mod integrations;
 pub mod invariants;
@@ -540,30 +596,66 @@ async fn async_main() {
     // deliberate deploy should not. exit(0) stays as the fallback if exec
     // itself fails (missing/unreadable binary), because the old behavior is
     // strictly better than a server running stale code.
-    jobs::spawn_loop(jobs::ids::SELF_ADOPT, Some(secs(5)), async {
-        let Ok(exe) = std::env::current_exe() else { return };
-        let Ok(meta) = std::fs::metadata(&exe) else { return };
-        let initial = meta.modified().ok();
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
-        loop {
-            interval.tick().await;
-            jobs::tick(jobs::ids::SELF_ADOPT);
-            let current = std::fs::metadata(&exe).ok().and_then(|m| m.modified().ok());
-            if current.is_some() && current != initial {
-                tracing::info!(
-                    "binary changed on disk — exec'ing the new build in place (self-adoption, \
-                     AMUX-3458: no exit means no launchd throttle window)"
-                );
-                let err = std::os::unix::process::CommandExt::exec(
-                    &mut std::process::Command::new(&exe),
-                );
-                // Only reachable when exec FAILED. Fall back to the old
-                // exit-for-relaunch path — slower (throttle) but correct.
-                tracing::warn!(%err, "exec failed — falling back to exit-for-relaunch");
-                std::process::exit(0);
+    // AEAB-52: self-adoption is right in PRODUCTION and wrong in a TEST HARNESS.
+    //
+    // `e2e/serve-head.sh` exists to pin a SPECIFIC build, and playwright.config.ts
+    // starts three servers from it (desktop 18823, mobile 18833, ios 18843). Each
+    // one builds, and every build rewrites the shared binary — so each server
+    // already running sees its own mtime move and exec's, refusing connections
+    // for ~1s. Whichever specs are mid-`page.goto` at that instant fail with
+    // ERR_CONNECTION_REFUSED, which is what three days of "flaky" desktop
+    // failures were: 3 failures, then 9 on a re-run of the SAME commit, then 2,
+    // then 2.
+    //
+    // The signature is why this is structural rather than random. Execs per port
+    // in run 32645871348, against server start order:
+    //     18823 desktop, started 1st -> 2 execs
+    //     18833 mobile,  started 2nd -> 1 exec
+    //     18843 ios,     started 3rd -> 0 execs
+    // Each server exec's once per server that starts AFTER it; the last never
+    // does, because nothing rebuilds after it. Only WHICH tests get caught is
+    // random.
+    //
+    // A server that hot-swaps itself mid-suite is also running a different binary
+    // from the one the suite chose, so this is a correctness problem for the
+    // RESULTS and not only noise.
+    //
+    // Opt-OUT, not opt-in: production keeps today's behaviour with no
+    // configuration, and only the harness that knows it pinned a build says so.
+    if !self_adopt_enabled() {
+        // NOT an early return: everything after this block is the rest of server
+        // startup (the port binds, the router). Skipping it would trade a flaky
+        // suite for a server that never listens.
+        tracing::info!(
+            "self-adoption DISABLED by AMUX_NO_SELF_ADOPT — this process will not exec on a \
+             binary change (AEAB-52: a test harness pins its build on purpose)"
+        );
+    } else {
+        jobs::spawn_loop(jobs::ids::SELF_ADOPT, Some(secs(5)), async {
+            let Ok(exe) = std::env::current_exe() else { return };
+            let Ok(meta) = std::fs::metadata(&exe) else { return };
+            let initial = meta.modified().ok();
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
+            loop {
+                interval.tick().await;
+                jobs::tick(jobs::ids::SELF_ADOPT);
+                let current = std::fs::metadata(&exe).ok().and_then(|m| m.modified().ok());
+                if current.is_some() && current != initial {
+                    tracing::info!(
+                        "binary changed on disk — exec'ing the new build in place (self-adoption, \
+                         AMUX-3458: no exit means no launchd throttle window)"
+                    );
+                    let err = std::os::unix::process::CommandExt::exec(
+                        &mut std::process::Command::new(&exe),
+                    );
+                    // Only reachable when exec FAILED. Fall back to the old
+                    // exit-for-relaunch path — slower (throttle) but correct.
+                    tracing::warn!(%err, "exec failed — falling back to exit-for-relaunch");
+                    std::process::exit(0);
+                }
             }
-        }
-    });
+        });
+    }
 
     // THE LEGACY 8822 BIND IS GONE (Ethan, 2026-08-11: "no more 8822 just rust").
     //

--- a/e2e/serve-head.sh
+++ b/e2e/serve-head.sh
@@ -29,6 +29,25 @@ REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # concurrent build WAIT and then find the work done, which is cheap.
 export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$HOME/.amux/rust-build-target}"
 
+# AEAB-52. THIS SCRIPT EXISTS TO PIN A SPECIFIC BUILD, so a server that hot-swaps
+# itself mid-suite is running a different binary from the one the suite chose.
+#
+# playwright.config.ts starts THREE of these (desktop 18823, mobile 18833,
+# ios-safari 18843). Each builds, every build rewrites the shared binary, and the
+# server's 5s SELF_ADOPT loop sees its own mtime move and exec's — refusing
+# connections for ~1s. Whichever specs are mid-`page.goto` fail with
+# ERR_CONNECTION_REFUSED. That was three days of "flaky" desktop failures: 3, then
+# 9 on a re-run of the SAME commit, then 2, then 2.
+#
+# The signature, execs per port against start order in run 32645871348:
+#     18823 desktop (1st) -> 2      18833 mobile (2nd) -> 1      18843 ios (3rd) -> 0
+# Each server exec's once per server started after it; the last never does.
+#
+# Set here rather than in playwright.config.ts because THIS is the script that
+# pins the build — anything else launching a pinned server gets it for free, and
+# the config cannot forget.
+export AMUX_NO_SELF_ADOPT=1
+
 dirty="$(git -C "$REPO" status --porcelain -- crates/ Cargo.toml Cargo.lock 2>/dev/null || true)"
 
 if [ "${AMUX_E2E_WORKING_TREE:-0}" = "1" ]; then

--- a/scripts/test-e2e-no-self-adopt.sh
+++ b/scripts/test-e2e-no-self-adopt.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# AEAB-52 — the e2e harness must actually SET the seam it depends on.
+#
+# The Rust side is unit-tested in lib.rs (self_adopt_enabled, both directions).
+# This pins the other half, which is the half that silently rots: a seam nobody
+# sets is decoration, and the ethos file's first rule is about exactly that —
+# mcp.json shipped six servers that reached 0 of 101 sessions because the flag
+# enabling them was never passed.
+#
+# Two properties, and the second is the one a careless edit breaks:
+#   1. serve-head.sh exports AMUX_NO_SELF_ADOPT=1
+#   2. it does so BEFORE it exec's cargo — an export after the exec line is
+#      unreachable, and would look completely correct in a diff.
+#
+# Exit 0 = all pass, 1 = a failure. Wired into .github/workflows/checks.yml.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+SERVE=e2e/serve-head.sh
+PASS=0; FAIL=0
+ok()  { PASS=$((PASS+1)); echo "  ok   — $1"; }
+bad() { FAIL=$((FAIL+1)); echo "  FAIL — $1"; }
+
+if [ ! -f "$SERVE" ]; then
+  echo "  FAIL — $SERVE not found"; exit 1
+fi
+
+# 1. the export exists at all
+if grep -qE '^[[:space:]]*export[[:space:]]+AMUX_NO_SELF_ADOPT=1[[:space:]]*$' "$SERVE"; then
+  ok "serve-head.sh exports AMUX_NO_SELF_ADOPT=1"
+else
+  bad "serve-head.sh does NOT export AMUX_NO_SELF_ADOPT=1 — the e2e servers will hot-swap mid-suite"
+fi
+
+# 2. it is reachable. `exec` replaces the process, so anything after the FIRST
+#    unconditional exec never runs. Compare line numbers rather than trusting
+#    that the file reads top-to-bottom the way it looks.
+exp_line=$(grep -nE '^[[:space:]]*export[[:space:]]+AMUX_NO_SELF_ADOPT=1' "$SERVE" | head -1 | cut -d: -f1)
+exec_line=$(grep -nE '^[[:space:]]*exec[[:space:]]+cargo' "$SERVE" | tail -1 | cut -d: -f1)
+if [ -n "$exp_line" ] && [ -n "$exec_line" ]; then
+  if [ "$exp_line" -lt "$exec_line" ]; then
+    ok "the export (line $exp_line) precedes the exec (line $exec_line), so it reaches the server"
+  else
+    bad "the export is at line $exp_line, AFTER the exec at line $exec_line — it never runs"
+  fi
+else
+  bad "could not locate both the export and the exec (export=${exp_line:-none} exec=${exec_line:-none})"
+fi
+
+# 3. the Rust side reads the same name. Two spellings of one seam is the drift
+#    this repo keeps finding; a rename on one side alone would leave the harness
+#    setting a variable nothing consults, and every symptom would look identical.
+if grep -q 'AMUX_NO_SELF_ADOPT' crates/amux-server/src/lib.rs; then
+  ok "the server reads AMUX_NO_SELF_ADOPT under the same name"
+else
+  bad "crates/amux-server/src/lib.rs does not mention AMUX_NO_SELF_ADOPT — the two halves disagree"
+fi
+
+echo
+echo "e2e-no-self-adopt: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Three days of "flaky" desktop e2e failures were **not flake** and were not any of the diffs they landed on (#140, #141, #147). Four CI cycles and two investigations.

### The symptom, identical every time

A small, **varying** number of `[desktop]` specs fail with `net::ERR_CONNECTION_REFUSED at https://localhost:18823/` while 230+ pass. Never an assertion — the app simply does not load. Counts observed: **3, then 9 on a re-run of the same commit, then 2, then 2.** A different count on an identical commit is the tell.

### The cause

`lib.rs` runs a SELF_ADOPT loop that stats its own binary every 5s and `exec`s when the mtime moves. Right in production — a deploy reaches the fleet in ~5s with no launchd throttle. Wrong in a harness whose entire purpose is to pin a build.

`playwright.config.ts` starts **three** servers from `serve-head.sh`; each one builds, and every build rewrites the shared binary — so each server already running execs and refuses connections for ~1s.

### The signature, and why this is structural rather than random

Execs per port in run 32645871348, against server start order:

```
18823 desktop, started 1st -> 2 execs
18833 mobile,  started 2nd -> 1 exec
18843 ios,     started 3rd -> 0 execs
```

Each server execs once per server that starts *after* it; the last never does, because nothing rebuilds after it. Only **which** tests get caught is random.

It is also a correctness problem for the results, not only noise: a server that hot-swaps mid-suite is answering from a different binary than the suite chose.

### Opt-out, not opt-in

Production keeps today's behaviour with no configuration; only a caller that *knows* it pinned a build says so. `AMUX_NO_SELF_ADOPT=0/false/off/no` explicitly re-**enable** — a negative name with a negative value is where an operator gets it backwards, so that is pinned rather than left to intuition.

Set in `serve-head.sh` rather than `playwright.config.ts` because that script is what pins the build: anything else launching a pinned server gets it for free, and the config cannot forget.

### Two test halves, both mutation-checked

The Rust unit test asserts **absent means enabled first** — the default is what protects production, and a seam that disabled unconditionally would pass any "does not exec" assertion while silently turning the feature off for the fleet.

`scripts/test-e2e-no-self-adopt.sh` pins the half that rots silently — a seam nobody sets is decoration (ethos rule 1):

| mutation | result |
|---|---|
| remove the export | 2 of 3 fail |
| move it *after* the `exec` | 1 fails, naming both line numbers |
| rename the var on the Rust side only | 1 fails on the two halves disagreeing |

The second is the one a careless edit makes: an export after `exec cargo` is unreachable and looks perfect in a diff.

### Acceptance is the mechanism, not the verdict

`grep -c "binary changed on disk"` in the e2e job log must go **3 → 0**. A green suite alone would not prove it, since the window is timing-dependent and a run can miss it by luck.

### Note

`check` on this PR will inherit main's current failure — `the_contract_documents_every_real_list_filter`, red since 64a9cb7d (AF-161), filed as AEAB-53 and routed to the `amux` lane. That failure is named and identifiable, so it does not obscure this diff's own result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx