### PR TITLE
fix: malformed JSON on session verb endpoints returns 400, not 500

### DIFF
--- a/crates/amux-server/src/api/session_verbs.rs
+++ b/crates/amux-server/src/api/session_verbs.rs
@@ -9475,7 +9475,17 @@ async fn dispatch(
     let qs = parse_qs(q.as_deref().unwrap_or(""));
     let body: Value = match parse_body(&body_bytes) {
         Ok(v) => v,
-        Err(e) => return jresp(StatusCode::INTERNAL_SERVER_ERROR, json!({"error": e})),
+        Err(e) => {
+            tracing::warn!(
+                session = %name,
+                method = %method.as_str(),
+                action = %action,
+                body_sample = %String::from_utf8_lossy(&body_bytes[..body_bytes.len().min(100)]),
+                parse_error = %e,
+                "malformed_request_body: JSON parsing failed"
+            );
+            return jresp(StatusCode::BAD_REQUEST, json!({"error": e}));
+        }
     };
     // Validate session exists (py:74882) — for every action, share included.
     // ONE exception: a RETRY of a partially-completed rename addresses the


### PR DESCRIPTION
## What & why

`POST /api/sessions/{name}/{*verb}` returned HTTP 500 when the request body
was malformed JSON. That's a client error (bad input), not a server error —
should be 400. It also logged nothing, so a malformed request left no trace
to catch it in a sweep.

## What's included

- `api/session_verbs.rs`: malformed-JSON branch now returns `400 Bad Request`
  instead of `500 Internal Server Error`, and logs a `tracing::warn!` with
  the session, method, action, a truncated body sample, and the parse error
  — so the next occurrence surfaces in `server-rs.log` / `/api/logs/analyze`
  without anyone needing to go looking for it.

## How I tested

- `cargo check --workspace` / `cargo clippy --workspace --all-targets -- -D warnings` clean
- Live: `curl -X POST .../api/sessions/<name>/send -d '{bad json'` → `400`
  with a structured error body, and the corresponding `WARN
  malformed_request_body: ...` line appears in `server-rs.log`

## Checklist

- [x] One focused change — single fix, single file, 12 lines
- [x] Builds clean: cargo check + clippy
- [x] Tested end-to-end (live curl + log verification, see above)
- [x] Rebased on latest main
- [ ] No dedicated automated test added for this path — happy to add one if wanted (a small integration test posting malformed JSON to a `session_verbs` route and asserting 400 + the log line)
