### PR TITLE
fix(test): compare a round-tripped timestamp with a tolerance, not bit equality (AEAB-56)

### DIFF
--- a/crates/amux-server/src/api/request_log.rs
+++ b/crates/amux-server/src/api/request_log.rs
@@ -3029,7 +3029,36 @@ mod tests {
             1,
             "the spanning row must be gone and the genuinely slow one must remain: {outliers:?}"
         );
-        assert_eq!(outliers[0]["ts"], json!(now - 10.0), "the survivor is the one after boot");
+        // TOLERANCE, not assert_eq! (AEAB-56). `outliers[0]["ts"]` has crossed a
+        // storage boundary — stored as SQLite REAL, read back, serialised to
+        // JSON — while the right-hand side is recomputed here, and serde_json
+        // compares Numbers bit-for-bit. On 2026-08-24 that failed one ULP apart:
+        //     left:  1787580761.0102837
+        //     right: 1787580761.0102835
+        // A unix timestamp is ~1.787e9, so an f64's ~15-16 significant digits
+        // run out at the 17th and the last one is not representable. Whether the
+        // two agree depends on the value of `now` — the test was passing or
+        // failing on the clock rather than on the behaviour it asserts, and it
+        // blocked an unrelated PR whose whole diff was a Dockerfile line.
+        //
+        // The claim is WHICH ROW SURVIVED, and the two candidates are 270s apart
+        // (the specimen is at boot+20 = now-280, the control at now-10). 1e-3 is
+        // five orders below a millisecond and five below any plausible drift,
+        // and 270,000x smaller than the gap it must not mask — a wrong row is
+        // 270 seconds away, not a microsecond. So this cannot go green on the
+        // failure it exists to catch.
+        //
+        // The three sibling `["ts"]` assertions in this crate (dictation.rs:1777,
+        // history.rs:635 and :764) compare INTEGER literals, which round-trip
+        // exactly; grepped, and this was the only computed-float one.
+        let survivor_ts = outliers[0]["ts"].as_f64().expect("ts is a number");
+        assert!(
+            (survivor_ts - (now - 10.0)).abs() < 1e-3,
+            "the survivor is the one after boot: got {survivor_ts}, want ~{} (the excluded \
+             specimen is at {}, 270s away)",
+            now - 10.0,
+            boot + 20.0
+        );
 
         // THE EXCLUSION IS PUBLISHED, NOT SILENT. A detector that quietly drops
         // rows is one nobody can audit (AF-178), and a zero here is what tells a


### PR DESCRIPTION
`stats_does_not_report_a_restart_spanning_row_as_a_slow_one` asserted

```rust
assert_eq!(outliers[0]["ts"], json!(now - 10.0), ...)
```

where the left side has crossed a storage boundary — SQLite REAL → read back → JSON — and the right side is recomputed in the test. `serde_json` compares Numbers bit-for-bit, so on 2026-08-24 it failed **one ULP apart**:

```
left:  1787580761.0102837
right: 1787580761.0102835
```

A unix timestamp is ~1.787e9. An f64 carries ~15–16 significant digits and that value has 17, so the last one isn't representable and whether the two agree depends on the value of `now`. **The test was passing or failing on the clock rather than on the behaviour it asserts** — and it blocked an unrelated PR (#152) whose entire diff was a Dockerfile line and a YAML path list.

### The tolerance cannot mask the failure it exists for

That's the only thing separating this from a mute. The claim is **which row survived**, and the two candidates are **270 seconds apart**: the excluded specimen sits at `boot + 20` (= `now - 280`), the surviving control at `now - 10`. `1e-3` is 270,000× smaller than that gap. A wrong row is 270 seconds away, not a microsecond.

Demonstrated against the real failing values rather than argued:

| case | result |
|---|---|
| exact equality, correct value 1 ULP off | `false` — the flake |
| tolerance, correct value 1 ULP off | passes |
| tolerance, **wrong row 270s away** | **FAILS** — the property that matters |
| tolerance, drifted 1ms | passes |

### The class is closed, not sampled

Grepped for siblings: the three other `["ts"]` assertions in this crate (`dictation.rs:1777`, `history.rs:635`, `history.rs:764`) all compare **integer** literals, which round-trip exactly. This was the only computed-float one.

The behaviour under test is unchanged and still asserted: the restart-spanning row is excluded, the genuinely slow one survives, and both published exclusion counters are still checked exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx