### PR TITLE
feat: add systemd user service support for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,42 @@ make test       # clippy + cargo test
 
 `make run` is the command after `git pull` — it rebuilds release, installs the binary, and the launchd-managed server picks it up automatically. `make dev` is for working on migrations or features you don't want touching the live DB.
 
-**Requirements:** macOS (primary; on Linux the installer builds and installs the binaries and prints how to run the server), tmux 3.2+, and at least one of Claude Code, Codex CLI, or Gemini CLI. The Rust toolchain is installed via rustup if you don't have it (with your confirmation).
+**Requirements:** tmux 3.2+, and at least one of Claude Code, Codex CLI, or Gemini CLI. The Rust toolchain is installed via rustup if you don't have it (with your confirmation).
+
+### Linux: systemd user services
+
+On Linux with systemd (Ubuntu 22.04+, Debian 11+, Fedora 36+), `./install.sh` automatically creates and enables three user-level services:
+
+- `amux-server.service` — the main server
+- `amux-builder.service` — auto-rebuild on code changes  
+- `amux-builder.timer` — periodic rebuild check (every 60s)
+
+After `./install.sh` completes, the services are ready to start:
+
+```bash
+systemctl --user enable amux-server amux-builder.timer
+systemctl --user start amux-server
+```
+
+View logs and status:
+
+```bash
+journalctl --user -u amux-server -f      # follow logs
+systemctl --user status amux-server      # service status
+```
+
+See [docs/systemd-setup.md](docs/systemd-setup.md) for complete documentation: troubleshooting, multi-user setup, environment overrides, and migration between versions.
+
+For other Linux distributions without systemd, run the server manually:
+
+```bash
+AMUX_RS_PORT=8824 ~/.local/bin/amux-server-rs
+```
+
+**Platform support:**
+- **macOS** (primary) — `./install.sh` sets up launchd agents for automatic startup and rebuild
+- **Linux** (systemd) — `./install.sh` creates systemd user services (Ubuntu 22.04+, Debian 11+, Fedora 36+)
+- **Other Linux** — `./install.sh` builds and installs binaries; run the server manually or wrap in your process manager
 
 > **License:** [MIT + Commons Clause](LICENSE) — free to use, modify, and self-host. Commercial resale requires a separate license.
 

--- a/docs/systemd-setup.md
+++ b/docs/systemd-setup.md
@@ -1,0 +1,289 @@
+# Systemd Setup Guide (Linux)
+
+This guide explains how to run amux as a systemd user service on Linux.
+
+## Overview
+
+amux on Linux runs as a **user-level systemd service** — no sudo required, and the service persists through login sessions.
+
+**What you get:**
+- ✓ Automatic startup when you log in
+- ✓ Automatic restart if the process crashes
+- ✓ Automatic rebuild when code changes (via amux-builder.timer)
+- ✓ Structured logs in journalctl
+- ✓ Lifecycle management via systemctl
+
+## Quick Start
+
+### 1. Install amux
+
+```bash
+cd /path/to/amux
+./install.sh
+```
+
+On systemd-based Linux, this automatically:
+- Creates service files in `~/.config/systemd/user/`
+- Runs `systemctl --user daemon-reload`
+- Prints next steps
+
+### 2. Enable and Start Services
+
+```bash
+# Enable server to start on login
+systemctl --user enable amux-server
+
+# Enable builder timer to watch for code changes
+systemctl --user enable amux-builder.timer
+
+# Start the server now
+systemctl --user start amux-server
+```
+
+### 3. Verify It's Running
+
+```bash
+# Check service status
+systemctl --user status amux-server
+
+# View logs
+journalctl --user -u amux-server -f
+```
+
+### 4. Access the Dashboard
+
+Open your browser and navigate to:
+```
+https://localhost:8824
+```
+
+Token is in: `~/.amux/auth_token`
+
+## Managing the Service
+
+### Check Status
+
+```bash
+# Server status
+systemctl --user status amux-server
+
+# Builder status
+systemctl --user status amux-builder.timer
+systemctl --user status amux-builder.service
+
+# All amux-related units
+systemctl --user list-units | grep amux
+```
+
+### View Logs
+
+```bash
+# Server logs (last 50 lines)
+journalctl --user -u amux-server -n 50
+
+# Follow logs in real-time
+journalctl --user -u amux-server -f
+
+# Builder logs
+journalctl --user -u amux-builder -n 50
+
+# Combined (server + builder)
+journalctl --user -u amux-server -u amux-builder -f
+```
+
+### Stop / Restart
+
+```bash
+# Stop the server
+systemctl --user stop amux-server
+
+# Restart the server
+systemctl --user restart amux-server
+
+# Stop everything (server + builder)
+systemctl --user stop amux-server amux-builder.timer
+```
+
+### Disable Services
+
+```bash
+# Disable auto-start
+systemctl --user disable amux-server
+systemctl --user disable amux-builder.timer
+
+# Services won't start on next login, but you can still run manually:
+systemctl --user start amux-server
+```
+
+## Service Files
+
+The installation creates three service files:
+
+### `~/.config/systemd/user/amux-server.service`
+
+Main amux server process. 
+
+**Key settings:**
+- `Type=simple` — straightforward daemon
+- `Restart=always` — restart on crash
+- `RestartSec=5` — wait 5 seconds between restarts
+- `StandardOutput=journal` — logs to journalctl
+
+### `~/.config/systemd/user/amux-builder.service`
+
+Watches git commits and rebuilds the server binary.
+
+**Runs:** `scripts/rust-auto-build.sh`  
+**Triggers:** Timer (every 60s) or on manual start  
+
+### `~/.config/systemd/user/amux-builder.timer`
+
+Periodic timer for the builder service.
+
+**Schedule:**
+- First check: 30 seconds after system boot
+- Subsequent checks: every 60 seconds while running
+
+## Environment Variables
+
+Service files use these substitutions (set during `install.sh`):
+
+| Variable | Example | Purpose |
+|---|---|---|
+| `$HOME` | `/home/username` | User home directory |
+| `$PORT` | `8824` | Server port (from AMUX_RS_PORT) |
+| `$BIN_DIR` | `~/.local/bin` | Where amux-server-rs binary lives |
+| `$SCRIPT_DIR` | `/path/to/amux` | amux checkout directory |
+| `$AMUX_HOME` | `~/.amux` | amux data directory |
+
+**To override:** Edit the service files in `~/.config/systemd/user/`
+
+```bash
+# Edit server service
+systemctl --user edit amux-server
+
+# Edit builder service
+systemctl --user edit amux-builder
+
+# Reload after changes
+systemctl --user daemon-reload
+systemctl --user restart amux-server
+```
+
+## Troubleshooting
+
+### Service won't start
+
+```bash
+# Check status and error messages
+systemctl --user status amux-server
+
+# View full logs
+journalctl --user -u amux-server -n 100
+
+# Common issues:
+# - Port already in use: change AMUX_RS_PORT
+# - Binary not found: check $BIN_DIR path
+# - Permission denied: check file permissions
+```
+
+### Builder not rebuilding code
+
+```bash
+# Check if timer is enabled
+systemctl --user list-timers | grep amux-builder
+
+# Check builder logs
+journalctl --user -u amux-builder -n 50
+
+# Manual trigger (test)
+systemctl --user start amux-builder.service
+
+# Check if it ran
+journalctl --user -u amux-builder -f
+```
+
+### Logs not appearing
+
+```bash
+# Journalctl can be finicky with paths. Try:
+journalctl --user --all -u amux-server
+
+# Or use grep:
+journalctl --user -u amux-server | grep "pattern"
+
+# Last 100 entries across all amux services:
+journalctl --user -u amux-server -u amux-builder -n 100
+```
+
+### Port already in use
+
+```bash
+# Find what's using the port
+lsof -i :8824
+
+# Change port (edit service file)
+systemctl --user edit amux-server
+# Add or change: Environment="AMUX_RS_PORT=8825"
+
+systemctl --user daemon-reload
+systemctl --user restart amux-server
+```
+
+### Service doesn't survive logout
+
+**This is expected behavior for user-level services.** By design:
+- Service runs while user is logged in
+- Service stops when user logs out (no lingering processes)
+- Service auto-restarts on next login
+
+**To run server while logged out:**
+- Use a system-level service (requires sudo, not recommended)
+- Use screen/tmux in a persistent session
+- Use a Docker container
+- Use a dedicated amux deployment machine (VPS, physical server)
+
+### Multiple Users
+
+Each user can run their own amux:
+
+```bash
+# User A
+mkdir -p ~/amux-a
+cd ~/amux-a
+/path/to/amux/install.sh
+
+# User B (same machine, different homedir)
+mkdir -p ~/amux-b
+cd ~/amux-b
+/path/to/amux/install.sh
+
+# Each has independent services:
+systemctl --user status amux-server  # Shows User A's service
+sudo -u userb systemctl --user status amux-server  # Shows User B's service
+```
+
+## Comparison with macOS (launchd)
+
+| Feature | Systemd (Linux) | launchd (macOS) |
+|---|---|---|
+| Service scope | User-level | User-level |
+| Auto-start | Login | Login |
+| Restart on crash | ✓ (Restart=always) | ✓ (KeepAlive=true) |
+| Auto-rebuild | ✓ (Timer) | ✓ (Agent pair) |
+| Logging | journalctl | system log / file |
+| Config location | `~/.config/systemd/user/` | `~/Library/LaunchAgents/` |
+| Management | `systemctl --user` | `launchctl` |
+
+## Next Steps
+
+- **Logs:** Monitor with `journalctl --user -u amux-server -f`
+- **Updates:** Code changes auto-rebuild (via timer)
+- **Backups:** Config lives in `~/.amux/` (back it up)
+- **Remote:** Use `amux-remote` to manage from another machine
+
+## See Also
+
+- [amux-remote guide](../amux-remote-guide.md) — manage remote deployments
+- [Install guide](../install-guide.md) — general setup
+- systemd docs: `man systemd.service`

--- a/install.sh
+++ b/install.sh
@@ -260,6 +260,13 @@ fi
 
 # ── 5. Service ──────────────────────────────────────────────────────────────
 if [[ "$OS" == "Linux" ]] && command -v systemctl &>/dev/null; then
+  # envsubst ships in gettext-base (Debian/Ubuntu) / gettext (Fedora), not
+  # always present on a minimal install — checked explicitly (review
+  # @esteininger, PR #166) alongside the other tool checks above (cargo,
+  # tmux, herdr) instead of letting it fail inside the `|| die` below with
+  # a message that names the template, not the missing package.
+  command -v envsubst >/dev/null 2>&1 || die "envsubst required (apt install gettext-base / dnf install gettext)"
+
   # Create systemd user services from templates.
   SYSTEMD_DIR="$HOME/.config/systemd/user"
   mkdir -p "$SYSTEMD_DIR"
@@ -295,6 +302,16 @@ if [[ "$OS" == "Linux" ]] && command -v systemctl &>/dev/null; then
   echo "Then: dashboard at ${BOLD}https://localhost:$PORT${RESET} · token in $AMUX_HOME/auth_token"
   echo ""
   say "See docs/systemd-setup.md for full documentation"
+  echo ""
+  # Deliberate, not incidental (review @esteininger, PR #166): this path
+  # never starts the server — it prints the enable/start commands above and
+  # exits — so there is nothing running yet to wait on. The macOS path
+  # below this one DOES start the service and polls /health before
+  # declaring success; saying so here keeps the two honest with each other
+  # instead of leaving Linux users to notice the asymmetry on their own.
+  say "Unlike the macOS path, this installer does not start the service or"
+  say "verify /health on Linux — run the two 'systemctl --user' commands"
+  say "above, then check https://localhost:$PORT/health yourself."
   exit 0
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -259,19 +259,54 @@ if [[ -f "$SCRIPT_DIR/scripts/hooks/hook-report.sh" ]]; then
 fi
 
 # ── 5. Service ──────────────────────────────────────────────────────────────
+if [[ "$OS" == "Linux" ]] && command -v systemctl &>/dev/null; then
+  # Create systemd user services from templates.
+  SYSTEMD_DIR="$HOME/.config/systemd/user"
+  mkdir -p "$SYSTEMD_DIR"
+
+  # Substitute variables in service templates and write to systemd directory.
+  # Export variables so envsubst can find them.
+  export BIN_DIR PORT AMUX_HOME SCRIPT_DIR
+
+  envsubst < "$SCRIPT_DIR/scripts/amux-server.service.template" \
+    > "$SYSTEMD_DIR/amux-server.service" || die "failed to create amux-server.service"
+
+  envsubst < "$SCRIPT_DIR/scripts/amux-builder.service.template" \
+    > "$SYSTEMD_DIR/amux-builder.service" || die "failed to create amux-builder.service"
+
+  envsubst < "$SCRIPT_DIR/scripts/amux-builder.timer.template" \
+    > "$SYSTEMD_DIR/amux-builder.timer" || die "failed to create amux-builder.timer"
+
+  # Reload systemd to recognize the new units.
+  systemctl --user daemon-reload || die "systemctl daemon-reload failed"
+
+  say "systemd user services created:"
+  say "  $SYSTEMD_DIR/amux-server.service"
+  say "  $SYSTEMD_DIR/amux-builder.service"
+  say "  $SYSTEMD_DIR/amux-builder.timer"
+  echo ""
+  say "Next: enable and start the services"
+  echo "  ${DIM}systemctl --user enable amux-server${RESET}"
+  echo "  ${DIM}systemctl --user enable amux-builder.timer${RESET}"
+  echo "  ${DIM}systemctl --user start amux-server${RESET}"
+  echo ""
+  say "View logs: ${DIM}journalctl --user -u amux-server -f${RESET}"
+  echo ""
+  echo "Then: dashboard at ${BOLD}https://localhost:$PORT${RESET} · token in $AMUX_HOME/auth_token"
+  echo ""
+  say "See docs/systemd-setup.md for full documentation"
+  exit 0
+fi
+
+# Non-systemd Linux or unsupported OS.
 if [[ "$OS" != "Darwin" ]]; then
-  # Honest degrade: no launchd here, and pretending to manage systemd from a
-  # bash installer is how services half-exist. Print exactly what to run.
-  warn "$OS: no service manager configured by this installer."
+  warn "$OS: systemd not detected. No service manager configured."
   echo ""
   echo "Run the server in the foreground:"
   echo "    AMUX_RS_PORT=$PORT $BIN_DIR/amux-server-rs"
   echo ""
   echo "Or wrap it in a systemd user unit (~/.config/systemd/user/amux.service):"
-  echo "    [Service]"
-  echo "    ExecStart=$BIN_DIR/amux-server-rs"
-  echo "    Environment=AMUX_RS_PORT=$PORT"
-  echo "    Restart=always"
+  echo "    See docs/systemd-setup.md for template"
   echo ""
   echo "Then: dashboard at ${BOLD}https://localhost:$PORT${RESET} · token in $AMUX_HOME/auth_token"
   exit 0

--- a/scripts/amux-builder.service.template
+++ b/scripts/amux-builder.service.template
@@ -5,15 +5,22 @@ PartOf=amux-server.service
 After=network-online.target
 
 [Service]
-Type=simple
+# Type=oneshot, no Restart= (review @esteininger, PR #166, 2026-08-28):
+# rust-auto-build.sh is a one-shot script with no loop of its own — on
+# macOS it's re-invoked by launchd's StartInterval=60. Type=simple +
+# Restart=always + RestartSec=10 on a script that exits immediately turns
+# THAT into the loop, at 10s instead of the intended 60s — 6x the rate,
+# and fighting the timer below rather than complementing it, since systemd
+# ends up trying to (re)start a unit that's already being restarted. The
+# timer is the only thing that should be starting this.
+Type=oneshot
 ExecStart=$SCRIPT_DIR/rust-auto-build.sh
 Environment="CARGO_TARGET_DIR=$HOME/.amux/rust-build-target"
 WorkingDirectory=$SCRIPT_DIR
-Restart=always
-RestartSec=10
 StandardOutput=journal
 StandardError=journal
 SyslogIdentifier=amux-builder
 
-[Install]
-WantedBy=default.target
+# No [Install] section on purpose: this unit is started by
+# amux-builder.timer, not by `systemctl --user enable amux-builder`
+# directly. A WantedBy= here would let both paths start it at once.

--- a/scripts/amux-builder.service.template
+++ b/scripts/amux-builder.service.template
@@ -1,0 +1,19 @@
+[Unit]
+Description=amux Server Builder (watches git commits)
+Documentation=https://amux.dev/docs
+PartOf=amux-server.service
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=$SCRIPT_DIR/rust-auto-build.sh
+Environment="CARGO_TARGET_DIR=$HOME/.amux/rust-build-target"
+WorkingDirectory=$SCRIPT_DIR
+Restart=always
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=amux-builder
+
+[Install]
+WantedBy=default.target

--- a/scripts/amux-builder.service.template
+++ b/scripts/amux-builder.service.template
@@ -14,7 +14,7 @@ After=network-online.target
 # ends up trying to (re)start a unit that's already being restarted. The
 # timer is the only thing that should be starting this.
 Type=oneshot
-ExecStart=$SCRIPT_DIR/rust-auto-build.sh
+ExecStart=$SCRIPT_DIR/scripts/rust-auto-build.sh
 Environment="CARGO_TARGET_DIR=$HOME/.amux/rust-build-target"
 WorkingDirectory=$SCRIPT_DIR
 StandardOutput=journal

--- a/scripts/amux-builder.timer.template
+++ b/scripts/amux-builder.timer.template
@@ -1,0 +1,11 @@
+[Unit]
+Description=amux Builder Timer (periodic rebuild check)
+Documentation=https://amux.dev/docs
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=60s
+Unit=amux-builder.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/amux-server.service.template
+++ b/scripts/amux-server.service.template
@@ -14,7 +14,6 @@ Restart=always
 RestartSec=5
 StandardOutput=journal
 StandardError=journal
-StandardErrorStream=journal
 SyslogIdentifier=amux-server
 
 [Install]

--- a/scripts/amux-server.service.template
+++ b/scripts/amux-server.service.template
@@ -1,0 +1,21 @@
+[Unit]
+Description=amux Server (Rust)
+Documentation=https://amux.dev/docs
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=$BIN_DIR/amux-server-rs
+Environment="AMUX_RS_PORT=$PORT"
+Environment="CARGO_TARGET_DIR=$HOME/.amux/rust-build-target"
+WorkingDirectory=$AMUX_HOME
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+StandardErrorStream=journal
+SyslogIdentifier=amux-server
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Comprehensive systemd user service support for Linux (Ubuntu 22.04+, Debian 11+, Fedora 36+) with auto-rebuild timer, complete documentation, and README integration.