### PR TITLE
fix(ci): unbreak main — Dockerfile COPY, the path filter that hid it, and the flake that blocked the fix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,9 +16,20 @@ on:
     # at repo root, outside every other pattern. Without it a fix to the lint
     # config alone could not re-trigger the very gate it fixes, so a red spa-lint
     # stayed red after the fix landed (32c416b: whitelisting XLSX did not re-run CI).
-    paths: ['crates/**', 'Cargo.toml', 'Cargo.lock', 'e2e/**', 'amux', 'scripts/**', 'eslint.config.mjs', '.github/workflows/rust.yml']
+    # `cloud/**` is the THIRD instance of the same shape as the two notes above,
+    # and it was found the same way — by a fix that could not prove itself.
+    # `dockerfile_copies_every_external_include_str_input` reads
+    # cloud/docker/Dockerfile and asserts it COPYs every external include_str!
+    # root, but `cloud/**` was in no pattern, so the test that GUARDS that file
+    # never ran when that file changed. Two consequences, and the second is the
+    # dangerous one: a PR fixing the Dockerfile ran only the secret scan and
+    # could not demonstrate the fix (AEAB-55, this commit), and a PR BREAKING it
+    # by editing only the Dockerfile would have gone green. The break would then
+    # surface as a dead cloud image on the next deploy — which is exactly the
+    # latency the test was written to remove.
+    paths: ['crates/**', 'Cargo.toml', 'Cargo.lock', 'e2e/**', 'amux', 'scripts/**', 'cloud/**', 'eslint.config.mjs', '.github/workflows/rust.yml']
   pull_request:
-    paths: ['crates/**', 'Cargo.toml', 'Cargo.lock', 'e2e/**', 'amux', 'scripts/**', 'eslint.config.mjs', '.github/workflows/rust.yml']
+    paths: ['crates/**', 'Cargo.toml', 'Cargo.lock', 'e2e/**', 'amux', 'scripts/**', 'cloud/**', 'eslint.config.mjs', '.github/workflows/rust.yml']
 
 jobs:
   check:

--- a/cloud/docker/Dockerfile
+++ b/cloud/docker/Dockerfile
@@ -56,6 +56,23 @@ COPY amux ./amux
 # so the next scripts/ include_str! does not re-break it; build-stage only (the
 # content is baked into the binary, the runtime stage needs none of it).
 COPY scripts scripts
+# frustrations.md IS A BUILD INPUT — the THIRD instance of this exact class
+# (AMUX-3033/AMUX-2936 for scripts/, and `amux` above before that). AF-191 added
+#   crates/amux-server/src/invariants/checks.rs:
+#     const MD: &str = include_str!("../../../../frustrations.md");
+# so cargo cannot compile amux-server without it. Missing here the build dies
+# with `couldn't read .../frustrations.md: No such file`, and it stays LATENT
+# until a deploy actually runs the build — rust CI compiles from the full
+# checkout, where the file is present.
+#
+# `dockerfile_copies_every_external_include_str_input` catches it before the
+# deploy does, which is why this was a red `check` on main rather than a broken
+# image. That test is the whole reason this is a one-line fix and not an
+# incident; the comments above record the two times it was an incident.
+#
+# Build-stage only: the content is baked into the binary by include_str!, so the
+# runtime stage needs none of it.
+COPY frustrations.md frustrations.md
 
 # --release is REQUIRED, not a preference. `rust-embed` is built without the
 # `debug-embed` feature, so a DEBUG binary reads the dashboard from

--- a/crates/amux-server/src/api/request_log.rs
+++ b/crates/amux-server/src/api/request_log.rs
@@ -3029,7 +3029,36 @@ mod tests {
             1,
             "the spanning row must be gone and the genuinely slow one must remain: {outliers:?}"
         );
-        assert_eq!(outliers[0]["ts"], json!(now - 10.0), "the survivor is the one after boot");
+        // TOLERANCE, not assert_eq! (AEAB-56). `outliers[0]["ts"]` has crossed a
+        // storage boundary — stored as SQLite REAL, read back, serialised to
+        // JSON — while the right-hand side is recomputed here, and serde_json
+        // compares Numbers bit-for-bit. On 2026-08-24 that failed one ULP apart:
+        //     left:  1787580761.0102837
+        //     right: 1787580761.0102835
+        // A unix timestamp is ~1.787e9, so an f64's ~15-16 significant digits
+        // run out at the 17th and the last one is not representable. Whether the
+        // two agree depends on the value of `now` — the test was passing or
+        // failing on the clock rather than on the behaviour it asserts, and it
+        // blocked an unrelated PR whose whole diff was a Dockerfile line.
+        //
+        // The claim is WHICH ROW SURVIVED, and the two candidates are 270s apart
+        // (the specimen is at boot+20 = now-280, the control at now-10). 1e-3 is
+        // five orders below a millisecond and five below any plausible drift,
+        // and 270,000x smaller than the gap it must not mask — a wrong row is
+        // 270 seconds away, not a microsecond. So this cannot go green on the
+        // failure it exists to catch.
+        //
+        // The three sibling `["ts"]` assertions in this crate (dictation.rs:1777,
+        // history.rs:635 and :764) compare INTEGER literals, which round-trip
+        // exactly; grepped, and this was the only computed-float one.
+        let survivor_ts = outliers[0]["ts"].as_f64().expect("ts is a number");
+        assert!(
+            (survivor_ts - (now - 10.0)).abs() < 1e-3,
+            "the survivor is the one after boot: got {survivor_ts}, want ~{} (the excluded \
+             specimen is at {}, 270s away)",
+            now - 10.0,
+            boot + 20.0
+        );
 
         // THE EXCLUSION IS PUBLISHED, NOT SILENT. A detector that quietly drops
         // rows is one nobody can audit (AF-178), and a zero here is what tells a


### PR DESCRIPTION
**main is red on `check`** since the AF-191 reconcile work added

```rust
// crates/amux-server/src/invariants/checks.rs:2508
const MD: &str = include_str!("../../../../frustrations.md");
```

without the matching COPY. Four consecutive main runs failed (`974b779e`, `14573a02`, `70cabaf4`, `373a3f10`) and every PR opened against main inherits it.

### Third instance of the same class

`amux` was the first — broke the cloud deploy on 2026-08-12. `scripts/` was the second (AMUX-3033 + AMUX-2936) — broke the first green deploy after main went green on 2026-08-15. **Both times it was latent until a deploy actually ran the build**, because rust CI compiles from the full checkout where the file exists.

The outcome differed this time only because `dockerfile_copies_every_external_include_str_input` exists now. It converted a broken cloud image into a red check. That's worth saying in the file, since the two earlier entries in that comment block are incident reports and this one is not.

Build-stage only: `include_str!` bakes the content into the binary, so the runtime stage needs none of it — same reasoning as the `scripts` line directly above it.

### Verified rather than assumed

Simulated the test's own two halves against the patched file before pushing. The COPY-source scraper now yields `{Cargo.toml, amux, crates, frustrations.md, scripts}` and no needed include root is missing.

### Not my change

It's the `amux` lane's, ~40 minutes old, and I filed **AEAB-55** and routed it there first. I'm taking it because main red blocks every PR in the repo, the failing test states the fix verbatim so there's no judgment call in it, and a Dockerfile `COPY` cannot conflict semantically with the `checks.rs` work still in flight.

If you were already on it, say so and I'll close this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx