### PR TITLE
fix(browser): AMUX-98 -- a malformed selector is 400, not 502

### DIFF
--- a/crates/amux-server/src/api/browser.rs
+++ b/crates/amux-server/src/api/browser.rs
@@ -616,21 +616,30 @@ fn driver_err(e: chrome::DriverError) -> Response {
     }
 }
 
-/// 504 for a CDP call that never answered, 502 for one that failed (AMUX-3672).
+/// 504 for a CDP call that never answered, 400 for a page-side exception
+/// (AMUX-98), 502 for everything else — a real transport/protocol failure
+/// (AMUX-3672).
 ///
-/// Both were 502, and `/api/logs/analyze` groups by (status, method, target) —
-/// so "the browser is WEDGED" and "the browser REJECTED our call" landed in the
-/// same row and only the error body separated them. A wedged browser is the one
-/// that means something else is wrong (a contended profile, a hung tab); a
-/// protocol error usually means the caller asked for something impossible.
-/// Making them different status codes makes them different groups in every log
-/// view, for free.
+/// All three used to be 502, and `/api/logs/analyze` groups by (status,
+/// method, target) — so "the browser is WEDGED", "the browser REJECTED our
+/// call", and "the CALLER'S OWN SELECTOR was malformed" landed in the same
+/// row and only the error body separated them. A wedged browser means
+/// something else is wrong (a contended profile, a hung tab); a protocol
+/// error usually means the caller asked for something impossible; a page
+/// exception from a bad selector (e.g. Playwright-style `text=...` syntax
+/// reaching a native `querySelector`) is a plain caller mistake — the same
+/// class `click_outcome`'s NOELEMENT/NOTVISIBLE/STALE sentinels already
+/// answer 400 for, just arriving as an exception instead of a string.
+/// Splitting all three into different status codes makes them different
+/// groups in every log view, for free.
 ///
 /// Decided on the TYPE, never by matching the message: a status code that
 /// depends on error wording breaks the first time someone rephrases it.
 fn cdp_status(e: &anyhow::Error) -> StatusCode {
     if e.downcast_ref::<chrome::CdpTimeout>().is_some() {
         StatusCode::GATEWAY_TIMEOUT
+    } else if e.downcast_ref::<chrome::PageException>().is_some() {
+        StatusCode::BAD_REQUEST
     } else {
         StatusCode::BAD_GATEWAY
     }
@@ -1613,7 +1622,14 @@ async fn action(headers: HeaderMap, body: Option<Json<Value>>) -> Response {
             match out {
                 Ok(v) if v.get("error").is_some() => err(StatusCode::BAD_REQUEST, v),
                 Ok(v) => Json(v).into_response(),
-                Err(e) => err(StatusCode::BAD_GATEWAY, json!({ "error": with_cause(&e) })),
+                // AMUX-98: a malformed selector (e.g. Playwright-style
+                // `text=...` reaching a native `querySelector`) throws
+                // INSIDE click_selector's own eval, before click_outcome
+                // ever sees a NOELEMENT/NOTVISIBLE/STALE string to classify
+                // — so this arm used to blanket-502 the caller's own typo.
+                // cdp_status now tells that PageException apart from a real
+                // transport failure by TYPE.
+                Err(e) => err(cdp_status(&e), json!({ "error": with_cause(&e) })),
             }
         }
         "type" => {
@@ -1621,7 +1637,7 @@ async fn action(headers: HeaderMap, body: Option<Json<Value>>) -> Response {
             match cdp.call("Input.insertText", json!({ "text": text }), ten).await {
                 Ok(_) => Json(json!({ "ok": true, "typed": text.chars().count(), "backend": "native" }))
                     .into_response(),
-                Err(e) => err(StatusCode::BAD_GATEWAY, json!({ "error": with_cause(&e) })),
+                Err(e) => err(cdp_status(&e), json!({ "error": with_cause(&e) })),
             }
         }
         "input" => {
@@ -1636,7 +1652,7 @@ async fn action(headers: HeaderMap, body: Option<Json<Value>>) -> Response {
             );
             let raw = match cdp.eval(&js, 20).await {
                 Ok(r) => r,
-                Err(e) => return err(StatusCode::BAD_GATEWAY, json!({ "error": with_cause(&e) })),
+                Err(e) => return err(cdp_status(&e), json!({ "error": with_cause(&e) })),
             };
             if raw.as_str() != Some("FOCUSED") {
                 let v = chrome::click_outcome(
@@ -1649,21 +1665,21 @@ async fn action(headers: HeaderMap, body: Option<Json<Value>>) -> Response {
             match cdp.call("Input.insertText", json!({ "text": text }), ten).await {
                 Ok(_) => Json(json!({ "ok": true, "index": idx, "typed": text.chars().count() }))
                     .into_response(),
-                Err(e) => err(StatusCode::BAD_GATEWAY, json!({ "error": with_cause(&e) })),
+                Err(e) => err(cdp_status(&e), json!({ "error": with_cause(&e) })),
             }
         }
         "key" => {
             let k = get_str("key").unwrap_or_default();
             match chrome::dispatch_key(&mut cdp, &k).await {
                 Ok(()) => Json(json!({ "ok": true, "key": k })).into_response(),
-                Err(e) => err(StatusCode::BAD_GATEWAY, json!({ "error": with_cause(&e) })),
+                Err(e) => err(cdp_status(&e), json!({ "error": with_cause(&e) })),
             }
         }
         "scroll" => {
             let dy = body.get("dy").and_then(Value::as_i64).unwrap_or(500);
             match cdp.eval(&format!("window.scrollBy(0,{dy})"), 10).await {
                 Ok(_) => Json(json!({ "ok": true, "dy": dy })).into_response(),
-                Err(e) => err(StatusCode::BAD_GATEWAY, json!({ "error": with_cause(&e) })),
+                Err(e) => err(cdp_status(&e), json!({ "error": with_cause(&e) })),
             }
         }
         "eval" => {
@@ -1736,12 +1752,15 @@ async fn action(headers: HeaderMap, body: Option<Json<Value>>) -> Response {
             match chrome::set_input_files(&mut cdp, &selector, &files).await {
                 Ok(v) if v.get("error").is_some() => err(StatusCode::BAD_REQUEST, v),
                 Ok(v) => Json(v).into_response(),
-                Err(e) => err(StatusCode::BAD_GATEWAY, json!({ "error": with_cause(&e) })),
+                // Same AMUX-98 class as "click": set_input_files' own probe
+                // interpolates the caller's selector into a querySelector
+                // eval, so a malformed one throws here too.
+                Err(e) => err(cdp_status(&e), json!({ "error": with_cause(&e) })),
             }
         }
         "back" => match cdp.eval("history.back()", 10).await {
             Ok(_) => Json(json!({ "ok": true })).into_response(),
-            Err(e) => err(StatusCode::BAD_GATEWAY, json!({ "error": with_cause(&e) })),
+            Err(e) => err(cdp_status(&e), json!({ "error": with_cause(&e) })),
         },
         "extract" => match state_payload(&mut cdp, &session).await {
             Ok(v) => Json(v).into_response(),
@@ -1784,9 +1803,11 @@ async fn action(headers: HeaderMap, body: Option<Json<Value>>) -> Response {
                             .into_response();
                     }
                     Ok(_) => {}
-                    Err(e) => {
-                        return err(StatusCode::BAD_GATEWAY, json!({ "error": with_cause(&e) }))
-                    }
+                    // AMUX-98: `probe` interpolates the caller's own
+                    // selector when one was given (the text-search branch
+                    // above has no selector to be malformed), so this is
+                    // the same class of caller mistake as "click".
+                    Err(e) => return err(cdp_status(&e), json!({ "error": with_cause(&e) })),
                 }
                 if std::time::Instant::now() >= deadline {
                     // A timeout is an OUTCOME, not a malformed request: 200
@@ -1823,7 +1844,7 @@ async fn action(headers: HeaderMap, body: Option<Json<Value>>) -> Response {
                     Json(json!({ "ok": true, "viewport": { "w": w, "h": h }, "measured": seen }))
                         .into_response()
                 }
-                Err(e) => err(StatusCode::BAD_GATEWAY, json!({ "error": with_cause(&e) })),
+                Err(e) => err(cdp_status(&e), json!({ "error": with_cause(&e) })),
             }
         }
         _ => unreachable!("validated above"),
@@ -2209,6 +2230,40 @@ mod tests {
         let wrapped = anyhow::Error::new(chrome::CdpTimeout { method: "X".into(), secs: 1 })
             .context("while resizing the viewport");
         assert_eq!(cdp_status(&wrapped), StatusCode::GATEWAY_TIMEOUT);
+    }
+
+    /// AMUX-98. A malformed selector (Playwright-style `text=...` syntax
+    /// reaching a native `document.querySelector`) throws INSIDE the page,
+    /// which `CdpClient::eval` now carries as a `PageException` rather than
+    /// a bare anyhow message — the caller's own mistake, same class as the
+    /// NOELEMENT/NOTVISIBLE/STALE sentinels `click_outcome` already answers
+    /// 400 for, not amux's infrastructure failing (502).
+    #[test]
+    fn a_page_exception_is_400_not_502() {
+        let page_ex = anyhow::Error::new(chrome::PageException(
+            "SyntaxError: Failed to execute 'querySelector' on 'Document': \
+             'text=Create credentials' is not a valid selector."
+                .into(),
+        ));
+        assert_eq!(cdp_status(&page_ex), StatusCode::BAD_REQUEST);
+        // Message text is unchanged from the old bail!("eval: {desc}") this
+        // replaced, so nothing reading the error body sees a diff.
+        assert!(page_ex.to_string().starts_with("eval: SyntaxError"));
+
+        // CONTROL: a real transport failure is untouched by this change —
+        // still 502, not folded into the new 400 case.
+        let protocol = anyhow::anyhow!("CDP websocket closed during Page.navigate");
+        assert_eq!(cdp_status(&protocol), StatusCode::BAD_GATEWAY);
+
+        // CONTROL: a timeout still wins over both of the above.
+        let timeout = anyhow::Error::new(chrome::CdpTimeout { method: "Y".into(), secs: 2 });
+        assert_eq!(cdp_status(&timeout), StatusCode::GATEWAY_TIMEOUT);
+
+        // CONTROL: a PageException wrapped in CONTEXT is still a
+        // PageException — same reasoning as the CdpTimeout control above.
+        let wrapped = anyhow::Error::new(chrome::PageException("boom".into()))
+            .context("while clicking a selector");
+        assert_eq!(cdp_status(&wrapped), StatusCode::BAD_REQUEST);
     }
 
     /// AMUX-3403: an unknown field posted to start is CAPTURED, not silently

--- a/crates/amux-server/src/integrations/browser.rs
+++ b/crates/amux-server/src/integrations/browser.rs
@@ -1725,7 +1725,18 @@ impl CdpClient {
                 .and_then(Value::as_str)
                 .or_else(|| ex.get("text").and_then(Value::as_str))
                 .unwrap_or("page threw");
-            anyhow::bail!("eval: {desc}");
+            // Carried as a TYPE (AMUX-98), same technique as CdpTimeout right
+            // below: a caller-supplied selector that is not valid CSS (e.g.
+            // Playwright-style `text=...` syntax reaching a native
+            // `document.querySelector`) throws HERE, inside the page — the
+            // caller's mistake, not amux's. Every OTHER caller of `eval()`
+            // (click_selector, the "wait" selector probe, ...) used to
+            // propagate this as a bare anyhow error indistinguishable from a
+            // real transport failure, so the API boundary answered 502 for a
+            // malformed selector — "amux is broken" for what was actually a
+            // well-formed refusal. Message text is UNCHANGED ("eval: {desc}"),
+            // only the type changed, so this is not a wire-format break.
+            return Err(anyhow::Error::new(PageException(desc.to_string())));
         }
         Ok(r.pointer("/result/value").cloned().unwrap_or(Value::Null))
     }
@@ -1778,6 +1789,34 @@ impl std::fmt::Display for CdpTimeout {
 }
 
 impl std::error::Error for CdpTimeout {}
+
+/// A page-side exception from `Runtime.evaluate` (AMUX-98) — the SCRIPT
+/// threw, most commonly because a caller-supplied selector interpolated
+/// into a `document.querySelector(...)` call is not valid CSS (e.g. a
+/// Playwright-style `text=...` selector, which native `querySelector` does
+/// not understand and rejects with a `SyntaxError`). This is the caller's
+/// mistake, same class as the NOELEMENT/NOTVISIBLE/STALE sentinels
+/// `click_outcome` already maps to 400 — it just arrives as an exception
+/// instead of a benign string return, because the malformed selector fails
+/// before the click JS's own logic ever runs.
+///
+/// Carried as a TYPE, same technique as [`CdpTimeout`] right above (and for
+/// the identical reason, AMUX-3672): the API boundary decides the status
+/// code from the error's TYPE, never by matching its message text, so a
+/// future rewording can't silently flip a 400 into a 502.
+#[derive(Debug)]
+pub struct PageException(pub String);
+
+impl std::fmt::Display for PageException {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Unchanged wording ("eval: {desc}") from the old bail!() this
+        // replaced — callers and tests that match on the message see no
+        // difference; only the type is now inspectable.
+        write!(f, "eval: {}", self.0)
+    }
+}
+
+impl std::error::Error for PageException {}
 
 impl From<anyhow::Error> for DriverError {
     fn from(e: anyhow::Error) -> Self {


### PR DESCRIPTION
Card AMUX-98 filed on `POST /api/browser/action` → 502 with body `eval: SyntaxError: Failed to execute 'querySelector' on 'Document': 'text=Create credentials' is not a valid selector.` The caller used Playwright-style selector syntax (`text=...`) against amux's native CDP driver, which speaks plain CSS via `document.querySelector`. Per the card's own text: "A 5xx is amux failing, not amux declining — if this is really a refusal, the fix is the STATUS CODE, not the caller."

**Root cause:** `CdpClient::eval()` folded two very different failure classes into one untyped `anyhow::Error` — a page-side JS exception (the script, or a caller-supplied selector interpolated into one, threw) and a real CDP transport/protocol failure. `click_selector`, `set_input_files`, and the "wait" selector probe all interpolate a caller-supplied selector into an `eval()` call and propagated whichever came back as a bare `Err`, so a malformed selector 502'd exactly like a wedged browser — the same row-folding defect AMUX-3672 already fixed once (`CdpTimeout` vs a protocol error → 504 vs 502), recurring here as a third unhandled failure class.

**Fix:** same technique as AMUX-3672 — carry the page exception as a TYPE (`PageException`, `integrations/browser.rs`), not a string. `cdp_status()` now downcasts three ways: `CdpTimeout` → 504, `PageException` → 400, everything else → 502. Applied uniformly across every `Err(e)` arm in `api/browser.rs`'s `action` dispatch (click, type, input, key, scroll, files, back, wait, viewport) rather than just the one arm that filed the card, since `eval()` is their shared mechanism and click/files/wait all interpolate a caller selector into it the same way.

Message text is byte-for-byte unchanged (`"eval: {desc}"`), so nothing reading the error body sees a difference — only the type is now inspectable, same non-breaking shape as the `CdpTimeout` precedent.

**Tests:** `a_page_exception_is_400_not_502` pins the 3-way `cdp_status()` dispatch plus two CONTROL cases (a real protocol error stays 502, a `PageException` wrapped in `.context()` is still recognised) — matches the existing `a_cdp_timeout_is_504_and_a_protocol_error_is_502` test's own depth.

Verified via Woodpecker CI (clone/check/clippy/test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)