### PR TITLE
fix(reclaim): being skipped stopped counting as a reason to keep skipping

### DIFF
--- a/crates/amux-server/migrations/0035_reclaim_skipped_hits_repair.sql
+++ b/crates/amux-server/migrations/0035_reclaim_skipped_hits_repair.sql
@@ -1,0 +1,56 @@
+-- Repair `reclaim_skipped.hits`, which two different events were writing with
+-- two different meanings until the fix that ships alongside this migration.
+--
+-- `hits` is read in exactly one place that matters:
+--
+--     WHERE reason='provider' OR (reason='stalled' AND hits >= STALL_HITS_TO_SKIP)
+--
+-- and the constant it is compared against documents the intent: "A directory is
+-- only routed around after it has hung this many separate scans. One observation
+-- is an anecdote, and the cost of believing it is a permanent hole in the scan
+-- that nothing announces."
+--
+-- But the end-of-scan refresh in `run_scan` also did `hits=hits+1`, once per
+-- scan that ROUTED AROUND the path. Being skipped is a consequence of the
+-- exemption, not evidence for it, so every scan after the first voted to keep an
+-- exemption it was already obeying. The threshold became unfalsifiable.
+--
+-- The live table when this was found (2026-08-30, 24 scans of history):
+--
+--     ~/Library/CloudStorage        provider   hits=8
+--     ~/Library/Mobile Documents    provider   hits=8
+--     ~/Downloads                   stalled    hits=10
+--
+-- The provider rows are what make this certain rather than probable: they are
+-- seeded hits=0, and `record_stalled_dir` only ever writes reason='stalled', so
+-- a provider row has NO legitimate route to a nonzero count. All 8 came from the
+-- refresh. ~/Downloads is those same 8 plus 2 real stalls -- and server-rs.log
+-- holds exactly two `walk thread is blocked` lines for it, nine seconds apart on
+-- 2026-08-22, which is ONE incident recorded twice by the two server processes
+-- that share this database.
+--
+-- Removing the increment stops the ratchet but does not undo it: without this
+-- migration ~/Downloads stays excluded from every future scan forever, on
+-- evidence that has now been withdrawn. So the counts are repaired here.
+
+-- Provider rows: 0 is the only defensible value. They are a standing decision,
+-- they apply regardless of `hits`, and every count they carry was manufactured.
+UPDATE reclaim_skipped SET hits = 0 WHERE reason = 'provider';
+
+-- Stalled rows: clamp to 1, which is the most this data can honestly support.
+--
+-- The row's own EXISTENCE is evidence of exactly one stall -- `record_stalled_dir`
+-- inserts with hits=1 -- and every increment past that is unattributable, because
+-- nothing recorded which writer made it. 1 says what is known: "this directory
+-- stalled at least once; corroboration must be re-earned."
+--
+-- Deliberately NOT 0. Zeroing would discard the observation that created the row,
+-- and the anecdote is real data even though it is not yet a verdict.
+--
+-- The cost, stated plainly: a directory that genuinely hung several separate
+-- scans is knocked back to one, so re-establishing its exemption needs one more
+-- stall -- a single extra STALL_ABORT_SECS (300s) wait, once. That is the price
+-- of not being able to tell the two kinds of hit apart retroactively, and it is
+-- the right way round: the failure mode is one slow scan, not a third of a home
+-- directory silently uncovered.
+UPDATE reclaim_skipped SET hits = 1 WHERE reason = 'stalled' AND hits > 1;

--- a/crates/amux-server/src/api/reclaim.rs
+++ b/crates/amux-server/src/api/reclaim.rs
@@ -309,10 +309,12 @@ fn record_stalled_dir(store: &crate::db::SharedStore, path: String, detail: Stri
 /// It is not hypothetical — this is what the live table looked like when it was
 /// found (2026-08-30, amux.db, 24 scans of history):
 ///
-///     path                              reason    hits
-///     ~/Library/CloudStorage            provider     8
-///     ~/Library/Mobile Documents        provider     8
-///     ~/Downloads                       stalled     10
+/// ```text
+/// path                              reason    hits
+/// ~/Library/CloudStorage            provider     8
+/// ~/Library/Mobile Documents        provider     8
+/// ~/Downloads                       stalled     10
+/// ```
 ///
 /// The two `provider` rows are the proof, and they are why this is certain
 /// rather than likely. Provider rows are seeded `hits=0` and `record_stalled_dir`

--- a/crates/amux-server/src/api/reclaim.rs
+++ b/crates/amux-server/src/api/reclaim.rs
@@ -290,6 +290,71 @@ fn record_stalled_dir(store: &crate::db::SharedStore, path: String, detail: Stri
     }
 }
 
+/// Mark the skip rows a scan leaned on as still live. `last_seen` ONLY.
+///
+/// The `hits` column answers exactly one question — "how many separate scans
+/// has this directory HUNG?" — because that is the question
+/// `STALL_HITS_TO_SKIP` is asked: a directory is routed around only after a
+/// second scan corroborates the first, since one observation is an anecdote
+/// and the cost of believing it is a silent permanent hole in the scan.
+///
+/// This function used to do `hits=hits+1` alongside the `last_seen` write, and
+/// that turned the threshold into a ratchet that manufactured its own evidence.
+/// Being skipped is a CONSEQUENCE of the exemption, not corroboration for it,
+/// so counting it meant every subsequent scan voted to keep the exemption it
+/// was already obeying. Once a path crossed the threshold once it could never
+/// fall back below it, could never be re-tested, and `hits` could no longer
+/// distinguish "hung ten scans" from "hung once and was avoided nine times".
+///
+/// It is not hypothetical — this is what the live table looked like when it was
+/// found (2026-08-30, amux.db, 24 scans of history):
+///
+///     path                              reason    hits
+///     ~/Library/CloudStorage            provider     8
+///     ~/Library/Mobile Documents        provider     8
+///     ~/Downloads                       stalled     10
+///
+/// The two `provider` rows are the proof, and they are why this is certain
+/// rather than likely. Provider rows are seeded `hits=0` and `record_stalled_dir`
+/// only ever writes `reason='stalled'`, so a provider row has no legitimate path
+/// to a nonzero count at all — every one of those 8 came from here. `~/Downloads`
+/// is the same 8 plus the 2 genuine stalls it did record, and server-rs.log
+/// contains exactly two `walk thread is blocked` lines for it, nine seconds
+/// apart on 2026-08-22, one incident seen by both servers.
+///
+/// So `~/Downloads` — a directory that answers readdir in ~2s with 318 entries —
+/// was permanently excluded from disk reclaim on the strength of one contended
+/// moment, and the counter that would have let anyone notice was being inflated
+/// by the exclusion itself. The sibling test
+/// `provider_roots_seed_as_skips_and_can_be_cleared` warns in its own doc comment
+/// that "a one-way ratchet would let the scan's coverage shrink silently over
+/// time, which is worse than the hang it is avoiding: a hang is visible". This
+/// was that ratchet, one function away from the test that named it.
+///
+/// This is its own function rather than three lines inline in `run_scan` for one
+/// reason: inline it could not be called from a test, so nothing in the suite
+/// could ever observe what it did to `hits`. The suite covered
+/// `record_stalled_dir` — the increment that was CORRECT — and had no reach at
+/// all into the one that was wrong.
+fn touch_skips(store: &crate::db::SharedStore, paths: Vec<String>) {
+    if paths.is_empty() {
+        return;
+    }
+    let now = now_secs();
+    let res = store.write(move |c| {
+        for p in &paths {
+            c.execute(
+                "UPDATE reclaim_skipped SET last_seen=?2 WHERE path=?1",
+                rusqlite::params![p, now],
+            )?;
+        }
+        Ok(crate::db::WriteOutcome { applied: true, events: vec![] })
+    });
+    if let Err(e) = res {
+        tracing::error!(error = %e, "failed to refresh reclaim skip last_seen");
+    }
+}
+
 // ── volume state ─────────────────────────────────────────────────────────────
 
 pub(crate) fn now_secs() -> i64 {
@@ -1312,18 +1377,7 @@ fn run_scan(store: crate::db::SharedStore, scan_id: String, cfg: ScanCfg, cancel
         .map(|p| p.to_string_lossy().into_owned())
         .collect();
     let n_skipped = hit_skips.len();
-    if !hit_skips.is_empty() {
-        let now = now_secs();
-        let _ = store.write(move |c| {
-            for p in &hit_skips {
-                c.execute(
-                    "UPDATE reclaim_skipped SET last_seen=?2, hits=hits+1 WHERE path=?1",
-                    rusqlite::params![p, now],
-                )?;
-            }
-            Ok(crate::db::WriteOutcome { applied: true, events: vec![] })
-        });
-    }
+    touch_skips(&store, hit_skips);
 
     // Snapshot-held space as a first-class finding. Without this the UI shows
     // a big reclaimable total that the disk will not actually hand back.
@@ -2493,5 +2547,95 @@ mod tests {
         assert_eq!(reason, "stalled");
         assert!(detail.contains("45s"), "detail must carry the stall duration: {detail}");
         assert_eq!(hits, 2, "a repeat stall must increment rather than insert a second row");
+    }
+
+    /// Being routed around must not COUNT as evidence for being routed around.
+    ///
+    /// `STALL_HITS_TO_SKIP` asks "how many separate scans has this directory
+    /// hung?", so only a stall may answer it. The end-of-scan refresh used to
+    /// answer it too, which made the exemption self-certifying: every scan that
+    /// obeyed the skip cast a vote to keep it, and a path that crossed the
+    /// threshold once could never come back.
+    ///
+    /// The regression this pins is not theoretical. ~/Downloads reached hits=10
+    /// on two real stalls nine seconds apart (one incident, seen by both server
+    /// processes) plus eight scans that merely walked past it, and was excluded
+    /// from disk reclaim for eight days on that arithmetic.
+    #[test]
+    fn being_routed_around_does_not_corroborate_a_skip() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store: crate::db::SharedStore =
+            Arc::new(crate::db::Store::open(&dir.path().join("t.db")).expect("open"));
+        let victim = "/Users/someone/Downloads";
+        let victim_path = PathBuf::from(victim);
+
+        record_stalled_dir(&store, victim.into(), "quiet 300s".into());
+        assert!(
+            !load_skips(&store).contains(&victim_path),
+            "one stall is an observation, not an exemption"
+        );
+
+        // Ten scans route around it. Under the old code each of these did
+        // hits=hits+1, so the FIRST one alone crossed STALL_HITS_TO_SKIP and
+        // the directory was exempt from then on.
+        for _ in 0..10 {
+            touch_skips(&store, vec![victim.to_string()]);
+        }
+
+        let hits: i64 = store
+            .read()
+            .expect("read")
+            .query_row("SELECT hits FROM reclaim_skipped WHERE path=?1", [victim], |r| r.get(0))
+            .expect("row");
+        assert_eq!(hits, 1, "hits counts stalls only; ten skips must add none, got {hits}");
+        assert!(
+            !load_skips(&store).contains(&victim_path),
+            "a directory must not become permanently exempt by being skipped"
+        );
+
+        // CONTROL. Without this the assertion above would also pass if the
+        // threshold had simply stopped working, which is the opposite bug and a
+        // worse one -- a scan that hangs forever on a genuinely dead mount.
+        record_stalled_dir(&store, victim.into(), "quiet 300s".into());
+        assert!(
+            load_skips(&store).contains(&victim_path),
+            "a second REAL stall must still exempt the directory"
+        );
+    }
+
+    /// last_seen still moves, which is the whole reason the refresh exists:
+    /// a skip row nothing has hit lately may be a fossil, and only a moving
+    /// last_seen can tell a live exemption from one whose filesystem came back.
+    #[test]
+    fn touching_a_skip_moves_last_seen_without_touching_hits() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store: crate::db::SharedStore =
+            Arc::new(crate::db::Store::open(&dir.path().join("t.db")).expect("open"));
+        let p = "/mnt/slow";
+
+        store
+            .write(move |c| {
+                c.execute(
+                    "INSERT INTO reclaim_skipped (path, reason, detail, first_seen, last_seen, hits)
+                     VALUES (?1,'stalled','seeded',100,100,1)",
+                    [p],
+                )?;
+                Ok(crate::db::WriteOutcome { applied: true, events: vec![] })
+            })
+            .expect("seed");
+
+        touch_skips(&store, vec![p.to_string()]);
+
+        let (last_seen, hits): (i64, i64) = store
+            .read()
+            .expect("read")
+            .query_row(
+                "SELECT last_seen, hits FROM reclaim_skipped WHERE path=?1",
+                [p],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .expect("row");
+        assert!(last_seen > 100, "last_seen must advance, got {last_seen}");
+        assert_eq!(hits, 1, "hits must be untouched by a refresh");
     }
 }

--- a/crates/amux-server/src/db/migrate.rs
+++ b/crates/amux-server/src/db/migrate.rs
@@ -196,6 +196,11 @@ const MIGRATIONS: &[Migration] = &[
         name: "0034_request_log_load1",
         sql: include_str!("../../migrations/0034_request_log_load1.sql"),
     },
+    Migration {
+        version: 35,
+        name: "0035_reclaim_skipped_hits_repair",
+        sql: include_str!("../../migrations/0035_reclaim_skipped_hits_repair.sql"),
+    },
 ];
 
 /// Migrations embedded in THIS binary that the DB has not recorded yet.


### PR DESCRIPTION
## What & why

`reclaim_skipped.hits` was written by two different events with opposite meanings, which turned the skip-list threshold into a ratchet that manufactured its own evidence. `~/Downloads` has been excluded from every disk reclaim scan for 8 days as a result.

`hits` is read in exactly one place that matters, in `load_skips()`:

```sql
WHERE reason='provider' OR (reason='stalled' AND hits >= STALL_HITS_TO_SKIP)
```

and the constant's own doc comment states the intent: *"A directory is only routed around after it has hung this many separate scans. One observation is an anecdote, and the cost of believing it is a permanent hole in the scan that nothing announces."*

But two writers fed it:

| writer | means | legitimate? |
|---|---|---|
| `record_stalled_dir()` | "this directory **hung** a scan" | yes — this is the corroboration the threshold asks for |
| end-of-scan refresh in `run_scan()` | "this scan **routed around** the path" | no — a consequence of the exemption, counted as evidence for it |

So every scan after the first cast a vote to keep an exemption it was already obeying. Once a path crossed the threshold it could never fall back below it, could never be re-tested, and `hits` could no longer distinguish "hung ten scans" from "hung once and was walked past nine times". The check could not fail.

### The evidence

The live table, over 24 scans of history:

```
path                          reason     hits
~/Library/CloudStorage        provider      8
~/Library/Mobile Documents    provider      8
~/Downloads                   stalled      10
```

**The provider rows are what make this certain rather than likely.** They are seeded `hits=0`, and `record_stalled_dir` only ever writes `reason='stalled'` — so a provider row has *no legitimate route* to a nonzero count. All 8 came from the refresh. `~/Downloads` is those same 8 plus 2 genuine stalls, and `server-rs.log` holds exactly two `walk thread is blocked` lines for it, nine seconds apart on 2026-08-22 — one incident recorded twice by the two server processes sharing the database. 8 + 2 = 10. The arithmetic closing exactly is what turns this from a theory into a measurement.

`~/Downloads` answers `readdir` in ~2s with 318 entries. It was excluded on one contended moment, on a machine that hit 0.12 GB free this week, and the counter that would have let anyone notice was being inflated by the exclusion itself — so the longer it went unnoticed, the better corroborated it looked.

The file already knew. `provider_roots_seed_as_skips_and_can_be_cleared` warns in its own doc comment that *"a one-way ratchet would let the scan's coverage shrink silently over time, which is worse than the hang it is avoiding: a hang is visible."* This was that ratchet, one function away from the test that named it. It survived because the suite covered the increment that was **correct**, and the wrong one was three lines inline in `run_scan` — unreachable from any test.

### The change

1. The refresh writes `last_seen` only. That was always its stated purpose ("without a `last_seen` that moves, nobody can tell a live exemption from a fossil"); the `hits` increment was never justified by its own comment.
2. Extracted as `touch_skips()` rather than left inline, specifically so a test can observe what it does to `hits`.
3. **Migration 0035** repairs the counts already stored. Removing the increment stops the ratchet but does not undo it — without the repair `~/Downloads` stays excluded forever on evidence that has now been withdrawn.
   - `provider` → 0. No legitimate nonzero value exists, and these rows apply regardless of `hits`.
   - `stalled` → clamped to 1. The row's *existence* proves one stall (`record_stalled_dir` inserts with `hits=1`) and every increment past that is unattributable. Deliberately **not** 0, which would discard a real observation.
   - Cost, stated plainly: a directory that genuinely hung several separate scans needs one more stall to re-earn its exemption — one extra 300s wait, once. That is the right way round versus a third of a home directory silently uncovered.

## How I tested

**`cargo clippy --workspace --all-targets -- -D warnings`** — clean.

**`cargo test --workspace`** — 1474 passed, 1 failed. The failure is `api::settings::tests::guard_helpers_defaults_and_spellings`, and it is **pre-existing and unrelated**: I confirmed it by stashing this branch's changes and running it against pristine `origin/main`, where it fails identically (`assertion failed: !task_guard_enabled(home)` — it reads real `$HOME` state). All 16 reclaim tests pass.

**Mutation check — the new tests can fail, and do.** Restoring `hits=hits+1`:

```
being_routed_around_does_not_corroborate_a_skip ... FAILED
  hits counts stalls only; ten skips must add none, got 11
touching_a_skip_moves_last_seen_without_touching_hits ... FAILED
  left: 2, right: 1
test result: FAILED. 14 passed; 2 failed
```

`got 11` is the live table's own arithmetic. All 14 pre-existing reclaim tests keep passing under the mutation, so the new tests indict the ratchet and nothing else. The regression test carries a **control** asserting a second *real* stall still exempts the path — because "the threshold stopped working" is the opposite bug and a worse one (a scan that hangs forever on a genuinely dead mount).

**End-to-end, against the incident's own artifact.** Migration 0035 applied to the real `reclaim_skipped` rows:

```
BEFORE                                        reason    hits  skipped
~/Library/CloudStorage                        provider     8        1
~/Library/Mobile Documents                    provider     8        1
~/Downloads                                   stalled     10        1
~/Library/Containers/…/ExternalViewService    stalled      1        0

AFTER
~/Library/CloudStorage                        provider     0        1
~/Library/Mobile Documents                    provider     0        1
~/Downloads                                   stalled      1        0   ← back in the scan
~/Library/Containers/…/ExternalViewService    stalled      1        0
```

Two rows change state and two do not, so the check discriminates rather than just coming back clean.

No client change (`crates/amux-dashboard/static/` untouched), so no `APP_VER` / `CACHE` bump needed.

## Deliberately not in this PR

Same file, same root cause — the reclaim subsystem assumes it is the only process using its tables — kept out so this stays small and revertible:

- **`reap_orphaned_scans()` has no owner filter**, so a peer's boot reaps a live scan. 20 of the 24 scans ever run are `interrupted` with *"server restarted mid-scan; the scan thread did not survive"*, and several pairs share both `started_at` and `finished_at` to the second (duration 0).
- **The "one scan at a time" guard is check-then-act across two processes** — `SELECT COUNT(*) WHERE status='running'` then `INSERT`, non-atomic. On 2026-08-30 03:03:09 both servers started a scan in the same second: one ran 307s and stalled, the other reported `done` in **27 seconds**, and that 27-second row is what the UI shows as the latest scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqiH3gJWS1TyDkZHadYHs5
