### PR TITLE
fix(disk): the low-space alarm re-measures, and the watch looks when space is low (AEAB-59)

### DIFF
--- a/crates/amux-server/src/runtime_jobs/autofix.rs
+++ b/crates/amux-server/src/runtime_jobs/autofix.rs
@@ -3714,6 +3714,59 @@ fn invariant_signature_parts(sig: &str) -> Option<(String, String)> {
     }
 }
 
+/// AEAB-59. A suppressed re-finding whose TITLE has changed is NOT a duplicate —
+/// it is news about the same condition, and dropping it is how an alarm becomes
+/// a stopped clock.
+///
+/// Measured 2026-08-25: AMUX-30 still read "disk: 4.2 GB free, below the 50 GB
+/// floor" while the volume was at 0.94 GB. The detector had found the condition
+/// every two minutes for five days and every one of those findings was
+/// discarded, because the idem index says one card per condition forever. That
+/// is right for avoiding duplicate cards and wrong for a card whose CONTENT is a
+/// measurement: the condition had not changed, the number had, by 4.5x, and the
+/// number is the whole point. A stopped clock reading "fine" is worse than no
+/// clock, because the board is read first and trusted.
+///
+/// Two gates, and they are what keep this from becoming the OTHER failure —
+/// rule 5, a card that accumulates until nothing about it is done or not-done:
+///   * the TITLE must have changed. These detectors put the measurement in the
+///     title, so an unchanged title means the number has not moved enough to
+///     render differently. A static condition writes nothing, forever.
+///   * and not more often than `AMUX_AUTOFIX_REFRESH_MIN_SECS` (default 6h),
+///     so a value oscillating around a rounding boundary cannot turn the card
+///     into a journal.
+///
+/// The desc block is REPLACED, never appended, for the same reason: the card
+/// stays one page however long the condition lasts.
+fn refresh_min_secs() -> i64 {
+    std::env::var("AMUX_AUTOFIX_REFRESH_MIN_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(6 * 3600)
+}
+
+const REFRESH_MARK: &str = "\n\n<!-- autofix:current -->\n";
+
+/// Strip any previous refresh block, so the replacement cannot stack.
+pub(crate) fn desc_without_refresh(desc: &str) -> &str {
+    match desc.find(REFRESH_MARK) {
+        Some(i) => &desc[..i],
+        None => desc,
+    }
+}
+
+/// Should the existing card be refreshed? Split out so both gates are testable
+/// without a store or a clock — the whole defect was a decision nobody could see.
+pub(crate) fn should_refresh(
+    old_title: &str,
+    new_title: &str,
+    updated_at: i64,
+    now: i64,
+    min_secs: i64,
+) -> bool {
+    old_title != new_title && now - updated_at >= min_secs
+}
+
 async fn file_finding(state: &AppState, f: &Finding) -> anyhow::Result<Option<String>> {
     // PER-TENANT CLOUD: do not drop the server's own health/ops findings onto a
     // customer's board (AMUX-3014). Off by env in the cloud image; on locally
@@ -3726,6 +3779,45 @@ async fn file_finding(state: &AppState, f: &Finding) -> anyhow::Result<Option<St
     {
         let conn = state.store.read()?;
         if already_filed(&conn, &f.signature) {
+            // AEAB-59: do not just drop it — if the MEASUREMENT moved, say so on
+            // the card that already exists. Read-only here; the write is below.
+            let fresh_title = truncate(&f.title, 160);
+            let existing: Option<(String, String, String, i64)> = conn
+                .query_row(
+                    "SELECT id, title, COALESCE(desc,''), COALESCE(updated_at, created_at) \
+                       FROM issues WHERE source_ref = ?1 AND archived = 0 LIMIT 1",
+                    rusqlite::params![format!("autofix:{}", f.signature)],
+                    |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?)),
+                )
+                .ok();
+            let now_s = crate::api::reclaim::now_secs();
+            let Some((card_id, old_title, old_desc, updated_at)) = existing else {
+                return Ok(None);
+            };
+            if !should_refresh(&old_title, &fresh_title, updated_at, now_s, refresh_min_secs()) {
+                return Ok(None);
+            }
+            drop(conn);
+            let body = format!(
+                "{}{}The measurement moved. Re-read {} — previously titled:\n  {}\n\n{}",
+                desc_without_refresh(&old_desc),
+                REFRESH_MARK,
+                chrono::Utc::now().format("%Y-%m-%d %H:%M UTC"),
+                old_title,
+                render_desc(f)
+            );
+            let (cid, ttl) = (card_id.clone(), fresh_title.clone());
+            let _ = state.store.write(move |c| {
+                c.execute(
+                    "UPDATE issues SET title = ?2, desc = ?3, updated_at = ?4 WHERE id = ?1",
+                    rusqlite::params![cid, ttl, body, now_s],
+                )?;
+                Ok(crate::db::WriteOutcome { applied: true, events: vec![] })
+            });
+            tracing::info!(
+                card = %card_id, detector = %f.signature,
+                "autofix refreshed a standing card — the measurement moved (AEAB-59)"
+            );
             return Ok(None);
         }
     }
@@ -4201,6 +4293,62 @@ fn parse_ts(s: &str) -> Option<f64> {
 
 #[cfg(test)]
 mod tests {
+
+    // ── AEAB-59: a standing card must re-measure, and must not become a journal ──
+    //
+    // Every "refreshes" below has a neighbour that must NOT, because the two
+    // failures are opposite and both real: a card frozen at a five-day-old
+    // number, and a card rewritten every tick until nothing on it is
+    // done-or-not-done (ethos rule 5).
+
+    /// THE BUG. AMUX-30 read "4.2 GB free" for five days while the volume fell
+    /// to 0.94 GB. Same condition, same signature, different number — and the
+    /// number is the whole point of the card.
+    #[test]
+    fn a_moved_measurement_refreshes_the_standing_card() {
+        let day = 86_400;
+        assert!(super::should_refresh(
+            "disk: 4.2 GB free, below the 50 GB floor",
+            "disk: 0.9 GB free, below the 50 GB floor",
+            0, 5 * day, 6 * 3600,
+        ));
+    }
+
+    /// THE CONTROL, and the one that stops this becoming rule 5's journal: an
+    /// unchanged title writes nothing, however long the condition stands. A
+    /// refresh that fired on a static condition would rewrite the card every
+    /// tick forever.
+    #[test]
+    fn an_unchanged_measurement_writes_nothing_however_old() {
+        let t = "disk: 4.2 GB free, below the 50 GB floor";
+        assert!(!super::should_refresh(t, t, 0, 365 * 86_400, 6 * 3600));
+    }
+
+    /// The rate gate. A value oscillating across a rounding boundary would
+    /// otherwise rewrite the card on every tick — the same journal, arrived at
+    /// from the other direction.
+    #[test]
+    fn a_moved_measurement_still_waits_out_the_rate_gate() {
+        let now = 1_000_000;
+        assert!(!super::should_refresh("a", "b", now - 60, now, 6 * 3600));
+        assert!(super::should_refresh("a", "b", now - 6 * 3600, now, 6 * 3600));
+    }
+
+    /// The refresh block is REPLACED, never appended, or the card grows without
+    /// bound for as long as the condition lasts — which for a disk alarm is
+    /// exactly the case where somebody eventually has to read it.
+    #[test]
+    fn the_refresh_block_replaces_and_never_stacks() {
+        let base = "original body";
+        let once = format!("{base}{}first", super::REFRESH_MARK);
+        assert_eq!(super::desc_without_refresh(&once), base);
+        let twice = format!("{once}{}second", super::REFRESH_MARK);
+        assert_eq!(
+            super::desc_without_refresh(&twice), base,
+            "a second refresh must still strip back to the original body"
+        );
+        assert_eq!(super::desc_without_refresh(base), base, "no block is a no-op");
+    }
 
     // ── connector-auth: token rot files one card per ACCOUNT ────────────────
 

--- a/crates/amux-server/src/runtime_jobs/disk_watch.rs
+++ b/crates/amux-server/src/runtime_jobs/disk_watch.rs
@@ -64,6 +64,57 @@ fn floor_bytes() -> u64 {
     env_u64("AMUX_DISK_WATCH_FLOOR_GB", 25) * 1024 * 1024 * 1024
 }
 
+/// Free space below which the volume is worth LOOKING AT now rather than at the
+/// next weekly wake (AEAB-59 / LR-70).
+///
+/// The module doc argues against a threshold and is right about the thing it
+/// argues about: "a threshold that auto-deletes" is a bad trade. This job
+/// deletes nothing — the commit that added it says so in its title — so a
+/// threshold that REPORTS is a different object and that reasoning does not
+/// reach it. Recorded here because otherwise this looks like it contradicts a
+/// decision already taken.
+///
+/// Measured 2026-08-25: the volume was at 0.94 GB free and the next watcher scan
+/// was due 2026-08-29, four days out, because the trigger was a pure 7-day
+/// interval with no free-space condition anywhere in it. Nothing in amux was
+/// going to look.
+fn low_free_bytes() -> u64 {
+    env_u64("AMUX_DISK_WATCH_LOW_FREE_GB", 5) * 1024 * 1024 * 1024
+}
+
+/// Minimum gap between LOW-SPACE scans. Without it a volume parked under the
+/// floor starts a walk every hour forever — the scan-storm the whole feature is
+/// built to avoid, and self-inflicted load on the resource being investigated
+/// (the amux-cloud spin-catcher, ethos rule 7: what does the detector COST, and
+/// is the cost paid in the same resource as the fault).
+fn low_free_every_secs() -> u64 {
+    env_u64("AMUX_DISK_WATCH_LOW_FREE_EVERY_SECS", 6 * 3600)
+}
+
+/// Should a scan start now? Split out from `tick` so BOTH triggers are testable
+/// without a store, a walker or a clock — the interval one never was.
+///
+/// `free` is None when statfs failed: fall back to the interval alone rather
+/// than treating an unreadable volume as full, which would start a scan every
+/// grace window on a machine that cannot even measure itself.
+pub(crate) fn should_scan(
+    now: i64,
+    newest_finished: Option<i64>,
+    free: Option<u64>,
+    low_free: u64,
+    every: i64,
+    low_every: i64,
+) -> bool {
+    let age = newest_finished.map(|fin| now - fin);
+    // No completed scan ever: the interval rule already says yes, and it must
+    // keep saying yes independently of the disk reading.
+    let Some(age) = age else { return true };
+    if age > every {
+        return true;
+    }
+    matches!(free, Some(f) if f < low_free) && age > low_every
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct Growth {
     pub path: String,
@@ -215,12 +266,25 @@ async fn tick(state: AppState) {
 
     let now = crate::api::reclaim::now_secs();
     let newest = scans.first().cloned();
-    let stale = newest
-        .as_ref()
-        .map(|(_, fin)| now - fin > scan_every_secs() as i64)
-        .unwrap_or(true);
+    // AEAB-59: TWO triggers now — the weekly cadence, and a low-free-space one
+    // with its own shorter grace window. Read the volume from statfs rather than
+    // from the last scan's stored df_free, which is a number from up to seven
+    // days ago and is exactly the staleness this is fixing.
+    let free_now = crate::api::reclaim::df_bytes(std::path::Path::new(
+        &std::env::var("HOME").unwrap_or_else(|_| "/".into()),
+    ))
+    .map(|(free, _total)| free);
+    let stale = should_scan(
+        now,
+        newest.as_ref().map(|(_, fin)| *fin),
+        free_now,
+        low_free_bytes(),
+        scan_every_secs() as i64,
+        low_free_every_secs() as i64,
+    );
 
-    // Kick a scan when the newest completed one has aged out. Never two at
+    // Kick a scan when the newest completed one has aged out, or when the volume
+    // is low and the last look is older than the short grace window. Never two at
     // once: the reclaim API refuses that anyway, and a walker competing with
     // another walker is the disruption this whole feature avoids.
     if stale && running == 0 {
@@ -328,6 +392,94 @@ pub fn spawn(state: AppState) -> super::PeriodicTask {
 
 #[cfg(test)]
 mod tests {
+
+    // ── AEAB-59: the low-space trigger, and the cells that keep it honest ──
+    //
+    // WEEK/LOW/GRACE are named so a reader can see which rule each case is
+    // about. The pairs matter more than the individual cases: every "fires"
+    // has a neighbour that must NOT fire, because a trigger that is always
+    // true is the same defect as one that never is (ethos rule 7 — a threshold
+    // below the baseline is reporting that the machine is ON).
+    const WEEK: i64 = 7 * 86_400;
+    const GRACE: i64 = 6 * 3_600;
+    const LOW: u64 = 5 * 1024 * 1024 * 1024;
+    const PLENTY: u64 = 40 * 1024 * 1024 * 1024;
+
+    /// The bug this card is about: 0.94 GB free, last scan 3 days ago, and the
+    /// old rule said "not for another 4 days". The interval alone cannot
+    /// express urgency.
+    #[test]
+    fn a_low_volume_is_looked_at_without_waiting_for_the_weekly_wake() {
+        let now = 1_000_000;
+        let three_days_ago = now - 3 * 86_400;
+        assert!(
+            super::should_scan(now, Some(three_days_ago), Some(LOW - 1), LOW, WEEK, GRACE),
+            "under the floor and 3 days since the last look must scan"
+        );
+        // THE CONTROL. Same age, healthy volume: the weekly rule still governs
+        // and must say no, or the low-space path has simply removed the cadence.
+        assert!(
+            !super::should_scan(now, Some(three_days_ago), Some(PLENTY), LOW, WEEK, GRACE),
+            "plenty of space at 3 days must still wait for the weekly wake"
+        );
+    }
+
+    /// THE SCAN-STORM CELL. A volume parked under the floor must not start a
+    /// walk every hour: that is self-inflicted load aimed at the resource being
+    /// investigated, which is the amux-cloud spin-catcher's exact failure.
+    #[test]
+    fn a_low_volume_still_respects_its_own_grace_window() {
+        let now = 1_000_000;
+        assert!(
+            !super::should_scan(now, Some(now - 60), Some(LOW - 1), LOW, WEEK, GRACE),
+            "a scan a minute ago must not be repeated just because space is low"
+        );
+        assert!(
+            super::should_scan(now, Some(now - GRACE - 1), Some(LOW - 1), LOW, WEEK, GRACE),
+            "past the grace window it may look again"
+        );
+    }
+
+    /// The weekly cadence is untouched — this is additive, and a regression
+    /// here would trade one blind spot for another.
+    #[test]
+    fn the_weekly_cadence_still_governs_a_healthy_volume() {
+        let now = 10 * 86_400;
+        assert!(
+            super::should_scan(now, Some(now - WEEK - 1), Some(PLENTY), LOW, WEEK, GRACE),
+            "aged past a week must scan regardless of free space"
+        );
+        assert!(
+            !super::should_scan(now, Some(now - WEEK + 1), Some(PLENTY), LOW, WEEK, GRACE),
+            "inside the week with space to spare must not"
+        );
+    }
+
+    /// statfs FAILED. An unreadable volume must fall back to the interval, not
+    /// read as full — otherwise a machine that cannot measure itself starts a
+    /// walk every grace window forever, and `unwrap_or_default()` on a disk
+    /// reading is how a fallback becomes a fault.
+    #[test]
+    fn an_unreadable_volume_falls_back_to_the_interval_rather_than_reading_as_full() {
+        let now = 1_000_000;
+        assert!(
+            !super::should_scan(now, Some(now - GRACE - 1), None, LOW, WEEK, GRACE),
+            "no reading must NOT be treated as low"
+        );
+        assert!(
+            super::should_scan(now, Some(now - WEEK - 1), None, LOW, WEEK, GRACE),
+            "no reading still honours the weekly cadence"
+        );
+    }
+
+    /// Never scanned at all: the interval rule already answered yes and must
+    /// keep doing so independently of the disk reading, including when statfs
+    /// fails on a first boot.
+    #[test]
+    fn a_volume_never_scanned_is_scanned_whatever_the_disk_says() {
+        assert!(super::should_scan(1_000_000, None, Some(PLENTY), LOW, WEEK, GRACE));
+        assert!(super::should_scan(1_000_000, None, None, LOW, WEEK, GRACE));
+    }
     use super::*;
     use std::sync::Arc;
 


### PR DESCRIPTION
amux detected the volume falling for five days and **neither surface said so again**. Free space went 1.8 → 1.4 → 0.94 GB across three daily reviews and crossed 1 GB with nothing in amux changing.

## Surface 1 — the card was a stopped clock

```
AMUX-30 title:  "disk: 4.2 GB free, below the 50 GB floor"
actual:          0.94 GB free
```

The detector finds the condition every ~2 minutes and **every finding was discarded**, because `idx_sev_idem` gives one card per condition forever. That's right for avoiding duplicate cards and wrong for a card whose *content* is a measurement: the condition hadn't changed, the number had — by 4.5× — and the number is the whole point. A stopped clock reading "fine" is worse than no clock, because the board is read first and trusted.

A suppressed re-finding now **refreshes** the standing card. Two gates keep it from becoming the opposite failure — rule 5's journal:

- the **title must have changed**. These detectors put the measurement in the title, so an unchanged title means the number hasn't moved enough to render differently, and a static condition writes nothing forever.
- and not more often than `AMUX_AUTOFIX_REFRESH_MIN_SECS` (default 6h), so a value oscillating across a rounding boundary can't rewrite the card every tick.

The desc block is **replaced, never appended**, so the card stays one page however long the condition lasts.

## Surface 2 — the disk *watch* had no low-space condition at all

```rust
let stale = newest.map(|(_, fin)| now - fin > scan_every_secs()).unwrap_or(true);
```

A pure 7-day interval. Two scans completed `2026-08-22 17:05:41`, so at 0.94 GB free the next look was due **2026-08-29** — four days out, and nothing else walks the volume.

**The module doc argues against a threshold and is right about the thing it argues about.** It says "a threshold that auto-deletes" is a bad trade. This job *deletes nothing* — the commit that added it says so in its title — so a threshold that **reports** is a different object and that reasoning doesn't reach it. Saying it out loud because otherwise this looks like it contradicts a decision already taken.

Second, independent trigger: scan when free space is under `AMUX_DISK_WATCH_LOW_FREE_GB` (5) **and** the last look is older than `AMUX_DISK_WATCH_LOW_FREE_EVERY_SECS` (6h). The grace window is the scan-storm cell — a volume parked under the floor must not start a walk every hour, which would be self-inflicted load aimed at the resource under investigation. The 7-day cadence is untouched.

`statfs` failing falls back to the interval rather than reading as full, or a machine that cannot measure itself walks every grace window forever.

## Tests — 9 added, every "fires" paired with a "must not"

| mutation | result |
|---|---|
| drop the low-space trigger | 2 fail |
| drop the grace window | 1 fails (the scan-storm cell) |
| `None` reads as full | 1 fails |
| drop the title gate | 1 fails (the journal cell) |
| drop the rate gate | 1 fails |

The refresh block was also checked to strip back to the original body after **two** applications, so it cannot stack.

## Not done

Reclaiming anything. Every candidate is someone's cache or amux's own database, and that's the owner's call (AMUX-30, AEAB-41). Nor is this built locally — the volume has 790 MB free and the auto-builder already clears its 1 GB cache on every run at this level.

Ledger: LR-69, LR-70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4vuEScunv4K6RMwQoT9xx