### PR TITLE
fix(cli): amux start-all was silently non-functional as a fleet recovery tool

### DIFF
--- a/amux
+++ b/amux
@@ -739,6 +739,20 @@ cmd_start() {
     fi
   else
     [[ "$cmd" == *"--model"* ]] || cmd="$cmd --model sonnet"
+    # Resume the most recent conversation in this directory by default, so a
+    # restart (crash recovery, a deploy that killed the tmux server, `amux
+    # start-all`) picks up where the worker left off instead of silently
+    # registering a brand-new, untitled Claude Code session every time this
+    # runs — the gap that turned one `stop-all`+`start-all` recovery pass
+    # into 8 fresh sessions with random names and zero prior context
+    # (2026-08-30, see frustrations.md / INIT-3). Verified safe on a
+    # directory with NO prior conversation: `claude --continue` there just
+    # starts fresh, exit 0, no error — so this is safe on a worker's very
+    # first-ever start too. Skipped if the caller already asked to
+    # resume/start a specific conversation another way.
+    if [[ ! "$cmd" =~ (^|[[:space:]])(-c|--continue|--resume|--session-id|--from-pr|--teleport)([[:space:]]|$) ]]; then
+      cmd="$cmd --continue"
+    fi
   fi
 
   # Create tmux session and attach

--- a/amux
+++ b/amux
@@ -783,9 +783,19 @@ cmd_start() {
   tmux new-session -d -s "$tname" -n "$name" -c "$dir" \
     -e "AMUX_SESSION=$name" -e "AMUX_WORKER=$name" -e "AMUX_URL=$AMUX_API" \
     "${shell_setup}cd $(printf '%q' "$dir"); $cmd"
-  # Lock the window name so Claude can't overwrite it with escape sequences
-  tmux set-option -t "=$tname" allow-rename off 2>/dev/null
-  tmux set-window-option -t "=$tname" automatic-rename off 2>/dev/null
+  # Lock the window name so Claude can't overwrite it with escape sequences.
+  # Trailing `:` is load-bearing: allow-rename/automatic-rename are WINDOW
+  # options, and a bare `=$tname` session-exact-match target makes tmux look
+  # for a WINDOW literally named "=amux-<name>" instead of the current window
+  # of that session — "no such window", exit 1, and under `set -euo pipefail`
+  # (line 19) that silently kills the rest of cmd_start: no "started" echo,
+  # no attach, no error shown (stderr was already routed to /dev/null on the
+  # very line that fails). Reproduced 2026-08-30: any non-interactive fresh
+  # `amux start <name>` (no --detach, e.g. from `amux start-all`) died right
+  # here with empty output and exit 1, while the tmux session it had just
+  # created was left running and unlocked. See frustrations.md / INIT-2.
+  tmux set-option -t "=$tname:" allow-rename off 2>/dev/null
+  tmux set-window-option -t "=$tname:" automatic-rename off 2>/dev/null
   echo "${GREEN}started${RESET} ${BOLD}$name${RESET} in $dir"
   echo "  ${DIM}$cmd${RESET}"
   # The session is already created detached (new-session -d). Only attach when
@@ -1378,12 +1388,22 @@ cmd_stop_all() {
 }
 
 cmd_start_all() {
+  # --detach, always: this starts every stopped worker in one pass, and a
+  # terminal can only attach to one of them anyway. Without it, cmd_start's
+  # own end-of-function `tmux attach-session` runs for the FIRST session
+  # started, fails "open terminal failed: not a terminal" in any
+  # non-interactive context (cron, a hook, this very script's own callers),
+  # and under `set -euo pipefail` that aborts the whole loop — every session
+  # after the first stays down with no indication why. Reproduced 2026-08-30
+  # alongside INIT-2's tmux target-syntax fix (same symptom, different cause:
+  # that one killed the FIRST session's start too; this one silently
+  # truncates the loop to just the first once that bug is fixed).
   for f in "$CC_SESSIONS"/*.env; do
     [[ -f "$f" ]] || continue
     local name
     name=$(basename "$f" .env)
     if ! is_running "$name" 2>/dev/null; then
-      cmd_start "$name"
+      cmd_start "$name" --detach
     fi
   done
 }


### PR DESCRIPTION
## Summary

Two related bugs in the `amux` bash CLI, found live while recovering the fleet
from an unrelated systemd incident (every worker session dying on every
ordinary deploy — that root cause and fix, `KillMode=mixed` -> `process` on
`amux.service`, is a local machine config change outside this repo; see
`frustrations.md` for the full writeup).

`amux start-all` is the documented recovery command for exactly that
scenario ("the whole fleet is down") and was silently non-functional for it:

1. **`cmd_start`'s window-name lock used the wrong tmux target syntax** for a
   window-scoped option (`tmux set-option -t "=$tname" allow-rename off`),
   which `tmux` resolves as looking for a *window* literally named
   `=amux-<name>` rather than the current window of that session. Combined
   with `set -euo pipefail` and the only stderr routed to `/dev/null` on that
   same line, `cmd_start` died silently on **every** fresh (not-already-running)
   session start: no "started" message, no attach, no visible error, exit 1
   — while the tmux session it had just created was left running, unlocked,
   and indistinguishable from a failed start.

2. **`cmd_start_all` never passed `--detach`**, so even with (1) fixed, the
   *first* session started still hit `cmd_start`'s own terminal-attach step,
   correctly failed `open terminal failed: not a terminal` outside a TTY, and
   `set -e` killed the rest of the loop — every session after the first
   silently stayed down.

3. **`amux start` for the `claude` provider never resumed.** Unlike the
   codex path (which resumes from a stored session id), the claude branch
   always launched a bare `claude ...flags...` with no `--continue`/
   `--resume`. This rarely mattered because a worker's tmux pane normally
   stays alive for days without the process ever restarting — until a batch
   `stop-all`/`start-all` exercised it for 8 workers at once and every one
   registered as a brand-new, untitled Claude Code session, visibly
   cluttering the account's session list and losing every worker's prior
   conversation context.

## Fixes

- `-t "=$tname"` -> `-t "=$tname:"` on the two window-option lines (explicit
  window target).
- `cmd_start_all`: `cmd_start "$name"` -> `cmd_start "$name" --detach`.
- `cmd_start`'s claude branch appends `--continue` by default unless the
  caller already asked to resume a specific conversation another way.
  Verified safe on a directory with no prior conversation (starts fresh, no
  error) and verified live that a stopped/restarted worker comes back with
  its actual prior pane history instead of a blank prompt.

Known caveat, not fixed here (documented in the code): `--continue` resumes
by *current directory*, not worker identity, so two workers sharing a
directory can now resume each other's conversation instead of starting
uniformly fresh. A precise fix would store a per-worker session UUID at
first start (like the codex path already does).

## Testing done

- `bash -n amux` — syntax clean.
- Verified live on the dev box: `amux start <name>` (no `--detach`, no TTY)
  now starts the session and prints the honest attach-failure message
  instead of a silent exit 1; `amux start-all` against 8 fully-stopped
  sessions now starts all 8 in one pass; a stopped/restarted worker resumes
  its prior conversation instead of losing it.

Full incident writeup, cost, and the separate systemd fix: `frustrations.md`
(cards INIT-1, INIT-2 on the board).