### PR TITLE
feat(workers): give send a canonical route so a worker id can be addressed

### DIFF
--- a/crates/amux-server/src/api/request_log.rs
+++ b/crates/amux-server/src/api/request_log.rs
@@ -961,6 +961,7 @@ pub const ROUTE_TABLE: &[RouteEntry] = &[
     RouteEntry { path: "/api/workers/{id}/start", methods: &["POST"] },
     RouteEntry { path: "/api/workers/{id}/stop", methods: &["POST"] },
     RouteEntry { path: "/api/workers/{id}/peek", methods: &["GET"] },
+    RouteEntry { path: "/api/workers/{id}/send", methods: &["POST"] },
     RouteEntry { path: "/api/workers/{id}/dead-letters", methods: &["GET"] },
     // -- memories / messages / schedules / verify / prefs / criteria
     RouteEntry { path: "/api/memories", methods: &["GET", "POST"] },

--- a/crates/amux-server/src/api/session_verbs.rs
+++ b/crates/amux-server/src/api/session_verbs.rs
@@ -9430,7 +9430,7 @@ async fn dispatch(
     // silent 404).
     //
     // But the pointer only helps when the modern API actually implements the
-    // verb, and for `peek`/`send` it did not: `/api/workers` mounts exactly
+    // verb, and for `peek`/`send` it did not: `/api/workers` mounted exactly
     // `/`, `/{id}`, `/{id}/start`, `/{id}/stop`, `/{id}/peek`, so a send fell
     // through to THIS dispatcher and answered 501 naming itself — a pointer at
     // the path that just refused. The dashboard reaches every session verb by
@@ -9444,6 +9444,15 @@ async fn dispatch(
     // (AMUX-1768), cross-group scoping, msg_id idempotency, board capture and
     // the delivery verdict all live in `send_post`. So they fall through, and
     // everything else keeps the pointer until it has a modern home.
+    //
+    // `send` now HAS a canonical route (`POST /api/workers/{id}/send`), and the
+    // sentence above still holds: that route resolves its target and calls
+    // `send_post`, so promoting the spelling did not add an implementation. The
+    // exemption is what keeps the OTHER spelling working — the SPA sends from
+    // ~16 call sites, all of them `/api/sessions/<name>/send` — and removing
+    // `send` from this list would hand every one of them the pointer instead.
+    // The list shrinks when a verb's legacy spelling has no callers left, not
+    // when it gains a modern route.
     const NATIVE_ONLY_HERE: [&str; 2] = ["peek", "send"];
     if !NATIVE_ONLY_HERE.contains(&action.as_str()) {
         let is_rust_worker = state
@@ -11354,6 +11363,35 @@ fn send_response_id(name: &str, msg_id: &str) -> String {
     } else {
         format!("msg-{name}-{msg_id}")
     }
+}
+
+/// `send` reached from the MODERN route (`POST /api/workers/{id}/send`) rather
+/// than through `session_verb_handler`.
+///
+/// An ALIAS, in the same sense as the DELETE-on-the-resource spelling above: it
+/// calls `send_post`, the same function the catch-all reaches, so the two
+/// spellings cannot drift. The origin stamp (AMUX-1768), cross-group scoping,
+/// msg_id idempotency, board capture and the delivery verdict stay in exactly
+/// one place.
+///
+/// The only thing repeated here is the existence gate the dispatcher applies to
+/// every verb before it dispatches. The modern route does not pass through that
+/// dispatcher, and a send to a name with no env file must not reach `send_text`
+/// — `send_post` addresses the session by NAME (env file, meta.json, tmux), so
+/// without one it would have nothing to deliver to and no place to record it.
+pub(crate) async fn send_verb(
+    state: &AppState,
+    name: &str,
+    headers: &HeaderMap,
+    body: &Value,
+) -> Response {
+    if !env_path(name).exists() {
+        return jresp(
+            StatusCode::NOT_FOUND,
+            json!({"error": format!("session '{name}' not found")}),
+        );
+    }
+    send_post(state, name, headers, body).await
 }
 
 async fn send_post(state: &AppState, name: &str, headers: &HeaderMap, body: &Value) -> Response {

--- a/crates/amux-server/src/api/session_verbs.rs
+++ b/crates/amux-server/src/api/session_verbs.rs
@@ -11385,6 +11385,20 @@ pub(crate) async fn send_verb(
     headers: &HeaderMap,
     body: &Value,
 ) -> Response {
+    // NAME FIRST, THEN EXISTENCE — the order `start_block_reason` uses, and
+    // here it is load-bearing rather than tidy. This route resolves its target
+    // from the STORE, and a stored `display_name` is only checked for
+    // emptiness when the worker is created, so a value carrying `/` can reach
+    // this function in a way the dispatcher's single URL path segment could
+    // not. Checking existence first would `stat` outside `sessions/`, and a
+    // `/compact` send goes on to `create_dir_all` under
+    // `transcripts_dir().join(name)` before anything validates the name.
+    if !valid_session_name(name) {
+        return jresp(
+            StatusCode::BAD_REQUEST,
+            json!({"error": "invalid session name", "name": name}),
+        );
+    }
     if !env_path(name).exists() {
         return jresp(
             StatusCode::NOT_FOUND,

--- a/crates/amux-server/src/api/workers.rs
+++ b/crates/amux-server/src/api/workers.rs
@@ -1144,6 +1144,53 @@ mod tests {
 
     // ---- RR-0034 test list ----------------------------------------------
 
+    /// A stored `display_name` cannot walk out of the sessions directory.
+    ///
+    /// `create_worker` only checks that `display_name` is non-empty, so the
+    /// store can hold `../escaped`. This route is the first thing that turns a
+    /// stored name into a filesystem path, and the paths are built by
+    /// concatenation (`sessions_dir().join(format!("{name}.env"))`), so without
+    /// the name check the existence gate stats outside `sessions/` — and a
+    /// `/compact` send goes further and `create_dir_all`s under
+    /// `transcripts_dir().join(name)`.
+    ///
+    /// The planted file is what makes this test bite: with it, the traversed
+    /// path EXISTS, so an existence-first ordering sails past the gate and the
+    /// send proceeds under a name that is a path.
+    ///
+    /// What is pinned here is the ORDER — the refusal names the name, before
+    /// anything builds a path from it. The `create_dir_all` itself does not
+    /// happen in this fixture (`claude_home()` holds no project matching the
+    /// planted `CC_DIR`, so the backup returns before writing), which is why
+    /// this asserts on the refusal rather than on an absent directory: an
+    /// assertion that cannot fail would pin nothing.
+    #[tokio::test]
+    async fn a_stored_display_name_cannot_escape_the_sessions_dir() {
+        let home = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(home.path().join("sessions")).unwrap();
+        std::fs::write(home.path().join("escaped.env"), "CC_DIR=/tmp\n").unwrap();
+        let _home = crate::api::settings::test_env::set_home(home.path());
+        let (app, _dir) = app();
+        let id = create(&app, "../escaped").await;
+
+        let (st, _, v) = send(
+            &app,
+            "POST",
+            &format!("/api/workers/{id}/send"),
+            Some(json!({ "text": "/compact" })),
+        )
+        .await;
+        assert_eq!(
+            st,
+            StatusCode::BAD_REQUEST,
+            "a name with a path separator must be refused before it is used as one: {v}"
+        );
+        // The DISTINGUISHING assertion: refused on the name. Without the check
+        // this is the late `auto-wake failed: invalid session name` shape,
+        // which arrives only after the name has already been used as a path.
+        assert_eq!(v["error"], json!("invalid session name"), "{v}");
+    }
+
     /// A worker ID addressed at the modern send route reaches that worker.
     ///
     /// THE DEFECT THIS FAILS ON: before `/{id}/send` was a route, this path

--- a/crates/amux-server/src/api/workers.rs
+++ b/crates/amux-server/src/api/workers.rs
@@ -44,6 +44,20 @@ pub fn routes() -> Router<AppState> {
         .route("/{id}/start", post(start_worker))
         .route("/{id}/stop", post(stop_worker))
         .route("/{id}/peek", get(peek_worker))
+        // THE CANONICAL SPELLING OF `send`, promoted out of the catch-all
+        // (`/api/workers/{name}/{*verb}` in session_verbs.rs) that has been
+        // answering it. Only `send` is promoted: naming the other 40-odd verbs
+        // here would freeze the fleet substrate's spelling into this API before
+        // anyone has decided which of them belong to it. The catch-all shrinks
+        // as verbs earn a home, rather than being replaced wholesale.
+        //
+        // The body limit is disabled for the same reason the catch-all router
+        // disables it: long prompts ride /send bodies. Scoped to this route, so
+        // no other worker route's limit changes.
+        .route(
+            "/{id}/send",
+            post(send_worker).layer(axum::extract::DefaultBodyLimit::disable()),
+        )
 }
 
 /// `GET /api/ollama/models` — list locally installed Ollama models by running
@@ -996,6 +1010,55 @@ pub async fn peek_worker(
     }
 }
 
+/// `POST /api/workers/{id}/send` — deliver a prompt to a worker.
+///
+/// WHAT THIS ADDS over the catch-all it takes precedence over: the target is
+/// resolved through the store ONCE, so an id or a name alias reaches the same
+/// worker a display name does, and a rename between resolution and delivery
+/// cannot land the text in a different lane than the one that was addressed.
+///
+/// WHAT THIS DELIBERATELY DOES NOT DO: implement `send`. It hands off to
+/// `session_verbs::send_verb`, which is the one implementation — origin
+/// stamping (AMUX-1768), cross-group scoping, msg_id idempotency, board
+/// capture and the submitted/queued verdict all stay there. A second
+/// implementation of send is how two callers end up disagreeing about whether
+/// a message was delivered.
+///
+/// A key the store does not know is NOT a 404 here. The catch-all this route
+/// displaces serves every session name, store-backed or not, and `amux send`
+/// posts to this path for all of them; 404-ing the ones without a worker row
+/// would take delivery away from sessions that have it today. Unknown keys are
+/// passed through as session names, and `send_verb`'s existence gate answers
+/// for them exactly as the dispatcher would have.
+pub async fn send_worker(
+    State(state): State<AppState>,
+    Path(key): Path<String>,
+    headers: axum::http::HeaderMap,
+    body_bytes: axum::body::Bytes,
+) -> Response {
+    let store = state.store.clone();
+    let k = key.clone();
+    let joined = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+        let conn = store.read()?;
+        Ok(queries::get_worker(&conn, &k)?)
+    })
+    .await;
+    let resolved = match joined {
+        Ok(Ok(Some(row))) if !row.display_name.is_empty() => row.display_name,
+        // A row with no display name has no env file to address either, so
+        // there is nothing better to try than the key the caller used; the
+        // existence gate then reports the miss under the name they asked for.
+        Ok(Ok(_)) => key,
+        Ok(Err(e)) => return internal(e),
+        Err(e) => return internal(e),
+    };
+    let body = match crate::api::fs::parse_body(&body_bytes) {
+        Ok(v) => v,
+        Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, json!({ "error": e })),
+    };
+    crate::api::session_verbs::send_verb(&state, &resolved, &headers, &body).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1080,6 +1143,128 @@ mod tests {
     }
 
     // ---- RR-0034 test list ----------------------------------------------
+
+    /// A worker ID addressed at the modern send route reaches that worker.
+    ///
+    /// THE DEFECT THIS FAILS ON: before `/{id}/send` was a route, this path
+    /// fell to the catch-all `/api/workers/{name}/{*verb}`, which addresses the
+    /// fleet substrate BY NAME. The ulid was handed to `env_path(<id>)`
+    /// verbatim, matched nothing, and answered `session '<id>' not found` — so
+    /// the assertion below reads back the id instead of `hw` without the fix.
+    /// Every other worker route accepts an id; send was the one that did not,
+    /// which leaves a caller holding the only handle a rename does not move
+    /// unable to deliver with it.
+    ///
+    /// Asserted at the existence gate, not on a 200: a 200 needs a live
+    /// terminal, would launch one on the machine running the suite, and — the
+    /// reason that matters — would still pass against a route that resolved
+    /// nothing, because the name only becomes observable in the answer.
+    #[tokio::test]
+    async fn send_route_resolves_a_worker_id_to_its_session_name() {
+        let home = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(home.path().join("sessions")).unwrap();
+        let _home = crate::api::settings::test_env::set_home(home.path());
+        let (app, _dir) = app();
+        let id = create(&app, "hw").await;
+
+        let (st, _, v) = send(
+            &app,
+            "POST",
+            &format!("/api/workers/{id}/send"),
+            Some(json!({ "text": "hi" })),
+        )
+        .await;
+        assert_eq!(st, StatusCode::NOT_FOUND, "{v}");
+        assert_eq!(
+            v["error"],
+            json!("session 'hw' not found"),
+            "the id must resolve to the worker's name, not be used as one: {v}"
+        );
+    }
+
+    /// A promoted route that `/api/debug/routes` does not report is a route
+    /// nobody can find.
+    ///
+    /// The drift guard in request_log.rs (`every_absolute_route_literal_is_in_
+    /// route_table`) cannot see this one: it scans for `.route("/api/…")`
+    /// literals, and everything this module mounts is written relative to the
+    /// `/api/workers` nest — peek, start and stop are unguarded by it for the
+    /// same reason. So the promoted route is pinned against the served table
+    /// directly. Adjacent and pre-existing; not this change's to close.
+    #[tokio::test]
+    async fn the_promoted_send_route_is_reported_by_debug_routes() {
+        let (app, _dir) = app();
+        let (st, _, v) = send(&app, "GET", "/api/debug/routes", None).await;
+        assert_eq!(st, StatusCode::OK, "{v}");
+        let row = v["routes"]
+            .as_array()
+            .expect("routes array")
+            .iter()
+            .find(|r| r["path"] == "/api/workers/{id}/send")
+            .unwrap_or_else(|| panic!("promoted route absent from the served table: {v}"));
+        assert_eq!(row["methods"], json!(["POST"]));
+    }
+
+    /// Promoting the route did not put a ceiling on prompts that had none.
+    ///
+    /// The catch-all's router disables the body limit outright (session_verbs.
+    /// rs — "long prompts ride /send bodies"), so `POST /api/workers/<n>/send`
+    /// has been uncapped. Nested under `/api/workers` it would instead inherit
+    /// the protected router's 16MB cap (mod.rs), which is a narrowing, not a
+    /// default — hence the disable on the route. Sized ABOVE 16MB deliberately:
+    /// at 3MB this passes either way and pins nothing.
+    #[tokio::test]
+    async fn a_prompt_larger_than_the_default_body_limit_still_reaches_the_gate() {
+        let home = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(home.path().join("sessions")).unwrap();
+        let _home = crate::api::settings::test_env::set_home(home.path());
+        let (app, _dir) = app();
+
+        let big = "x".repeat(17 * 1024 * 1024);
+        let (st, _, v) = send(
+            &app,
+            "POST",
+            "/api/workers/ghost/send",
+            Some(json!({ "text": big })),
+        )
+        .await;
+        assert_eq!(
+            st,
+            StatusCode::NOT_FOUND,
+            "a 17MB prompt must reach the existence gate, not be refused by size: {v}"
+        );
+    }
+
+    /// The promoted route does not narrow what the catch-all it displaces
+    /// served.
+    ///
+    /// A real route takes precedence over the wildcard, so every `amux send`
+    /// now lands here — including sends to plain env-file sessions that have no
+    /// worker row at all. Answering `worker not found` for those would take
+    /// delivery away from sessions that have it today, and it would be the
+    /// wrong fact besides: the store's silence says nothing about whether the
+    /// session exists.
+    #[tokio::test]
+    async fn send_route_passes_a_key_with_no_worker_row_through_as_a_session() {
+        let home = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(home.path().join("sessions")).unwrap();
+        let _home = crate::api::settings::test_env::set_home(home.path());
+        let (app, _dir) = app();
+
+        let (st, _, v) = send(
+            &app,
+            "POST",
+            "/api/workers/ghost/send",
+            Some(json!({ "text": "hi" })),
+        )
+        .await;
+        assert_eq!(st, StatusCode::NOT_FOUND, "{v}");
+        assert_eq!(
+            v["error"],
+            json!("session 'ghost' not found"),
+            "an unknown key is a session miss, not a worker miss: {v}"
+        );
+    }
 
     #[tokio::test]
     async fn create_get_rename_then_alias_resolves() {
@@ -1357,6 +1542,17 @@ mod tests {
         assert_eq!(st, StatusCode::UNAUTHORIZED);
         // The legacy alias must not be an auth bypass.
         let (st, _, _) = send(&app, "GET", "/api/sessions", None).await;
+        assert_eq!(st, StatusCode::UNAUTHORIZED);
+        // Nor is the promoted send route, which is the one route here that
+        // puts text into somebody else's terminal. It sits in the same
+        // protected router as the rest, and this says so out loud.
+        let (st, _, _) = send(
+            &app,
+            "POST",
+            "/api/workers/hw/send",
+            Some(json!({ "text": "hi" })),
+        )
+        .await;
         assert_eq!(st, StatusCode::UNAUTHORIZED);
         let (st, _, _) = send_with(
             &app,


### PR DESCRIPTION
## What & why

`POST /api/workers/<n>/send` has been answered by the catch-all `/api/workers/{name}/{*verb}`, which addresses the fleet substrate **by name**. A worker **id** handed to that path went to `env_path("wrk_01M0…")` verbatim and came back `session 'wrk_01M0…' not found`. Every other worker route accepts an id, and the id is the one handle a rename does not move.

This is direction **(b)** from #134 — complete the modern surface rather than widen the legacy dispatcher. Only `send` is promoted; naming the other 40-odd verbs here would freeze the substrate's spelling into this API before anyone has decided which of them belong to it. The catch-all shrinks as verbs earn a home rather than being replaced wholesale.

`Refs #134`, not `Closes` — the inventory and the rest of the direction call stay open there.

### It does not implement `send`

`send_worker` resolves the target **once** through the store and calls `session_verbs::send_verb`, which reaches the same `send_post` the legacy spelling does. Origin stamping (AMUX-1768), cross-group scoping, msg_id idempotency, board capture and the delivery verdict stay in exactly one place. Resolving once is deliberate: a rename between resolution and delivery cannot land the text in a different lane than the one that was addressed.

`peek`/`send` stay exempt in `NATIVE_ONLY_HERE`. The SPA sends from ~16 `/api/sessions/<name>/send` call sites; dropping the exemption would hand every one of them the pointer instead of a delivery — the regression #135 fixed. That list shrinks when a verb's legacy spelling has no callers left, not when it gains a modern route. The comment there now says that instead of leaving the old justification standing.

### Two things a promoted route silently takes away

A real route wins over the wildcard, so **everything** that used to reach the catch-all now lands here. Both pinned by tests:

- **Sessions with no worker row.** `amux send` posts to this path for plain env-file sessions too. Unknown keys pass through as session names — `worker not found` would take delivery away from sessions that have it today, and it is the wrong fact besides (the store's silence says nothing about whether the session exists).
- **Body size.** The catch-all's router disables the limit outright ("long prompts ride /send bodies"); nested under `/api/workers` the route would inherit the protected router's 16MB cap, which is a narrowing, not a default. Verified load-bearing — without the layer a 17MB prompt is `413 Failed to buffer the request body: length limit exceeded`.

### Security counts (self-audited, so you don't have to)

| | |
|---|---|
| new routes | **1** — `POST /api/workers/{id}/send` |
| auth / guard lines removed | **0** — the only deletion in the diff is one comment word (`mounts` → `mounted`) |
| dependency changes | **0** — no `Cargo.toml` touched |
| credentials | **0** |
| user input | the prompt stays a JSON body value handed to the existing `send_post`; no shell interpolation is introduced |

`worker_routes_sit_behind_auth_including_legacy_paths` now asserts auth explicitly for the one route here that puts text into somebody else's terminal.

### Adjacent, deliberately NOT fixed here

`every_absolute_route_literal_is_in_route_table` (request_log.rs) only matches `.route("/api/…")` — **absolute** literals. Everything `workers::routes()` mounts is written relative to the `/api/workers` nest, so `peek`, `start`, `stop` and now `send` are all invisible to that guard and their `ROUTE_TABLE` rows are unverified. I pinned the promoted route against the served table directly (`the_promoted_send_route_is_reported_by_debug_routes`) rather than change a shared guard in this PR. Happy to send the general fix separately if you want it.

## Checklist

- [x] **One focused change** — one verb, one module
- [x] **It builds clean:** `cargo check --workspace` and `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] **Tests pass:** `cargo test --workspace` — 1675 passed / 6 failed, and those 6 are identical on unmodified `80b18300` (stashed and re-ran to confirm); see below
- [ ] **Client change?** — n/a, no `crates/amux-dashboard/static/` files touched, so no `APP_VER` / `CACHE` bump
- [x] **Tested end-to-end** — drove the endpoint on a real server, transcript below
- [x] Rebased on latest `main` (`80b18300`)

## How I tested

### The A/B, same host, same store, same worker

```console
# BEFORE — server at 2b428975. NATIVE_ONLY_HERE, the catch-all route and the
# existence gate are untouched between 2b428975 and 80b18300, so this is the
# 80b18300 behaviour:
#   git diff 2b428975 80b18300 -- crates/amux-server/src/api/session_verbs.rs
#   | grep -E '^[+-].*(NATIVE_ONLY_HERE|api/workers/\{name\}|env_path\(&name\)\.exists)'
#   -> no output
$ curl -X POST -d '{"text":"probe"}' \
    https://localhost:8824/api/workers/wrk_01M0EJWHHFNVMZ4H22Z4J0A3GW/send
{"error":"session 'wrk_01M0EJWHHFNVMZ4H22Z4J0A3GW' not found"}            [404]

# AFTER — same host, rebuilt at 80b18300 + this diff
$ curl -sk https://localhost:8824/health | jq '{commit, build}'
{"commit":"80b183001807","build":"cb893c1d09dac7e7"}     # build = sha256 of the binary

$ curl https://localhost:8824/api/debug/routes \
    | jq -r '.routes[]|select(.path|startswith("/api/workers"))|"\(.methods) \(.path)"'
["GET","POST"]            /api/workers
["GET","PATCH","DELETE"]  /api/workers/{id}
["POST"]                  /api/workers/{id}/start
["POST"]                  /api/workers/{id}/stop
["GET"]                   /api/workers/{id}/peek
["POST"]                  /api/workers/{id}/send          <-- promoted
["GET"]                   /api/workers/{id}/dead-letters
["*"]                     /api/workers/{name}/{*verb}

$ curl -X POST -d '{"text":"…"}' \
    https://localhost:8824/api/workers/wrk_01M0EJWHHFNVMZ4H22Z4J0A3GW/send
{"ok":false,"message":"not running","submitted":false,
 "submission":"not_submitted",
 "fix":"POST /api/sessions/<name>/start, or send again to auto-wake it",
 "id":"msg-sphinx-frontend-worker2-1787626393051"}                        [409]
```

The `id` field is the proof of resolution: `msg-sphinx-frontend-worker2-…`, where BEFORE the ulid was used as a session name and 404'd.

### All four spellings land in the same implementation

The lanes were stopped, so nothing was delivered — what matters is **where each request stopped**. All four came back in `send_post`'s response shape (`ok` / `submitted` / `submission` / `fix` / `id`), i.e. they reached the implementation rather than being answered by routing.

| spelling | response | what it shows |
|---|---|---|
| `workers/<ID>/send` | `409 not running`, `id: msg-sphinx-frontend-worker2-…` | the promoted route; **the ulid resolved to the name** (BEFORE: 404) |
| `workers/<name>/send` | `409 not running`, same `id` shape | promoting did not break the existing spelling |
| `sessions/<name>/send` | `409 not running` | **legacy exemption intact** — not the 501 pointer, so the SPA's ~16 call sites are unaffected |
| `workers/gamebox-api/send` (env file, no worker row) | `501 herdr lane is not addressable`, `id: msg-gamebox-api-…` | **pass-through reaches the implementation**; not `worker not found` |

That last row is the path most at risk when a real route displaces a catch-all: a store miss passes through as a session name and the failure comes back as the backend's honest 501, not a routing 404.

### The test fails on the incident

Route registration removed, everything else unchanged:

```console
assertion `left == right` failed: the id must resolve to the worker's name, not be used as one:
  {"error":"session 'wrk_01M0VA1QK7H84T0FP71J0K8A6C' not found"}
  left:  String("session 'wrk_01M0VA1QK7H84T0FP71J0K8A6C' not found")
 right: String("session 'hw' not found")

# restored
test api::workers::tests::send_route_resolves_a_worker_id_to_its_session_name ... ok
```

`api::workers::tests` is 16/16.

### Pre-existing failures on my machine (not from this diff)

Confirmed by stashing the diff and re-running on unmodified `80b18300` — identical set:

- `api::file_viewer::tests::raw_guards_and_errors`
- `api::fs::tests::path_allowed_blocks_sensitive_and_system_paths`
- `api::fs::tests::read_denied_paths_answer_403`
- `api::fs::tests::symlink_into_sensitive_dir_is_denied`
- `native_output_matches_recorded_python_fixtures`
- `mdai_live_connect_then_run` — passes when run alone; only fails under full-suite load

### Not verified, and why

**The 200 delivery round-trip.** At measurement time all nine lanes on this host were stopped (`/peek` answered `worker has no live session` for all three store-backed workers), so producing a 200 would have meant auto-waking a real agent. I stopped rather than spend an agent's turn for a screenshot. The delivery code itself (`send_post`) is unchanged by this diff — the change is entirely upstream of it, in how the target is resolved — and the 409/501 transcripts above show requests arriving inside it by all four spellings. Happy to wake a lane and add the 200 if you would rather see it.
