### PR TITLE
fix(hooks): install-hooks.sh could not install from a worktree, and pre-commit built a second target tree

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -222,3 +222,11 @@ jobs:
           # nobody sets is decoration (ethos rule 1), and an export placed after
           # serve-head.sh's `exec` would look correct in a diff and never run.
           ./scripts/test-e2e-no-self-adopt.sh
+          # install-hooks.sh must work FROM A LINKED WORKTREE — CLAUDE.md tells
+          # every session to develop in one, and `.git` is a FILE there, so the
+          # hardcoded "$ROOT/.git/hooks" died mid-run and left the checkout with
+          # NO guards. Its case B is the load-bearing half: a test that only
+          # asserts "installing works" passes against the pre-fix script from a
+          # normal checkout, which is exactly how this went unnoticed. Both
+          # directions confirmed to fail before wiring in.
+          ./scripts/test-install-hooks-worktree.sh

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -202,6 +202,31 @@ if [ -n "$STAGED_RS" ]; then
 fi
 
 if echo "$STAGED" | grep -qE '^(crates/.*\.rs|Cargo\.(toml|lock))$'; then
+  # ONE SHARED TARGET DIR — and until now this hook was the single biggest
+  # violator of the rule CLAUDE.md states for everyone else.
+  #
+  # That rule exists because the opposite instruction filled the disk: a debug
+  # target tree is 10-15GB, ~37 of them accumulated under /private/tmp, and on
+  # 2026-08-10 the volume hit 741MB free with a 50-session fleet running and
+  # writes failing with ENOSPC. Every session is told to export
+  # CARGO_TARGET_DIR=~/.amux/rust-build-target so the fleet shares one warm
+  # cache instead of paying 15GB and a full rebuild each.
+  #
+  # This hook inherited whatever the committing shell happened to have, which
+  # for a git GUI, an editor, a cron job, or any session that did not export it
+  # is NOTHING — so it built into a repo-local ./target. Measured 2026-08-26 in
+  # a fresh worktree with no CARGO_TARGET_DIR exported: 631MB of ./target in the
+  # 2 minutes before the commit was killed, on its way to a second full tree,
+  # for a check that completes in seconds against the shared one. Nothing said
+  # so; the hook just looked slow, which is the shape people wait on rather than
+  # investigate.
+  #
+  # SETDEFAULT, NOT OVERRIDE (same discipline as server.env): a shell that has
+  # already chosen a target dir keeps it, and the flag CI passes is untouched.
+  # The builder's own spelling is copied rather than re-derived
+  # (scripts/rust-auto-build.sh:301) so the two cannot drift into two dirs.
+  : "${CARGO_TARGET_DIR:=$HOME/.amux/rust-build-target}"
+  export CARGO_TARGET_DIR
   echo "Checking Rust (cargo check --workspace --all-targets)..."
   # --all-targets IS THE POINT, not a flourish (AMUX-2807).
   #

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -245,12 +245,30 @@ check_tracked_guard_mode || true
 
 ROOT="$SRC"
 
-install -m 0755 "$ROOT/scripts/git-hooks/pre-commit" "$ROOT/.git/hooks/pre-commit"
-install -m 0755 "$ROOT/scripts/git-hooks/amux-staged-guard" "$ROOT/.git/hooks/amux-staged-guard"
-install -m 0755 "$ROOT/scripts/git-hooks/prepare-commit-msg" "$ROOT/.git/hooks/prepare-commit-msg"
-install -m 0755 "$ROOT/scripts/git-hooks/pre-push" "$ROOT/.git/hooks/pre-push"
-install -m 0755 "$ROOT/scripts/git-hooks/append-only-push-guard" "$ROOT/.git/hooks/append-only-push-guard"
-install -m 0755 "$ROOT/scripts/git-hooks/post-commit" "$ROOT/.git/hooks/post-commit"
+# WHERE THE HOOKS ACTUALLY LIVE — `git rev-parse --git-path hooks`, never
+# "$ROOT/.git/hooks" (2026-08-26). In a linked WORKTREE `.git` is a FILE, not a
+# directory, so the hardcoded path is not a directory at all and every install
+# below died with `install: cannot stat ... Not a directory` after the script had
+# already printed its first `ok` line — a half-run that leaves the checkout with
+# NO guards while looking like it started fine.
+#
+# This script already knew: line ~85 skips a linked worktree by name, and the
+# WARN at ~182 tells OTHER hooks to resolve guards this exact way. Only its own
+# install path still spelled the path by hand.
+#
+# The resolved dir is the git COMMON dir, shared by the main checkout and every
+# worktree — which is correct and is why the `--all` sweep skips worktrees: one
+# install covers them all.
+HOOKS="$(git -C "$ROOT" rev-parse --git-path hooks 2>/dev/null)"
+case "$HOOKS" in /*) : ;; ?*) HOOKS="$ROOT/$HOOKS" ;; *) HOOKS="$ROOT/.git/hooks" ;; esac
+mkdir -p "$HOOKS"
+
+install -m 0755 "$ROOT/scripts/git-hooks/pre-commit" "$HOOKS/pre-commit"
+install -m 0755 "$ROOT/scripts/git-hooks/amux-staged-guard" "$HOOKS/amux-staged-guard"
+install -m 0755 "$ROOT/scripts/git-hooks/prepare-commit-msg" "$HOOKS/prepare-commit-msg"
+install -m 0755 "$ROOT/scripts/git-hooks/pre-push" "$HOOKS/pre-push"
+install -m 0755 "$ROOT/scripts/git-hooks/append-only-push-guard" "$HOOKS/append-only-push-guard"
+install -m 0755 "$ROOT/scripts/git-hooks/post-commit" "$HOOKS/post-commit"
 
 # Verify rather than announce (ethos #7): compare what landed against its source,
 # so a stale installed copy cannot hide behind a success message. That drift was
@@ -260,10 +278,10 @@ install -m 0755 "$ROOT/scripts/git-hooks/post-commit" "$ROOT/.git/hooks/post-com
 # them.
 fail=0
 for h in pre-commit amux-staged-guard prepare-commit-msg pre-push post-commit append-only-push-guard; do
-  if cmp -s "$ROOT/scripts/git-hooks/$h" "$ROOT/.git/hooks/$h"; then
-    echo "  ok   .git/hooks/$h matches scripts/git-hooks/$h"
+  if cmp -s "$ROOT/scripts/git-hooks/$h" "$HOOKS/$h"; then
+    echo "  ok   $HOOKS/$h matches scripts/git-hooks/$h"
   else
-    echo "  FAIL .git/hooks/$h differs from scripts/git-hooks/$h" >&2
+    echo "  FAIL $HOOKS/$h differs from scripts/git-hooks/$h" >&2
     fail=1
   fi
 done
@@ -271,8 +289,8 @@ done
 # The shim is the whole chain: an installed guard that pre-commit never calls is
 # a file, not a guard. Check the LINK, not just the two files — this is exactly
 # the failure that shipped when pre-commit was overwritten without it.
-if grep -q 'amux-staged-guard' "$ROOT/.git/hooks/pre-commit" \
-   && grep -q '"\$g" || exit 1' "$ROOT/.git/hooks/pre-commit"; then
+if grep -q 'amux-staged-guard' "$HOOKS/pre-commit" \
+   && grep -q '"\$g" || exit 1' "$HOOKS/pre-commit"; then
   echo "  ok   pre-commit calls amux-staged-guard"
 else
   echo "  FAIL pre-commit does NOT call amux-staged-guard — sweep protection is OFF" >&2

--- a/scripts/test-install-hooks-worktree.sh
+++ b/scripts/test-install-hooks-worktree.sh
@@ -63,8 +63,18 @@ wt="$TMP/wt"
 git -C "$repo" worktree add -q -b feature "$wt"
 # The precondition the whole defect rests on. If this ever stops being true the
 # test is measuring nothing, so assert it rather than assume it.
-if [ -d "$wt/.git" ]; then
-  bad "fixture worktree has a .git DIRECTORY — precondition gone, this test is vacuous"
+#
+# TEST FOR THE PROPERTY, NOT FOR ITS NEGATION (Copilot, #158). This was written
+# as `[ -d "$wt/.git" ] && fail`, which is a DIFFERENT claim from the `ok` line
+# it guards: a `.git` that is missing entirely — a fixture whose `worktree add`
+# half-failed, or a path typo — is also "not a directory", so the check printed
+# "whose .git is a file" about a path with nothing at it, and every case below
+# would then fail for a reason that has nothing to do with the defect. Require
+# the regular file the linked-worktree shape actually produces, and name what
+# was found instead, so a broken fixture reads as a broken fixture.
+if [ ! -f "$wt/.git" ]; then
+  bad "fixture worktree's .git is not a regular FILE — precondition gone, this test is vacuous"
+  note "  found instead: $(ls -ld "$wt/.git" 2>&1)"
   exit 1
 fi
 ok "fixture: linked worktree whose .git is a file"

--- a/scripts/test-install-hooks-worktree.sh
+++ b/scripts/test-install-hooks-worktree.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# scripts/install-hooks.sh must work FROM A LINKED WORKTREE, and nothing tested it.
+#
+# CLAUDE.md tells every session to develop in a worktree and never in the checkout
+# the builder watches. install-hooks.sh resolved its destination as
+# "$ROOT/.git/hooks" — and in a linked worktree `.git` is a FILE, not a directory,
+# so every install died with
+#
+#     install: cannot stat '<worktree>/.git/hooks/pre-commit': Not a directory
+#
+# AFTER the script had already printed its first `ok` line. So the sanctioned way
+# to work was also the one way you could not install the secret scan, the
+# staged-guard, the push guard or the Amux-Session stamp — and the half-run reads
+# as having started fine.
+#
+# The script already knew the shape: its --all sweep skips linked worktrees BY
+# NAME, and its own WARN tells OTHER hooks to resolve guards with
+# `git rev-parse --git-path hooks`. Only its own install path still spelled the
+# path by hand, which is why a test belongs here rather than a comment.
+#
+# CASE B IS THE LOAD-BEARING HALF. A test that only asserts "installing works"
+# passes against the pre-fix script the moment it is run from a NORMAL checkout,
+# which is how this went unnoticed: the defect is invisible unless the fixture is
+# a worktree. So B rebuilds the pre-fix behaviour (the hardcoded path) and asserts
+# it FAILS on the same fixture. Confirmed before wiring in: with B's mutation
+# applied to the shipped script, A fails and B passes.
+set -uo pipefail
+
+SRC_REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fail=0
+
+note() { printf '  %s\n' "$*"; }
+ok()   { printf '  ok   %s\n' "$*"; }
+bad()  { printf '  FAIL %s\n' "$*" >&2; fail=1; }
+
+# ── the fixture: a real repo with a real linked worktree ─────────────────────
+# A COPY, not the amux checkout itself: this test must not install into the tree
+# it is run from (a test with a side effect on the developer's hooks is one
+# nobody runs twice), and mktemp gives us a `.git` we can safely inspect.
+repo="$TMP/origin"
+mkdir -p "$repo/scripts"
+cp -p "$SRC_REPO/scripts/install-hooks.sh" "$repo/scripts/"
+cp -pr "$SRC_REPO/scripts/git-hooks" "$repo/scripts/"
+git -C "$repo" init -q -b main
+git -C "$repo" config user.email t@example.com
+git -C "$repo" config user.name  t
+git -C "$repo" add -A
+# `-c core.hooksPath=/dev/null` so the fixture's OWN commit does not run the
+# hooks under test — the fixture must not depend on what it is checking.
+git -C "$repo" -c core.hooksPath=/dev/null commit -qm "fixture"
+
+# check_tracked_guard_mode asserts the guard is tracked 100755. If the copy lost
+# the bit, this test would report the SCRIPT as broken when the fixture is.
+mode=$(git -C "$repo" ls-files -s scripts/git-hooks/amux-staged-guard | awk '{print $1}')
+if [ "$mode" != "100755" ]; then
+  bad "fixture lost the guard's exec bit (tracked $mode) — fix the fixture, not the script"
+  exit 1
+fi
+
+wt="$TMP/wt"
+git -C "$repo" worktree add -q -b feature "$wt"
+# The precondition the whole defect rests on. If this ever stops being true the
+# test is measuring nothing, so assert it rather than assume it.
+if [ -d "$wt/.git" ]; then
+  bad "fixture worktree has a .git DIRECTORY — precondition gone, this test is vacuous"
+  exit 1
+fi
+ok "fixture: linked worktree whose .git is a file"
+
+common_hooks="$(git -C "$wt" rev-parse --git-path hooks)"
+case "$common_hooks" in /*) ;; *) common_hooks="$wt/$common_hooks" ;; esac
+
+# ── A: the shipped script installs when run FROM the worktree ────────────────
+out="$(cd "$wt" && bash scripts/install-hooks.sh 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ]; then
+  bad "A: install-hooks.sh from a worktree exited $rc"
+  printf '%s\n' "$out" | sed 's/^/       /' >&2
+else
+  ok "A: install-hooks.sh from a worktree exited 0"
+fi
+
+missing=""
+for h in pre-commit pre-push prepare-commit-msg amux-staged-guard; do
+  [ -x "$common_hooks/$h" ] || missing="$missing $h"
+done
+if [ -n "$missing" ]; then
+  bad "A: hooks absent from $common_hooks:$missing"
+else
+  ok "A: all four hooks landed in the git COMMON dir, executable"
+fi
+
+# The destination is the COMMON dir, shared by the main checkout and every
+# worktree — which is WHY the --all sweep may skip worktrees: one install covers
+# them. Asserted so a future "fix" that installs into a per-worktree directory
+# (silently giving each worktree its own copy to drift) fails here.
+if [ -e "$wt/.git/hooks" ]; then
+  bad "A: something created $wt/.git/hooks — the destination must be the common dir"
+else
+  ok "A: nothing was written under the worktree's own .git"
+fi
+
+# ── B: the PRE-FIX behaviour must fail on the same fixture ───────────────────
+# Rebuilt from the incident rather than from a convenient case: the one line that
+# resolved the destination by hand. Anything else about the script is unchanged,
+# so a pass here would mean case A proves nothing about worktrees.
+# INTO THE WORKTREE, not into $repo/scripts. The first cut wrote it to the main
+# checkout and ran it from the worktree, so bash exited 127 "No such file or
+# directory" — a FAILURE, which this case reads as success, so it reported a pass
+# while measuring nothing. That is the loud-wrong probe: it answered, and the
+# answer was the one being hoped for. Hence both the path and the assertion below.
+sed 's|^HOOKS="\$(git -C .*|HOOKS="$ROOT/.git/hooks"|' \
+  "$wt/scripts/install-hooks.sh" > "$wt/scripts/install-hooks-prefix.sh"
+if ! grep -q 'HOOKS="\$ROOT/.git/hooks"' "$wt/scripts/install-hooks-prefix.sh"; then
+  # An unapplied mutation and a working fix produce the same green. Check the
+  # mutation LANDED before reading its result.
+  bad "B: the mutation did not apply — B proves nothing, fix the sed"
+else
+  bout="$(cd "$wt" && bash scripts/install-hooks-prefix.sh 2>&1)"; brc=$?
+  if [ "$brc" -eq 0 ]; then
+    bad "B: the pre-fix path SUCCEEDED from a worktree — case A is not discriminating"
+  elif printf '%s' "$bout" | grep -q 'Not a directory'; then
+    ok "B: the pre-fix path still dies with 'Not a directory' (rc=$brc)"
+  else
+    # ANY OTHER FAILURE IS NOT EVIDENCE. A missing file, a syntax error or a
+    # permission problem all exit non-zero and would let this case certify a
+    # fixture that never exercised the defect.
+    bad "B: pre-fix path failed (rc=$brc) but NOT with 'Not a directory' — B did not"
+    bad "   exercise the defect; its own fixture is broken:"
+    printf '%s\n' "$bout" | tail -3 | sed 's/^/       /' >&2
+  fi
+fi
+
+[ "$fail" -eq 0 ] && echo "install-hooks worktree suite: PASS" || echo "install-hooks worktree suite: FAIL" >&2
+exit "$fail"


### PR DESCRIPTION
## What & why

Two defects in the git-hooks toolchain, both hit by following CLAUDE.md's own
instructions. No issue to close — neither was filed; I hit them while working.

**1. `install-hooks.sh` could not install from a linked worktree, and nothing tested it.**
`.git` in a linked worktree is a FILE, so the hardcoded `"$ROOT/.git/hooks"` is not a
directory and every install died with

```
install: cannot stat '<worktree>/.git/hooks/pre-commit': Not a directory
```

*after* the script had already printed its first `ok`. So the sanctioned way to work —
CLAUDE.md says to develop in a worktree, never in the checkout the builder watches — was
also the one way you could not install the secret scan, the staged-guard, the push guard
or the `Amux-Session` stamp, and the half-run reads as having started fine. Measured
here: all four MISSING in a checkout with three live worktrees, which is where the
untrailered commits the deploy recipe tells you to "treat as foreign" come from.

The script already knew the shape — its `--all` sweep skips linked worktrees by name, and
its own WARN tells *other* hooks to resolve guards with `git rev-parse --git-path hooks`.
Only its own install path still spelled the path by hand. That resolution also honours
`core.hooksPath`, which the hardcode did not.

**2. `pre-commit` built a SECOND 15GB target tree per checkout.**
CLAUDE.md tells every session to export `CARGO_TARGET_DIR=~/.amux/rust-build-target`, in
the imperative, because the opposite instruction once filled the volume to 741MB free.
This hook was the one place that ignored it, and it is the place that runs most often:
`cargo check`/`clippy --workspace --all-targets` inherited whatever the committing shell
happened to export, which for a git GUI, an editor, a cron job, or any session that did
not export it is nothing.

`setdefault`, not override — the same discipline `config.rs` uses for `server.env`, so a
shell that has already chosen a dir keeps it and CI's flags are untouched. The builder's
spelling is copied rather than re-derived (`scripts/rust-auto-build.sh:301`) so the two
cannot drift apart.

Happy to split these into two PRs if you would rather review them separately — they are
two distinct defects that share a subsystem and a cause (the toolchain assumes a normal
checkout and an exported env).

## Checklist

- [x] **One focused change** — one subsystem (`scripts/`), one commit per defect; see the
      offer to split above
- [x] **It builds clean:** `cargo check --workspace` green. `clippy` not re-run: the diff
      touches **zero Rust** — `.github/workflows/checks.yml`, `scripts/install-hooks.sh`,
      `scripts/git-hooks/pre-commit`, and one new shell suite
- [x] **Tests pass:** the new suite passes; no Rust test is reachable from this diff
- [x] **Client change?** — none
- [x] **Tested end-to-end** — drove both scripts, from a real linked worktree, and pinned
      the pre-fix behaviour (below)
- [x] Rebased on latest `main` (`d26a7e4c`)

## How I tested

**The test is the load-bearing half, because the defect is invisible from a normal
checkout** — a suite asserting "installing works" would have been green throughout.
`scripts/test-install-hooks-worktree.sh` builds a real repo with a real linked worktree,
asserts the fixture's `.git` really is a file, and pins both directions:

```console
$ bash scripts/test-install-hooks-worktree.sh
  ok   fixture: linked worktree whose .git is a file
  ok   A: install-hooks.sh from a worktree exited 0
  ok   A: all four hooks landed in the git COMMON dir, executable
  ok   A: nothing was written under the worktree's own .git
  ok   B: the pre-fix path still dies with 'Not a directory' (rc=1)
install-hooks worktree suite: PASS
```

- **A**'s third cell exists so a future "fix" that installs *per-worktree* copies — which
  would silently let each drift — fails here. The destination must be the common dir,
  which is why the `--all` sweep may skip worktrees at all.
- **B** rebuilds the pre-fix behaviour by mutating the one line that resolved the path by
  hand, and must still die with the defect's own message. Confirmed to fail before wiring
  in: with B's mutation applied to the shipped script, A goes red.
- B's first cut wrote its mutant into the wrong tree, so bash exited 127 — a *failure*
  that the case read as success, reporting a PASS while exercising nothing. It now
  refuses any exit that is not `Not a directory`, and separately checks that the mutation
  landed at all (an unapplied mutation and a working fix produce the same green).

**Hook 2** — because "the check got faster" and "the check got turned off" look identical
from a green hook, the `setdefault` is pinned in both directions rather than assumed.
Re-checked on this rebased head:

```console
$ env -u CARGO_TARGET_DIR bash -c ': "${CARGO_TARGET_DIR:=$HOME/.amux/rust-build-target}"; echo $CARGO_TARGET_DIR'
/home/<me>/.amux/rust-build-target          # unset -> shared dir

$ CARGO_TARGET_DIR=/tmp/mine bash -c ': "${CARGO_TARGET_DIR:=$HOME/.amux/rust-build-target}"; echo $CARGO_TARGET_DIR'
/tmp/mine                                   # already chosen -> survives, NOT overridden

$ ls -d target
ls: cannot access 'target': No such file or directory      # no repo-local tree
```

The hook was also driven end-to-end with `CARGO_TARGET_DIR` unset when the commit was
made (rc=0, `cargo clippy passed`, shared dir written). The 631MB figure is from that
session — measured on 2026-08-26 in a fresh worktree *before* the fix, in the ~2 minutes
before the commit was killed, on its way to a second full tree.

Registered in `checks.yml` next to the other shell suites: an unwired suite is a
capability nobody receives (ethos rule 1), and this repo has already shipped one
(`test-amux-url.sh` sat unwired).

**Not run locally:** `shellcheck` (not installed on this machine) — CI's check job covers
it.
