### PR TITLE
ci(rust): run on cloud/** — the test guarding the Dockerfile never met it

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,9 +16,26 @@ on:
     # at repo root, outside every other pattern. Without it a fix to the lint
     # config alone could not re-trigger the very gate it fixes, so a red spa-lint
     # stayed red after the fix landed (32c416b: whitelisting XLSX did not re-run CI).
-    paths: ['crates/**', 'Cargo.toml', 'Cargo.lock', 'e2e/**', 'amux', 'scripts/**', 'eslint.config.mjs', '.github/workflows/rust.yml']
+    # `cloud/**` is the THIRD instance of the same shape as the two notes above,
+    # and it was found the same way — by a fix that could not prove itself.
+    # `dockerfile_copies_every_external_include_str_input` reads
+    # cloud/docker/Dockerfile and asserts it COPYs every external include_str!
+    # root, but `cloud/**` was in no pattern, so the test that GUARDS that file
+    # never ran when that file changed. Two consequences, and the second is the
+    # dangerous one: a PR fixing the Dockerfile ran only the secret scan and
+    # could not demonstrate the fix (AEAB-55), and a PR BREAKING it by editing
+    # only the Dockerfile would have gone green. The break would then surface as
+    # a dead cloud image on the next deploy — which is exactly the latency the
+    # test was written to remove.
+    #
+    # The AEAB-55 fix itself is the argument for this one. That COPY reached main
+    # by being "swept into that commit through the shared index while staged"
+    # (23eac180) rather than through a reviewed change — so no PR gated it, and
+    # with `cloud/**` absent no PR could have. A test that cannot run when its
+    # subject changes does not catch the sweep going the other way.
+    paths: ['crates/**', 'Cargo.toml', 'Cargo.lock', 'e2e/**', 'amux', 'scripts/**', 'cloud/**', 'eslint.config.mjs', '.github/workflows/rust.yml']
   pull_request:
-    paths: ['crates/**', 'Cargo.toml', 'Cargo.lock', 'e2e/**', 'amux', 'scripts/**', 'eslint.config.mjs', '.github/workflows/rust.yml']
+    paths: ['crates/**', 'Cargo.toml', 'Cargo.lock', 'e2e/**', 'amux', 'scripts/**', 'cloud/**', 'eslint.config.mjs', '.github/workflows/rust.yml']
 
 jobs:
   check:


### PR DESCRIPTION
Split out of #152, which was closed as superseded. The Dockerfile COPY and the flaky-test fix both landed independently (`23eac180`, `95d78753`) — **this piece did not**, and `origin/main` still has zero `cloud/**` patterns.

`rust.yml` triggers on `crates/**`, `Cargo.toml`, `Cargo.lock`, `e2e/**`, `amux`, `scripts/**`, `eslint.config.mjs`, `.github/workflows/rust.yml`. No `cloud/**`. So `dockerfile_copies_every_external_include_str_input`, whose entire subject is `cloud/docker/Dockerfile`, **never runs when that Dockerfile changes.**

### The AEAB-55 fix is itself the argument for this one

Per the closing note on #152, that `COPY` reached main by being *"swept into that commit through the shared index while staged"* (`23eac180`) — it landed as a passenger on an unrelated commit rather than through a reviewed change. No PR gated it, and with `cloud/**` absent, no PR **could** have.

That cuts both ways, and the second way is the dangerous one: a PR **breaking** the Dockerfile by editing only that file goes green, and the break surfaces as a dead cloud image on the next deploy — precisely the latency `dockerfile_build_inputs.rs` exists to remove. The guard was there; it was unreachable from the only direction the damage comes from.

### Third instance of a shape documented twice in that same comment block

- `amux` + `scripts/**` were added because *"a PR that touched ONLY `amux` ran neither gate, so the guard existed but never met the file it guards."*
- `eslint.config.mjs` was added because *"a fix to the lint config alone could not re-trigger the very gate it fixes, so a red spa-lint stayed red after the fix landed."*

Same sentence, third file. Written into the comment so the fourth is recognised faster than by a fix that mysteriously produces one green check.

Over-covering is the safe direction for a gate, as the `amux` note already argues: a `cloud/`-only change now also runs cargo and e2e.

Self-demonstrating: `rust.yml` lists itself in its own paths, so this PR triggers the job that was missing.

Ledger: LR-68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx