### PR TITLE
test(routes): the route-literal scan claimed coverage it does not have

### DIFF
--- a/crates/amux-server/src/api/request_log.rs
+++ b/crates/amux-server/src/api/request_log.rs
@@ -2110,13 +2110,41 @@ mod tests {
     /// route.callers_have_routes filed a FALSE failure against a live route,
     /// which trains readers to skim past the 8 real ones next to it.
     ///
-    /// This is the source→table direction: every absolute `/api/...` literal
-    /// passed to `.route(` anywhere under src/api must appear in ROUTE_TABLE.
-    /// Nested routers mounting relative paths ("/{id}" under a nest) are out
-    /// of scope by the /api prefix, and that boundary is deliberate — the
-    /// absolute literals are where this class actually bit.
+    /// WHAT THIS COVERS THAT THE WALK DOES NOT, which is the only reason to
+    /// keep it now that `every_directly_routed_api_path_is_in_the_table`
+    /// (tests/route_table.rs) follows `.nest()`/`.merge()` and is strictly the
+    /// better instrument for anything mounted. That walk starts at
+    /// `api/mod.rs` and follows composition, so it can only reach a module the
+    /// composition names. This one READS THE FILES — every `.rs` in src/api,
+    /// mounted or not — so it still speaks for a module the walk cannot arrive
+    /// at, and for a mount shape nobody has taught the walk to follow yet.
+    /// Keeping both is deliberate: two instruments on different axes
+    /// disagreeing is how the gmail asymmetry (AMUX-2883) was found at all.
+    ///
+    /// WHAT IT DOES NOT COVER — the name used to claim "every absolute route
+    /// literal" and this list is why that was too much:
+    ///
+    /// - **Only a literal spelled at the call site.** The regex wants
+    ///   `.route("` followed by a `"/api/..."` string. A path built from a
+    ///   const, a `format!`, or a variable is invisible, and so is any mount
+    ///   that is not spelled `.route(`.
+    /// - **Only absolute `/api/` paths.** A nested router mounting `"/{id}"`
+    ///   is out of scope by the prefix. Deliberate — the absolute literals are
+    ///   where this class bit — but it means the walk is the ONLY check on a
+    ///   relative literal.
+    /// - **Only source→table.** A ROUTE_TABLE row with no mount behind it is
+    ///   not this test's business; `route_table_matches_the_real_router_both_directions`
+    ///   holds that direction.
+    /// - **Only the shipped half of each file** (`#[cfg(test)]` onward is cut,
+    ///   because test modules mount fixture paths like `/api/echo`).
+    /// - **Only the top level of src/api.** The scan is a flat `read_dir`, so
+    ///   if anyone ever adds a SUBDIRECTORY there its routes are skipped in
+    ///   silence — `found_any` below cannot see that, since the 81 files
+    ///   beside it keep the probe looking alive. There are no subdirectories
+    ///   today, which is exactly why this is written down rather than fixed:
+    ///   the day one appears, this is the sentence that says so.
     #[test]
-    fn every_absolute_route_literal_is_in_route_table() {
+    fn absolute_route_literals_in_api_files_are_tabled_even_if_never_mounted() {
         let api_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/api");
         let re = regex::Regex::new(r#"\.route\(\s*"(/api/[^"]+)""#).unwrap();
         let table: std::collections::BTreeSet<&str> =

--- a/crates/amux-server/tests/route_table.rs
+++ b/crates/amux-server/tests/route_table.rs
@@ -342,7 +342,9 @@ fn every_directly_routed_api_path_is_in_the_table() {
     //
     // Measured before the fix, on `a78ed225`: deleting the
     // `/api/workers/{id}/dead-letters` row from ROUTE_TABLE left this test AND
-    // `every_absolute_route_literal_is_in_route_table` green, while deleting
+    // `absolute_route_literals_in_api_files_are_tabled_even_if_never_mounted`
+    // (request_log.rs, renamed from `every_absolute_route_literal_is_in_route_table`
+    // for claiming coverage it does not have) green, while deleting
     // the `/api/workers/{id}/peek` row next to it turned this test red. The
     // control is what makes that a measurement rather than a story: the two
     // rows are adjacent, describe sibling routes, and differ only in that one


### PR DESCRIPTION
## What & why

The follow-up you offered on #157, item 1 — **narrow the name and the docstring, do not
delete the test.** No issue to close.

`every_absolute_route_literal_is_in_route_table` promises, in its name, every absolute
route literal, and checks a good deal less. That gap became load-bearing once #157 made
the walk in `tests/route_table.rs` follow `.nest()`, `.merge()`, and a merge written
inside a nest: the walk is now strictly the better instrument for anything mounted, so
the only live question about this one is what it still holds *alone*. A name that
overstates it answers that question wrongly, and the wrong answer is "delete it".

Renamed to **`absolute_route_literals_in_api_files_are_tabled_even_if_never_mounted`** —
the axis it genuinely owns.

**What it uniquely holds** (now the first thing the docstring says, since it is the
reason to keep it): the walk starts at `api/mod.rs` and follows composition, so it
reaches only modules the composition names. This one reads the FILES — every `.rs` in
`src/api`, mounted or not — so it still speaks for a module the walk cannot arrive at,
and for a mount shape nobody has taught the walk to follow yet. Your point about the
directory scan being a different axis is what the docstring now leads with, and the
gmail asymmetry is cited as the case that proves it.

**What it does not cover**, now written down rather than implied by a name:

- only a literal spelled at the call site — a path from a const, a `format!` or a
  variable is invisible, as is any mount not spelled `.route(`
- only absolute `/api/` paths; a nested `"/{id}"` is out of scope by the prefix, which
  means the walk is the **only** check on a relative literal
- only source→table; a `ROUTE_TABLE` row with no mount is
  `route_table_matches_the_real_router_both_directions`' business
- only the shipped half of each file (`#[cfg(test)]` onward is cut, because test modules
  mount fixture paths like `/api/echo`)
- only the **top level** of `src/api` — the scan is a flat `read_dir`, so a subdirectory
  added there would be skipped in silence, and the `found_any` guard cannot see it
  because the 81 files beside it keep the probe looking alive

**One judgement call worth flagging.** That last item is a live hazard, not a historical
note, and I left it as a sentence rather than fixing it. There are no subdirectories
under `src/api` today, so a recursion added now would be scaffolding with no fixture that
can fail — and an untestable "fix" next to a docstring that already names the hazard is
the worse of the two. Happy to send the recursion plus a fixture that creates a subdir
and asserts its literal is caught, if you would rather have it now.

## Checklist

- [x] **One focused change** — one test's name and docstring, plus the one stale
      reference to it
- [x] **It builds clean:** `cargo check --workspace` and
      `cargo clippy --workspace --all-targets -- -D warnings` both green
- [x] **Tests pass:** the renamed test and both `route_table` integration tests
- [x] **Client change?** — none
- [x] **Tested end-to-end** — the test was re-mutated after the rename, not assumed
- [x] Rebased on latest `main` (`d26a7e4c`)

## How I tested

**The rename is not the whole change, so the mutation was re-run against the renamed
test rather than assumed to carry over** — a rename applied to a test that no longer
discriminates reads identically to one applied to a test that does.

```console
# mutant: delete the /api/gmail/labels row from ROUTE_TABLE
$ cargo test -p amux-server --lib absolute_route_literals
test ... FAILED
    mounted but ABSENT from ROUTE_TABLE — ... (AF-116):
    gmail.rs: /api/gmail/labels

# restored
$ cargo test -p amux-server --lib absolute_route_literals
test api::request_log::tests::absolute_route_literals_in_api_files_are_tabled_even_if_never_mounted ... ok
```

`/api/gmail/labels` is the specimen on purpose: it is mounted in a **module** file, which
is the only place this scan speaks where `mod.rs`'s own literals do not — so a mutant
there exercises the axis the rename claims, rather than the overlap with the walk.

```console
$ cargo test -p amux-server --test route_table
test every_directly_routed_api_path_is_in_the_table ... ok
test route_table_matches_the_real_router_both_directions ... ok
```

The stale reference in `tests/route_table.rs`'s measurement note (the `a78ed225`
before/after that #157 recorded) is updated to the new name and says why it changed, so
the AF-116 provenance is not orphaned by the rename.
