### PR TITLE
Fix the end-to-end captured command task lifecycle

### DIFF
--- a/amux
+++ b/amux
@@ -2390,6 +2390,71 @@ Usage: amux board epic $id <EPIC-ID> | none"
       echo "$result" | _board_outcome "$id" "" "$_note"
       return $?
       ;;
+    decompose)
+      # The multi-card exit from a capture shell is deliberately ONE request.
+      # Creating children with repeated `board add` calls made dependency,
+      # priority, ownership and epic linking optional at every step, and left
+      # half a plan behind whenever one call failed.
+      local id="${1:-}"
+      _board_id_guard "decompose" "$id"
+      [[ -n "$id" ]] || die "Usage: amux board decompose <CAPTURE-ID> --stdin | --file <plan.json>
+The plan is JSON: {\"tasks\":[{\"title\":\"...\",\"description\":\"...\",\"type\":\"code\",\"priority\":0,\"depends_on\":[],\"next_action\":\"Implement ...\"}, ...]}
+depends_on contains 1-based indexes of earlier tasks. Priority is p0 (highest) through p3."
+      shift
+      local plan=""
+      case "${1:-}" in
+        --stdin|-) plan=$(cat); shift ;;
+        --file) [[ -n "${2:-}" && -r "${2:-}" ]] || die "amux board decompose: readable --file required"
+                plan=$(cat "$2"); shift 2 ;;
+        --help|-h) die "Usage: amux board decompose <CAPTURE-ID> --stdin | --file <plan.json>" ;;
+        *) die "amux board decompose: pass the plan with --stdin or --file" ;;
+      esac
+      [[ -n "$plan" ]] || die "amux board decompose: the plan is empty"
+      [[ $# -eq 0 ]] || _board_bad_flag decompose "$1" "--stdin --file <plan.json>"
+      local result
+      result=$(_curl -sk -X POST -H 'Content-Type: application/json' \
+        -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" \
+        -d "$plan" "$AMUX_API/api/board/$id/decompose")
+      echo "$result" | _board_outcome "$id" "" "decomposed atomically"
+      return $?
+      ;;
+    artifact)
+      # The API has had a structured artifact registry since migration 0046,
+      # but workers had no attributed CLI path to write it. A registry nobody
+      # can reach from the pickup instruction degrades back into prose.
+      local id="${1:-}" ref="${2:-}" kind="implementation" state="created" description=""
+      _board_id_guard "artifact" "$id"
+      [[ -n "$id" ]] || die "Usage: amux board artifact <ISSUE-ID> <file|URL|commit|PR> [--kind K] [--state S] [--description TEXT]"
+      shift
+      if [[ "${1:-}" == "--stdin" || "${1:-}" == "-" ]]; then
+        ref=$(cat); shift
+      elif [[ "${1:-}" == "--file" ]]; then
+        [[ -n "${2:-}" && -r "${2:-}" ]] || die "amux board artifact: readable --file required"
+        ref=$(cat "$2"); shift 2
+      else
+        ref="${1:-}"; [[ $# -gt 0 ]] && shift
+      fi
+      [[ -n "$ref" ]] || die "amux board artifact: artifact reference required"
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --kind) [[ -n "${2:-}" ]] || die "amux board artifact: --kind needs a value"; kind="$2"; shift 2 ;;
+          --state) [[ -n "${2:-}" ]] || die "amux board artifact: --state needs a value"; state="$2"; shift 2 ;;
+          --description) [[ -n "${2:-}" ]] || die "amux board artifact: --description needs text"; description="$2"; shift 2 ;;
+          --*) _board_bad_flag artifact "$1" "--kind <kind> --state <state> --description <text>" ;;
+          *) die "amux board artifact: unexpected argument '$1'" ;;
+        esac
+      done
+      local body result
+      body=$(R="$ref" K="$kind" S="$state" D="$description" python3 -c 'import json,os
+b={"ref":os.environ["R"],"kind":os.environ["K"],"state":os.environ["S"]}
+if os.environ.get("D"): b["description"]=os.environ["D"]
+print(json.dumps(b))')
+      result=$(_curl -sk -X POST -H 'Content-Type: application/json' \
+        -H "X-Amux-Worker: ${AMUX_WORKER:-${AMUX_SESSION:-}}" \
+        -d "$body" "$AMUX_API/api/board/$id/artifacts")
+      echo "$result" | _board_outcome "$id" "" "artifact registered"
+      return $?
+      ;;
     archive|unarchive)
       # AMUX-2492. `archived` had no per-card setter anywhere — only the age-archive
       # sweep and a per-session bulk update could touch it, so an automated action had
@@ -3168,6 +3233,11 @@ ${BOLD}amux board${RESET} — manage board issues from the CLI
   amux board status <ID> <status>  Set any status
   amux board type <ID> <type>      Correct a card's type (the gate is DERIVED from it)
   amux board epic <ID> <EPIC-ID>   Roll a card up under an epic ('none' detaches)
+  amux board decompose <ID> --stdin Atomically turn a captured prompt into an epic
+                                   plus ordered child tasks with dependencies,
+                                   p0-p3 priorities and concrete next actions.
+  amux board artifact <ID> <ref>   Register a file, URL, commit, PR, screenshot or
+                                   verification asset on the task.
   amux board reviewer <ID> <W>     Name the peer a card in review is handed to
   amux board block <ID> --on <why> Block a card WITHOUT changing its status, so its
                                    lifecycle position survives. --on is required:

--- a/crates/amux-dashboard/static/app.js
+++ b/crates/amux-dashboard/static/app.js
@@ -8372,7 +8372,7 @@ async function saveGlobalMemory() {
   }
 }
 
-const APP_VER = '0.9.772';   // bump together with the sw.js CACHE version
+const APP_VER = '0.9.773';   // bump together with the sw.js CACHE version
 
 // ── No silent failures (Ethan, 2026-08-09: "make sure every action has some
 // kind of response in the ui — i just deleted a worker and nothing happened").
@@ -25842,6 +25842,105 @@ function _boardDraftsPersist() {
 // known to have one — see the guard in the save handler (AMUX-2840).
 let _bdHydrated = false;
 
+function _bdConfigureGo(item) {
+  const goBtn = document.getElementById('bd-goto-session');
+  if (!goBtn) return;
+  const sess = item.session || '';
+  goBtn.style.display = sess ? '' : 'none';
+  goBtn.onclick = (e) => {
+    e.stopPropagation();
+    try { closeBoardDetail(); } catch (err) {}
+    openPeek(sess, { query: item.id });
+  };
+}
+
+function _bdArtifactRef(a) {
+  const ref = String((a && a.ref) || '');
+  if (/^https?:\/\//i.test(ref)) {
+    return '<a href="' + esc(ref) + '" target="_blank" rel="noopener noreferrer">' + esc(ref) + '</a>';
+  }
+  if (/^(?:\/|\.\.?\/)/.test(ref)) {
+    return '<span class="file-link" onclick="event.stopPropagation();openFilePreview(\''
+      + escJs(ref) + '\')">' + esc(ref) + '</span>';
+  }
+  return '<code>' + esc(ref) + '</code>';
+}
+
+// One renderer for cached open and authoritative hydration. Keeping relation
+// rendering here prevents the list card and GET detail from growing separate
+// definitions of the task's epic, source message, summary and assets.
+function _bdRenderMeta(item) {
+  const meta = document.getElementById('bd-meta');
+  if (!meta || !item) return;
+  const parts = [];
+  if (item.type) parts.push('Type ' + esc(item.type));
+  if (item.creator) parts.push('From ' + esc(item.creator));
+  if (item.created) parts.push('Created ' + timeAgo(item.created));
+  if (item.updated && item.updated !== item.created) parts.push('Updated ' + timeAgo(item.updated));
+  if (item.reviewer) parts.push('Reviewer ' + esc(item.reviewer));
+  if (item.source_ref) {
+    const lv = item.last_verified_at;
+    const ageH = lv ? Math.round((Date.now()/1000 - lv) / 3600) : null;
+    const stale = !lv || ageH > 24;
+    parts.push('Derived from ' + esc(String(item.source_ref).slice(0,60))
+      + (lv ? (' · source re-checked ' + ageH + 'h ago') : ' · never re-verified')
+      + (stale ? ' <span style="color:var(--red);font-weight:600;">STALE — re-check the source before acting</span>' : ''));
+  }
+  let html = parts.map(p => '<div class="board-detail-meta-row">' + p + '</div>').join('');
+  if (item.epic) {
+    html += '<div class="board-detail-meta-row"><b>Epic</b> <span class="task-id-chip" onclick="_openIssue(\''
+      + escJs(item.epic) + '\')">' + esc(item.epic) + '</span></div>';
+  }
+  const deps = Array.isArray(item.depends_on) ? item.depends_on : [];
+  if (deps.length) html += '<div class="board-detail-meta-row"><b>Blocked by</b> ' + deps.map(d =>
+    '<span class="task-id-chip" onclick="_openIssue(\'' + escJs(d) + '\')">' + esc(d) + '</span>').join(' ') + '</div>';
+
+  const summary = [
+    ['Next action', item.next_action],
+    ['Last result', item.last_result],
+    ['Unresolved', item.unresolved],
+    ['Evidence', item.evidence]
+  ].filter(x => x[1]);
+  if (summary.length) {
+    html += '<div class="board-detail-meta-row"><b>Work summary</b></div>'
+      + summary.map(x => '<div class="board-detail-meta-row"><span style="color:var(--dim)">'
+        + esc(x[0]) + ':</span> ' + _linkifyUrls(_linkifyCardIds(esc(String(x[1])))) + '</div>').join('');
+  }
+
+  const children = Array.isArray(item.children) ? item.children : [];
+  if (children.length) {
+    html += '<div class="board-detail-meta-row"><b>Child tasks (' + children.length + ')</b></div>'
+      + children.map(c => {
+        const sty = statusStyle(c.status || 'todo');
+        const pri = c.priority ? ' · ' + esc(c.priority) : '';
+        return '<div class="board-detail-meta-row" style="display:flex;gap:6px;align-items:center;">'
+          + '<span class="task-id-chip" onclick="_openIssue(\'' + escJs(c.id) + '\')">' + esc(c.id) + '</span>'
+          + '<span class="status-badge" style="background:' + sty.bg + ';color:' + sty.color + '">' + esc(c.status || 'todo') + '</span>'
+          + '<span>' + esc(c.title || '') + pri + '</span></div>';
+      }).join('');
+  }
+
+  const messages = Array.isArray(item.messages) ? item.messages : [];
+  if (messages.length) {
+    html += '<div class="board-detail-meta-row"><b>Source message' + (messages.length === 1 ? '' : 's') + '</b></div>'
+      + messages.map(m => {
+        const ts = Number(m.ts || 0); const sec = ts > 100000000000 ? Math.floor(ts / 1000) : ts;
+        return '<div class="board-detail-meta-row"><span class="task-id-chip">MSG-' + esc(String(m.id)) + '</span> '
+          + (m.session ? esc(m.session) + ' · ' : '') + (sec ? timeAgo(sec) + ' · ' : '')
+          + esc(String(m.text || '').slice(0,220)) + '</div>';
+      }).join('');
+  }
+
+  const artifacts = Array.isArray(item.artifacts) ? item.artifacts : [];
+  if (artifacts.length) {
+    html += '<div class="board-detail-meta-row"><b>Artifacts (' + artifacts.length + ')</b></div>'
+      + artifacts.map(a => '<div class="board-detail-meta-row">' + _bdArtifactRef(a)
+        + ' <span style="color:var(--dim)">· ' + esc(a.kind || 'artifact') + ' · ' + esc(a.state || 'created') + '</span>'
+        + (a.description ? '<div style="color:var(--dim)">' + esc(a.description) + '</div>' : '') + '</div>').join('');
+  }
+  meta.innerHTML = html;
+}
+
 /// Fetch the authoritative card and fill desc/log, WITHOUT clobbering anything
 /// the user has typed.
 ///
@@ -25857,22 +25956,37 @@ async function _bdHydrate(id) {
     const full = await r.json();
     if (!full || full.id !== id || boardDetailId !== id) return;  // modal moved on
     const idx = boardItems.findIndex(i => i.id === id);
+    const cached = idx >= 0 ? { ...boardItems[idx] } : {};
     if (idx >= 0) boardItems[idx] = Object.assign({}, boardItems[idx], full);
-    if (_boardDrafts[id]) { _bdHydrated = true; return; }  // user's draft wins
-    const d = document.getElementById('bd-desc');
-    // Only fill if the user has not started typing into it.
-    if (d && (d.value === '' || d.value === (full.desc || ''))) d.value = full.desc || '';
-    const l = document.getElementById('bd-log');
-    if (l && full.log !== undefined) l.textContent = full.log || '';
-    // RE-RENDER THE HISTORY TAB with the hydrated record. It was rendered at
-    // open time from the LIST item, and under slim that item carries no `log`
-    // — so the tab would show an empty history and a 0 count for every card,
-    // which reads as "nothing ever happened here" rather than as still
-    // loading. Same class as the blank desc, one surface over.
-    if (boardDetailId === id) {
       const merged = idx >= 0 ? boardItems[idx] : full;
       _bdRenderHistory(merged);
       if (typeof _bdRenderStatusBanner === 'function') _bdRenderStatusBanner(merged);
+    _bdRenderMeta(merged);
+    if (_boardDrafts[id]) { _bdHydrated = true; return; }  // user's draft wins
+    const title = document.getElementById('bd-title');
+    if (title && title.value === (cached.title || '')) {
+      title.value = full.title || '';
+      title.style.height = 'auto'; title.style.height = title.scrollHeight + 'px';
+    }
+    const d = document.getElementById('bd-desc');
+    // Only fill if the user has not started typing into it.
+    if (d && d.value === (cached.desc || '')) d.value = full.desc || '';
+    if (boardDetailStatus === (cached.status || 'todo')) {
+      boardDetailStatus = full.status || 'todo';
+      _renderDetailStatusBtns();
+    }
+    const sess = document.getElementById('bd-session');
+    if (sess && sess.value === (cached.session || '')) _populateSessionSelect('bd-session', full.session || '');
+    _bdConfigureGo(full);
+    const due = document.getElementById('bd-due');
+    if (due && due.value === (cached.due || '')) { due.value = full.due || ''; try { _dpSyncLabel(due); } catch (e) {} }
+    const dueTime = document.getElementById('bd-due-time');
+    if (dueTime && dueTime.value === (cached.due_time || '')) dueTime.value = full.due_time || '';
+    const gate = document.getElementById('bd-gate');
+    const oldGate = (Array.isArray(cached.gate) ? cached.gate : []).join('\n');
+    if (gate && gate.value === oldGate) gate.value = (Array.isArray(full.gate) ? full.gate : []).join('\n');
+    if (JSON.stringify(_tagState['bd'] || []) === JSON.stringify(cached.tags || [])) {
+      _tagState['bd'] = [...(full.tags || [])]; _beTagRenderChips('bd'); _beTagInputUpdate('bd');
     }
     _bdHydrated = true;
   } catch (e) { /* leave unhydrated; the save guard covers it */ }
@@ -25906,19 +26020,7 @@ function openBoardDetail(id) {
   const keyEl = document.getElementById('bd-key');
   if (keyEl) keyEl.textContent = item.id || '';
   _populateSessionSelect('bd-session', draft ? draft.session : (item.session || ''));
-  // One-tap jump from a card to the owning session's live progress
-  // (Ethan 07:19): opens the peek on the terminal, prefilled to search for
-  // this card id so the jump lands where the session last touched it.
-  const goBtn = document.getElementById('bd-goto-session');
-  if (goBtn) {
-    const _sess = (draft ? draft.session : item.session) || '';
-    goBtn.style.display = _sess ? '' : 'none';
-    goBtn.onclick = (e) => {
-      e.stopPropagation();
-      try { closeBoardDetail(); } catch (err) {}
-      openPeek(_sess, { query: item.id });
-    };
-  }
+  _bdConfigureGo({ ...item, session: draft ? draft.session : item.session });
   const dueEl = document.getElementById('bd-due');
   if (dueEl) { dueEl.value = draft ? (draft.due || '') : (item.due || ''); try { _dpSyncLabel(dueEl); } catch (e) {} }
   const dueTimeEl = document.getElementById('bd-due-time');
@@ -25929,26 +26031,7 @@ function openBoardDetail(id) {
   _tagState['bd'] = [...(item.tags || [])];
   _beTagRenderChips('bd');
   _beTagInputUpdate('bd');
-  const meta = document.getElementById('bd-meta');
-  const parts = [];
-  if (item.type) parts.push('Type ' + esc(item.type));
-  if (item.creator) parts.push('From ' + esc(item.creator));
-  if (item.created) parts.push('Created ' + timeAgo(item.created));
-  if (item.updated && item.updated !== item.created) parts.push('Updated ' + timeAgo(item.updated));
-  if (item.reviewer) parts.push('Reviewer ' + esc(item.reviewer));
-  if (item.source_ref) {
-    const lv = item.last_verified_at;
-    const ageH = lv ? Math.round((Date.now()/1000 - lv) / 3600) : null;
-    const stale = !lv || ageH > 24;
-    parts.push('Derived from ' + esc(String(item.source_ref).slice(0,60))
-      + (lv ? (' · source re-checked ' + ageH + 'h ago') : ' · never re-verified')
-      + (stale ? ' <span style="color:var(--red);font-weight:600;">STALE — re-check the source before acting</span>' : ''));
-  }
-  const deps = Array.isArray(item.depends_on) ? item.depends_on : [];
-  let depHtml = '';
-  if (deps.length) depHtml = '<div class="board-detail-meta-row">Blocked by ' + deps.map(d =>
-    '<span class="task-id-chip" onclick="_openIssue(\'' + escJs(d) + '\')" style="cursor:pointer;">' + esc(d) + '</span>').join(' ') + '</div>';
-  meta.innerHTML = parts.map(p => '<div class="board-detail-meta-row">' + p + '</div>').join('') + depHtml;
+  _bdRenderMeta(item);
   document.getElementById('bd-save-status').textContent = '';
   document.getElementById('board-detail-overlay').classList.add('active');
   setTimeout(() => document.getElementById('bd-title').focus(), 100);
@@ -26348,7 +26431,7 @@ async function boardDetailSave() {
   document.getElementById('bd-save-status').textContent = 'Saving...';
   const dueInput = document.getElementById('bd-due');
   const dueTimeInput = document.getElementById('bd-due-time');
-  const changes = { title, desc, status: boardDetailStatus, due: dueInput ? dueInput.value : '', due_time: dueTimeInput ? dueTimeInput.value : '', groups: [..._tagState['bd']], gate };
+  const changes = { title, desc, status: boardDetailStatus, due: dueInput ? dueInput.value : '', due_time: dueTimeInput ? dueTimeInput.value : '', tags: [..._tagState['bd']], gate };
   if (worker !== undefined) changes.session = worker;
   // The server enforces status gates: forward acknowledgement from _gateConfirm.
   if (_gateAck) { changes.gate_ack = true; if (Array.isArray(_gateAck)) changes.gate_checked = _gateAck; }
@@ -26387,13 +26470,13 @@ async function addBoardItem(title, desc, status, worker, groups, due, ownerType,
   gate = gate || [];
   const tempId = Math.random().toString(16).slice(2, 8);
   const now = Math.floor(Date.now() / 1000);
-  const tempItem = { id: tempId, title, desc, status, worker: worker || '', groups: groups || [], due: due || '', due_time: dueTime || '', gate: gate, creator: _getDeviceName(), owner_type: ownerType, created: now, updated: now, _pending: true };
+  const tempItem = { id: tempId, title, desc, status, session: worker || '', tags: groups || [], due: due || '', due_time: dueTime || '', gate: gate, creator: _getDeviceName(), owner_type: ownerType, created: now, updated: now, _pending: true };
   boardItems.push(tempItem);
   saveBoardCache();
   renderBoard();
   const r = await apiCall(API + '/api/board', {
     method: 'POST', headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({ title, desc, status, worker: worker || '', groups: groups || [], due: due || '', due_time: dueTime || '', gate: gate, creator: _getDeviceName(), owner_type: ownerType })
+    body: JSON.stringify({ title, desc, status, session: worker || '', tags: groups || [], due: due || '', due_time: dueTime || '', gate: gate, creator: _getDeviceName(), owner_type: ownerType })
   });
   if (r) {
     const item = await r.json();

--- a/crates/amux-dashboard/static/sw.js
+++ b/crates/amux-dashboard/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'amux-v0.9.772';
+const CACHE = 'amux-v0.9.773';
 const SHELL_URLS = ['/', '/manifest.json', '/icon.svg', '/icon.png', '/icon-192.png', '/icon-512.png'];
 
 // Install: pre-cache entire app shell

--- a/crates/amux-server/src/api/board.rs
+++ b/crates/amux-server/src/api/board.rs
@@ -77,10 +77,17 @@ pub fn routes() -> Router<AppState> {
         // SPA catch-all (405) and the CLI (pre-fix) exited 0 with the card
         // untouched — AMUX-2140 one layer down. Same mechanism auto-pickup uses.
         .route("/{id}/claim", post(claim_item))
+        // One write for the whole model-judged plan: the capture becomes the
+        // epic that the originating message already points at, and every child
+        // is created with its owner, priority and dependency edges intact.
+        .route("/{id}/decompose", post(decompose_item))
         .route("/{id}/capsule", get(capsule))
         .route("/{id}/verifications", get(list_verifications))
         .route("/{id}/artifacts", get(list_artifacts).post(create_artifact))
-        .route("/{id}/artifacts/{aid}", axum::routing::patch(patch_artifact).delete(delete_artifact))
+        .route(
+            "/{id}/artifacts/{aid}",
+            axum::routing::patch(patch_artifact).delete(delete_artifact),
+        )
 }
 
 /// GET /api/board/needsyou — THE owner view, capped (AF-318).
@@ -2895,21 +2902,340 @@ pub async fn get_item(State(state): State<AppState>, Path(id): Path<String>) -> 
     let key = id.clone();
     let joined = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
         let conn = store.read()?;
-        Ok(bs::get_issue(&conn, &key)?)
+        let Some(row) = bs::get_issue(&conn, &key)? else {
+            return Ok(None);
+        };
+        let mut child_ids = Vec::new();
+        let mut stmt = conn.prepare(
+            "SELECT id FROM issues WHERE epic=?1 AND deleted IS NULL ORDER BY created, id",
+        )?;
+        child_ids.extend(
+            stmt.query_map(rusqlite::params![row.id], |r| r.get::<_, String>(0))?
+                .flatten(),
+        );
+        let children = child_ids
+            .iter()
+            .filter_map(|child| bs::get_issue(&conn, child).ok().flatten())
+            .map(|child| {
+                json!({
+                    "id": child.id,
+                    "title": child.title,
+                    "status": child.status,
+                    "session": child.session,
+                    "type": child.item_type,
+                    "depends_on": child.depends_on,
+                    "priority": child.tags.iter().find(|t| t.starts_with('p')),
+                    "evidence": child.evidence,
+                    "last_result": child.last_result,
+                    "next_action": child.next_action,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        // A child inherits the source message of its epic for display, while
+        // cmd_history.card_id itself remains attached to the root epic. That
+        // keeps the Messages chip stable from prompt through completion.
+        let message_root = row.epic.as_deref().unwrap_or(&row.id);
+        let mut messages = Vec::new();
+        let mut msg_stmt = conn.prepare(
+            "SELECT id,text,type,session,ts,origin,card_id FROM cmd_history \
+             WHERE card_id=?1 ORDER BY ts DESC LIMIT 20",
+        )?;
+        messages.extend(
+            msg_stmt
+                .query_map(rusqlite::params![message_root], |r| {
+                    Ok(json!({
+                        "id": r.get::<_, i64>(0)?,
+                        "text": r.get::<_, String>(1)?,
+                        "type": r.get::<_, String>(2)?,
+                        "session": r.get::<_, String>(3)?,
+                        "ts": r.get::<_, i64>(4)?,
+                        "origin": r.get::<_, String>(5)?,
+                        "card_id": r.get::<_, Option<String>>(6)?,
+                    }))
+                })?
+                .flatten(),
+        );
+        let artifacts = crate::db::artifact_store::list_for_task(&conn, &row.id)?
+            .into_iter()
+            .map(|a| artifact_value(&a))
+            .collect::<Vec<_>>();
+        Ok(Some((row, children, messages, artifacts)))
     })
     .await;
     match joined {
-        Ok(Ok(Some(row))) => {
+        Ok(Ok(Some((row, children, messages, artifacts)))) => {
             // Weak ETag for read-modify-write callers (AMUX-1711 parity).
             let mut headers = HeaderMap::new();
             if let Ok(v) = format!("W/\"{}-{}\"", row.id, row.rev).parse() {
                 headers.insert("etag", v);
             }
-            (StatusCode::OK, headers, Json(detail_body(&row))).into_response()
+            let mut body = detail_body(&row);
+            body["children"] = json!(children);
+            body["messages"] = json!(messages);
+            body["artifacts"] = json!(artifacts);
+            (StatusCode::OK, headers, Json(body)).into_response()
         }
         Ok(Ok(None)) => not_found(&id),
         Ok(Err(e)) => internal(e),
         Err(e) => internal(e),
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct DecomposeTask {
+    title: String,
+    #[serde(default, alias = "desc")]
+    description: String,
+    #[serde(default = "default_decompose_type", rename = "type")]
+    item_type: String,
+    priority: u8,
+    #[serde(default)]
+    depends_on: Vec<usize>,
+    next_action: String,
+}
+
+fn default_decompose_type() -> String {
+    "code".into()
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct DecomposeBody {
+    tasks: Vec<DecomposeTask>,
+}
+
+fn validate_decomposition(tasks: &[DecomposeTask]) -> Result<(), String> {
+    if !(2..=50).contains(&tasks.len()) {
+        return Err("decomposition requires 2 to 50 child tasks".into());
+    }
+    for (idx, task) in tasks.iter().enumerate() {
+        let n = idx + 1;
+        if task.title.trim().is_empty() {
+            return Err(format!("task {n} has an empty title"));
+        }
+        if !bs::KNOWN_TYPES.contains(&task.item_type.as_str()) || task.item_type == "epic" {
+            return Err(format!(
+                "task {n} has invalid leaf type {:?}",
+                task.item_type
+            ));
+        }
+        if task.priority > 3 {
+            return Err(format!("task {n} priority must be 0 (highest) through 3"));
+        }
+        if bs::continuation_verdict(&task.next_action) != bs::ContinuationVerdict::Ok {
+            return Err(format!(
+                "task {n} needs a concrete next_action of at least three words"
+            ));
+        }
+        let mut seen = std::collections::HashSet::new();
+        for dep in &task.depends_on {
+            if *dep == 0 || *dep >= n {
+                return Err(format!(
+                    "task {n} dependency {dep} must name an earlier task by 1-based index"
+                ));
+            }
+            if !seen.insert(*dep) {
+                return Err(format!("task {n} repeats dependency {dep}"));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// POST /api/board/{id}/decompose — atomically turn a capture shell into an
+/// epic and create its ordered, attributed child plan.
+async fn decompose_item(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    headers: HeaderMap,
+    Json(body): Json<DecomposeBody>,
+) -> Response {
+    if let Err(why) = validate_decomposition(&body.tasks) {
+        return err(StatusCode::BAD_REQUEST, json!({"error": why, "item": id}));
+    }
+    let (_, actor) = actor_from_headers(&headers);
+    if actor == "api-anonymous" {
+        return err(
+            StatusCode::UNAUTHORIZED,
+            json!({"error":"decomposition requires X-Amux-Worker or X-Amux-Session attribution"}),
+        );
+    }
+
+    enum Out {
+        Missing,
+        NotCapture,
+        WrongOwner(String),
+        Already(IssueRow, Vec<IssueRow>),
+        Created(IssueRow, Vec<IssueRow>),
+    }
+    let tasks = body.tasks;
+    let id_w = id.clone();
+    let actor_w = actor.clone();
+    let slot: Arc<Mutex<Option<Out>>> = Arc::new(Mutex::new(None));
+    let slot_w = slot.clone();
+    let write = state
+        .store
+        .write_async(move |conn| {
+            let Some(mut parent) = bs::get_issue(conn, &id_w)? else {
+                return finish(&slot_w, Out::Missing, no_write());
+            };
+            let child_ids = {
+                let mut stmt = conn.prepare(
+                    "SELECT id FROM issues WHERE epic=?1 AND deleted IS NULL ORDER BY created,id",
+                )?;
+                let ids = stmt
+                    .query_map(rusqlite::params![id_w], |r| r.get::<_, String>(0))?
+                    .flatten()
+                    .collect::<Vec<_>>();
+                ids
+            };
+            if parent.item_type == "epic" && !child_ids.is_empty() {
+                let children = child_ids
+                    .iter()
+                    .filter_map(|child| bs::get_issue(conn, child).ok().flatten())
+                    .collect();
+                return finish(&slot_w, Out::Already(parent, children), no_write());
+            }
+            if parent.source.as_deref() != Some("capture")
+                && !parent.desc.trim_start().starts_with("**Prompt:**")
+            {
+                return finish(&slot_w, Out::NotCapture, no_write());
+            }
+            if parent
+                .session
+                .as_deref()
+                .is_some_and(|owner| owner != actor_w)
+            {
+                return finish(
+                    &slot_w,
+                    Out::WrongOwner(parent.session.clone().unwrap_or_default()),
+                    no_write(),
+                );
+            }
+
+            let now = now_secs();
+            let stamp = chrono::Local::now().format("%H:%M").to_string();
+            parent.item_type = "epic".into();
+            parent.updated = now;
+            parent.rev += 1;
+            parent.version += 1;
+            parent.log = Some(bs::append_log(
+                parent.log.as_deref(),
+                &stamp,
+                &format!(
+                    "decomposed by {actor_w} into {} ordered child task(s)",
+                    tasks.len()
+                ),
+            ));
+            bs::save_patched(conn, &mut parent)?;
+            let mut events = vec![ev_snap(&parent, MutationKind::Updated)];
+            let mut children: Vec<IssueRow> = Vec::with_capacity(tasks.len());
+            for (idx, task) in tasks.iter().enumerate() {
+                let deps = task
+                    .depends_on
+                    .iter()
+                    .map(|n| children[*n - 1].id.clone())
+                    .collect::<Vec<_>>();
+                let new = bs::NewIssue {
+                    title: task.title.trim().to_string(),
+                    desc: task.description.trim().to_string(),
+                    status: if deps.is_empty() {
+                        "todo".into()
+                    } else {
+                        "backlog".into()
+                    },
+                    session: parent.session.clone().or_else(|| Some(actor_w.clone())),
+                    item_type: task.item_type.clone(),
+                    creator: actor_w.clone(),
+                    owner_type: "agent".into(),
+                    due: None,
+                    due_time: None,
+                    reviewer: None,
+                    shepherd: None,
+                    gate: Vec::new(),
+                    depends_on: deps,
+                    tags: vec![format!("p{}", task.priority)],
+                    ask_type: None,
+                    ask_question: None,
+                    ask_unblocks: None,
+                    source: Some("decomposition".into()),
+                };
+                let mut child = bs::create_issue(conn, &new, now)?;
+                child.epic = Some(parent.id.clone());
+                child.next_action = Some(task.next_action.trim().to_string());
+                child.log = Some(bs::append_log(
+                    child.log.as_deref(),
+                    &stamp,
+                    &format!(
+                        "created by {actor_w} from epic {} as plan step {} (priority p{})",
+                        parent.id,
+                        idx + 1,
+                        task.priority
+                    ),
+                ));
+                child.updated = now;
+                child.rev += 1;
+                child.version += 1;
+                bs::save_patched(conn, &mut child)?;
+                events.push(ev_snap(&child, MutationKind::Created));
+                children.push(child);
+            }
+            finish(
+                &slot_w,
+                Out::Created(parent, children),
+                WriteOutcome {
+                    applied: true,
+                    events,
+                },
+            )
+        })
+        .await;
+    if let Err(e) = write {
+        return internal(e);
+    }
+    let outcome = slot.lock().expect("outcome slot poisoned").take();
+    match outcome {
+        Some(Out::Missing) => not_found(&id),
+        Some(Out::NotCapture) => err(
+            StatusCode::CONFLICT,
+            json!({"error":"only an auto-captured prompt can be decomposed atomically", "item":id}),
+        ),
+        Some(Out::WrongOwner(owner)) => err(
+            StatusCode::FORBIDDEN,
+            json!({"error":"capture belongs to another worker", "item":id, "owner":owner, "caller":actor}),
+        ),
+        Some(Out::Already(parent, children)) => Json(json!({
+            "ok": true,
+            "id": parent.id,
+            "status": parent.status,
+            "epic": detail_body(&parent),
+            "tasks": children.iter().map(detail_body).collect::<Vec<_>>(),
+            "idempotent": true,
+        }))
+        .into_response(),
+        Some(Out::Created(parent, children)) => {
+            tracing::info!(
+                target: "amux::board",
+                epic = %parent.id,
+                worker = %actor,
+                children = children.len(),
+                dependency_edges = children.iter().map(|c| c.depends_on.len()).sum::<usize>(),
+                priorities = %children.iter().filter_map(|c| c.tags.iter().find(|t| t.starts_with('p'))).cloned().collect::<Vec<_>>().join(","),
+                "board capture decomposed atomically"
+            );
+            (
+                StatusCode::CREATED,
+                Json(json!({
+                    "ok": true,
+                    "id": parent.id,
+                    "status": parent.status,
+                    "epic": detail_body(&parent),
+                    "tasks": children.iter().map(detail_body).collect::<Vec<_>>(),
+                })),
+            )
+                .into_response()
+        }
+        None => internal("decompose produced no outcome"),
     }
 }
 
@@ -6752,11 +7078,21 @@ async fn list_verifications(
 // Artifact CRUD (Phase 3a): per-task artifact registry.
 // ---------------------------------------------------------------------------
 
+fn artifact_value(r: &crate::db::artifact_store::ArtifactRow) -> Value {
+    json!({
+        "id": r.id,
+        "task_id": r.task_id,
+        "kind": r.kind,
+        "ref": r.ref_value,
+        "state": r.state,
+        "description": r.description,
+        "created_at": r.created_at,
+        "updated_at": r.updated_at,
+    })
+}
+
 /// GET /api/board/{id}/artifacts
-async fn list_artifacts(
-    State(state): State<AppState>,
-    Path(id): Path<String>,
-) -> Response {
+async fn list_artifacts(State(state): State<AppState>, Path(id): Path<String>) -> Response {
     let conn = match state.store.read() {
         Ok(c) => c,
         Err(e) => return (StatusCode::SERVICE_UNAVAILABLE, e.to_string()).into_response(),
@@ -6768,18 +7104,7 @@ async fn list_artifacts(
         Ok(r) => r,
         Err(e) => return (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     };
-    let items: Vec<Value> = rows.iter().map(|r| {
-        json!({
-            "id": r.id,
-            "task_id": r.task_id,
-            "kind": r.kind,
-            "ref": r.ref_value,
-            "state": r.state,
-            "description": r.description,
-            "created_at": r.created_at,
-            "updated_at": r.updated_at,
-        })
-    }).collect();
+    let items: Vec<Value> = rows.iter().map(artifact_value).collect();
     (StatusCode::OK, Json(json!(items))).into_response()
 }
 
@@ -6787,6 +7112,7 @@ async fn list_artifacts(
 async fn create_artifact(
     State(state): State<AppState>,
     Path(id): Path<String>,
+    headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> Response {
     let kind = match body.get("kind").and_then(|v| v.as_str()) {
@@ -6803,36 +7129,88 @@ async fn create_artifact(
     };
     let state_val = body.get("state").and_then(|v| v.as_str()).unwrap_or("created").to_string();
     let desc = body.get("description").and_then(|v| v.as_str()).map(|s| s.to_string());
+    if !crate::db::artifact_store::KNOWN_KINDS.contains(&kind.as_str()) {
+        return (StatusCode::BAD_REQUEST, Json(json!({
+            "error": "unknown artifact kind",
+            "kind": kind,
+            "valid_kinds": crate::db::artifact_store::KNOWN_KINDS,
+        }))).into_response();
+    }
+    if !crate::db::artifact_store::ARTIFACT_STATES.contains(&state_val.as_str()) {
+        return (StatusCode::BAD_REQUEST, Json(json!({
+            "error": "unknown artifact state",
+            "state": state_val,
+            "valid_states": crate::db::artifact_store::ARTIFACT_STATES,
+        }))).into_response();
+    }
+    let (_, actor) = actor_from_headers(&headers);
     let now = chrono::Utc::now().timestamp();
     let aid = format!("ART-{}", ulid::Ulid::new().to_string().to_lowercase());
     let row = crate::db::artifact_store::ArtifactRow {
         id: aid.clone(),
         task_id: id.clone(),
-        kind,
-        ref_value,
-        state: state_val,
+        kind: kind.clone(),
+        ref_value: ref_value.clone(),
+        state: state_val.clone(),
         description: desc,
         created_at: now,
         updated_at: now,
     };
     let aid_out = aid.clone();
+    let actor_w = actor.clone();
+    let kind_w = row.kind.clone();
+    let state_w = row.state.clone();
+    let ref_w = row.ref_value.clone();
+    let task_id_w = id.clone();
     let write = state.store.write_async(move |conn| {
-        if bs::get_issue(conn, &id).ok().flatten().is_none() {
+        let Some(mut task) = bs::get_issue(conn, &task_id_w)? else {
             return Err(rusqlite::Error::QueryReturnedNoRows);
-        }
+        };
         crate::db::artifact_store::insert(conn, &row)?;
+        let stamp = chrono::Local::now().format("%H:%M").to_string();
+        task.log = Some(bs::append_log(
+            task.log.as_deref(),
+            &stamp,
+            &format!("artifact ({actor_w}): {kind_w}/{state_w} {ref_w}"),
+        ));
+        task.updated = now;
+        task.rev += 1;
+        task.version += 1;
+        bs::save_patched(conn, &mut task)?;
         Ok(crate::db::WriteOutcome {
             applied: true,
-            events: vec![crate::db::PendingEvent {
-                entity_type: amux_core::revision::EntityType::Other("artifact".into()),
-                entity_id: aid.clone(),
-                mutation: amux_core::revision::MutationKind::Created,
-                payload: None,
-            }],
+            events: vec![
+                crate::db::PendingEvent {
+                    entity_type: amux_core::revision::EntityType::Other("artifact".into()),
+                    entity_id: aid.clone(),
+                    mutation: amux_core::revision::MutationKind::Created,
+                    payload: None,
+                },
+                ev_snap(&task, MutationKind::Updated),
+            ],
         })
     }).await;
     match write {
-        Ok(_) => (StatusCode::CREATED, Json(json!({"id": aid_out}))).into_response(),
+        Ok(_) => {
+            tracing::info!(
+                target: "amux::board",
+                task = %id,
+                artifact = %aid_out,
+                worker = %actor,
+                kind = %kind,
+                state = %state_val,
+                reference = %ref_value,
+                "board task artifact registered"
+            );
+            (StatusCode::CREATED, Json(json!({
+                "id": aid_out,
+                "task_id": id,
+                "kind": kind,
+                "ref": ref_value,
+                "state": state_val,
+                "actor": actor,
+            }))).into_response()
+        }
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }

--- a/crates/amux-server/src/api/request_log.rs
+++ b/crates/amux-server/src/api/request_log.rs
@@ -1339,6 +1339,7 @@ pub const ROUTE_TABLE: &[RouteEntry] = &[
     // scanned only api/mod.rs's own .route() calls.
     RouteEntry { path: "/api/board/contract", methods: &["GET"] },
     RouteEntry { path: "/api/board/ready", methods: &["GET"] },
+    RouteEntry { path: "/api/board/{id}/decompose", methods: &["POST"] },
     RouteEntry { path: "/api/board/needsyou", methods: &["GET"] },
     RouteEntry { path: "/api/schedules/{id}/skip", methods: &["POST"] },
     RouteEntry { path: "/api/search", methods: &["GET"] },

--- a/crates/amux-server/src/runtime_jobs/board_drive.rs
+++ b/crates/amux-server/src/runtime_jobs/board_drive.rs
@@ -79,7 +79,9 @@ use serde_json::{json, Value};
 
 use crate::api::AppState;
 use crate::db::board_store as bs;
+use crate::db::PendingEvent;
 use amux_core::board::TaskStatus;
+use amux_core::revision::{EntityType, MutationKind};
 
 /// Sweep cadence. Python's level sweep ran every 300s behind an idle EDGE that
 /// fired immediately; with no edge, 300s would mean a lane finishing a turn
@@ -636,6 +638,10 @@ pub struct DriveReport {
     /// (ethos rule 4 — a count that can read zero must publish whether the
     /// measurement ran).
     pub revisit_due_total: usize,
+    /// Epic capture roots completed this tick because every linked child is in
+    /// a terminal state. Without this, the original Messages chip remains
+    /// permanently non-terminal after all of the actual work has finished.
+    pub completed_epics: usize,
     pub lanes: Vec<LaneTrace>,
 }
 
@@ -1818,6 +1824,172 @@ async fn promote_ready_backlog(state: &AppState) -> (usize, usize) {
         }
     }
     (promoted, held_on_trigger)
+}
+
+fn child_terminal_for_epic(status: &str) -> bool {
+    matches!(
+        status.trim().to_ascii_lowercase().as_str(),
+        "done" | "verified" | "discarded" | "quarantined"
+    )
+}
+
+fn epic_completion_candidates(conn: &Connection) -> Vec<(String, Vec<(String, String)>)> {
+    let epic_ids = conn
+        .prepare(
+            "SELECT id FROM issues WHERE type='epic' AND deleted IS NULL \
+             AND COALESCE(archived,0)=0 AND status NOT IN ('done','verified','discarded','quarantined') \
+             ORDER BY created,id",
+        )
+        .and_then(|mut stmt| {
+            stmt.query_map([], |r| r.get::<_, String>(0))
+                .map(|rows| rows.flatten().collect::<Vec<_>>())
+        })
+        .unwrap_or_default();
+    epic_ids
+        .into_iter()
+        .filter_map(|epic| {
+            let children = conn
+                .prepare(
+                    "SELECT id,status FROM issues WHERE epic=?1 AND deleted IS NULL \
+                     AND COALESCE(archived,0)=0 ORDER BY created,id",
+                )
+                .and_then(|mut stmt| {
+                    stmt.query_map(rusqlite::params![epic], |r| {
+                        Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+                    })
+                    .map(|rows| rows.flatten().collect::<Vec<_>>())
+                })
+                .unwrap_or_default();
+            (!children.is_empty()
+                && children
+                    .iter()
+                    .all(|(_, status)| child_terminal_for_epic(status)))
+            .then_some((epic, children))
+        })
+        .collect()
+}
+
+/// Close every prompt-root epic whose children are all terminal. The parent is
+/// the id stored on the original message, so completing it is what makes the
+/// message's task chip report the state of the whole command rather than the
+/// state of whichever leaf happened to be created first.
+async fn complete_finished_epics(state: &AppState) -> usize {
+    let candidates = match state.store.read() {
+        Ok(conn) => epic_completion_candidates(&conn),
+        Err(_) => return 0,
+    };
+    let mut completed = 0;
+    for (epic, observed_children) in candidates {
+        let epic_w = epic.clone();
+        let reply = state
+            .store
+            .write_async(move |conn| {
+                let current = epic_completion_candidates(conn)
+                    .into_iter()
+                    .find(|(id, _)| id == &epic_w);
+                let Some((_, children)) = current else {
+                    return Ok(crate::db::WriteOutcome {
+                        applied: false,
+                        events: vec![],
+                    });
+                };
+                let Some(mut parent) = bs::get_issue(conn, &epic_w)? else {
+                    return Ok(crate::db::WriteOutcome {
+                        applied: false,
+                        events: vec![],
+                    });
+                };
+                let summary = children
+                    .iter()
+                    .map(|(id, status)| format!("{id}={status}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let now = chrono::Utc::now().timestamp();
+                let stamp = chrono::Local::now().format("%H:%M").to_string();
+                parent.evidence = Some(format!("all epic children terminal: {summary}"));
+                parent.last_result = Some(format!("Completed child plan: {summary}"));
+                parent.next_action = None;
+                parent.updated = now;
+                parent.rev += 1;
+                parent.version += 1;
+                parent.log = Some(bs::append_log(
+                    parent.log.as_deref(),
+                    &stamp,
+                    &format!("all child tasks terminal ({summary}); completing epic"),
+                ));
+                bs::save_patched(conn, &mut parent)?;
+                let mut events = vec![PendingEvent {
+                    entity_type: EntityType::Task,
+                    entity_id: parent.id.clone(),
+                    mutation: MutationKind::Updated,
+                    payload: Some(parent.snapshot()),
+                }];
+                let opts = crate::db::advance::AdvanceOpts {
+                    expected_from: Some(parent.status.clone()),
+                    gate_ack: true,
+                    skip_continuation: true,
+                    log_line: Some("status: epic -> done (all children terminal)".into()),
+                    ..Default::default()
+                };
+                match crate::db::advance::advance(conn, &parent.id, "done", "board_drive", &opts)? {
+                    Ok(out) => {
+                        events.extend(out.events);
+                        Ok(crate::db::WriteOutcome {
+                            applied: true,
+                            events,
+                        })
+                    }
+                    Err(_) => Ok(crate::db::WriteOutcome {
+                        applied: false,
+                        events: vec![],
+                    }),
+                }
+            })
+            .await;
+        if matches!(reply, Ok(r) if r.applied) {
+            completed += 1;
+            let children = observed_children
+                .iter()
+                .map(|(id, status)| format!("{id}={status}"))
+                .collect::<Vec<_>>()
+                .join(",");
+            tracing::info!(
+                target: "amux::board_drive",
+                %epic,
+                %children,
+                "board_drive: completed epic — every linked child is terminal"
+            );
+        }
+    }
+    completed
+}
+
+#[cfg(test)]
+mod epic_completion_unit_tests {
+    use super::*;
+
+    #[test]
+    fn epic_completes_only_after_every_child_is_terminal() {
+        let conn = crate::db::migrate::test_memdb();
+        conn.execute_batch(
+            "INSERT INTO issues (id,title,status,type,created,updated,owner_type) \
+             VALUES ('E-1','root','doing','epic',1,1,'agent');
+             INSERT INTO issues (id,title,status,type,epic,created,updated,owner_type) \
+             VALUES ('C-1','one','done','code','E-1',2,2,'agent');
+             INSERT INTO issues (id,title,status,type,epic,created,updated,owner_type) \
+             VALUES ('C-2','two','todo','code','E-1',3,3,'agent');
+             INSERT INTO issues (id,title,status,type,created,updated,owner_type) \
+             VALUES ('E-EMPTY','empty','doing','epic',4,4,'agent');",
+        )
+        .unwrap();
+        assert!(epic_completion_candidates(&conn).is_empty());
+        conn.execute("UPDATE issues SET status='verified' WHERE id='C-2'", [])
+            .unwrap();
+        let got = epic_completion_candidates(&conn);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].0, "E-1");
+        assert_eq!(got[0].1.len(), 2);
+    }
 }
 
 /// The revisit-date arm: promote `backlog` cards whose own due date arrived,
@@ -3243,6 +3415,13 @@ fn pickup_prompt(conn: &Connection, session: &str, row: &bs::IssueRow) -> String
         quoted_card_text(&row.title, &row.id),
         qnote
     );
+    prompt.push_str(&format!(
+        "\n\n[worker contract] Post material actions with `amux board status-update {} \
+         --stdin`. Register every file, URL, commit, PR, screenshot or test asset with \
+         `amux board artifact {} <ref>`. Finish this card, then keep driving ready \
+         todo/backlog work until no non-terminal task remains actionable.",
+        row.id, row.id
+    ));
     let full = format!("{}\n{}", row.desc, row.log.clone().unwrap_or_default());
     let full = full.trim();
     let cap = pickup_excerpt_chars();
@@ -3636,8 +3815,9 @@ pub fn select_advance_with(
             "[amux] {card_id} is a capture shell ({why}). Not blocking pickup, but not actionable either.\n\n\
              Not work? `amux board discard {card_id} --outcome-stdin`\n\
              One task? `amux board retitle {card_id} \"<title>\" --desc-stdin`\n\
-             Several? `amux board type {card_id} epic`, `amux board add \"<unit>\"`, \
-             `amux board epic <NEW-ID> {card_id}`"
+             Several? Produce the ordered JSON plan and run \
+             `amux board decompose {card_id} --stdin`. That single write preserves this \
+             message link and requires each child's dependencies, p0-p3 priority, and next action."
         );
         return Advance::Nudge {
             target: session.to_string(),
@@ -4192,6 +4372,9 @@ pub async fn drive_tick<F: Fleet>(state: &AppState, fleet: &F) -> DriveReport {
         started_at: now_f64(),
         ..Default::default()
     };
+    // Complete root epics before dispatch so the Messages chip and the board
+    // agree that a command is finished as soon as all of its leaves are.
+    report.completed_epics = complete_finished_epics(state).await;
     // DRIVE TO VERIFIED, BEFORE DISPATCH. A card parked in `backlog` on a
     // `depends_on` dependency re-activates to `todo` the moment every dependency
     // reaches a terminal status, so a "do B after A" command completes instead
@@ -7551,8 +7734,15 @@ mod tests {
         // behaviour — and the sibling test one screen down had already learned
         // it: "a wording rewrite must be free; an exit losing its command must
         // not be" (AMUX-3707).
-        for cmd in ["amux board discard", "amux board retitle", "amux board type"] {
-            assert!(text.contains(cmd), "the ask must still reach its exit `{cmd}`: {text}");
+        for cmd in [
+            "amux board discard",
+            "amux board retitle",
+            "amux board decompose",
+        ] {
+            assert!(
+                text.contains(cmd),
+                "the ask must still reach its exit `{cmd}`: {text}"
+            );
         }
     }
 
@@ -8317,7 +8507,11 @@ mod tests {
                 // while the epic exit it was guarding named no command at all,
                 // because `amux board epic` did not exist (AMUX-3707). A wording
                 // rewrite must be free; an exit losing its command must not be.
-                for cmd in ["amux board discard", "amux board type", "amux board epic"] {
+                for cmd in [
+                    "amux board discard",
+                    "amux board retitle",
+                    "amux board decompose",
+                ] {
                     assert!(
                         text.contains(cmd),
                         "the decompose ask must reach its exit with `{cmd}`: {text}"

--- a/crates/amux-server/tests/board_api.rs
+++ b/crates/amux-server/tests/board_api.rs
@@ -176,6 +176,138 @@ async fn create_list_detail_lifecycle() {
     assert_eq!(v["creator"], json!("orch"));
 }
 
+#[tokio::test]
+async fn capture_decomposition_is_atomic_ordered_and_keeps_the_message_on_the_epic() {
+    let (app, store, _dir) = app_with_store();
+    store
+        .write(|conn| {
+            conn.execute(
+                "INSERT INTO issues \
+                 (id,title,desc,status,session,type,creator,owner_type,source,created,updated) \
+                 VALUES ('ATE-1','Captured request','**Prompt:** build and verify it', \
+                         'doing','amux-testing-e2e','code','amux','agent','capture',1,1)",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO cmd_history (id,text,type,session,ts,origin,card_id) \
+                 VALUES (39225,'build and verify it','user','amux-testing-e2e',1000,'browser','ATE-1')",
+                [],
+            )?;
+            conn.execute(
+                "INSERT INTO issue_counters (prefix,next_n) VALUES ('ATE',2)",
+                [],
+            )?;
+            Ok(amux_server::db::WriteOutcome { applied: true, events: vec![] })
+        })
+        .unwrap();
+
+    let plan = json!({"tasks":[
+        {"title":"Implement the change","description":"Build the requested behavior.",
+         "type":"code","priority":0,"depends_on":[],"next_action":"Implement the requested behavior"},
+        {"title":"Verify the change","description":"Exercise the complete flow.",
+         "type":"investigation","priority":1,"depends_on":[1],"next_action":"Run the end to end verification"},
+        {"title":"Document the result","description":"Record the verified outcome.",
+         "type":"doc","priority":2,"depends_on":[2],"next_action":"Write the final result summary"}
+    ]});
+    let (st, _, made) = send_with(
+        &app,
+        "POST",
+        "/api/board/ATE-1/decompose",
+        Some(plan.clone()),
+        &[("X-Amux-Worker", "amux-testing-e2e")],
+    )
+    .await;
+    assert_eq!(st, StatusCode::CREATED, "{made}");
+    assert_eq!(made["epic"]["type"], json!("epic"));
+    let tasks = made["tasks"].as_array().unwrap();
+    assert_eq!(tasks.len(), 3);
+    assert_eq!(tasks[0]["status"], json!("todo"));
+    assert_eq!(tasks[1]["status"], json!("backlog"));
+    assert_eq!(tasks[1]["depends_on"], json!([tasks[0]["id"].clone()]));
+    assert_eq!(tasks[2]["depends_on"], json!([tasks[1]["id"].clone()]));
+    assert_eq!(tasks[0]["tags"], json!(["p0"]));
+    assert_eq!(tasks[1]["epic"], json!("ATE-1"));
+    assert_eq!(tasks[0]["session"], json!("amux-testing-e2e"));
+
+    let (st, _, detail) = send(&app, "GET", "/api/board/ATE-1", None).await;
+    assert_eq!(st, StatusCode::OK);
+    assert_eq!(detail["children"].as_array().unwrap().len(), 3);
+    assert_eq!(detail["messages"][0]["id"], json!(39225));
+    assert_eq!(detail["messages"][0]["card_id"], json!("ATE-1"));
+
+    let first_id = tasks[0]["id"].as_str().unwrap();
+    let (st, _, artifact) = send(
+        &app,
+        "POST",
+        &format!("/api/board/{first_id}/artifacts"),
+        Some(json!({"kind":"implementation","ref":"/tmp/result.md","state":"created"})),
+    )
+    .await;
+    assert_eq!(st, StatusCode::CREATED, "{artifact}");
+    let (_, _, child_detail) = send(&app, "GET", &format!("/api/board/{first_id}"), None).await;
+    assert_eq!(child_detail["epic"], json!("ATE-1"));
+    assert_eq!(child_detail["messages"][0]["id"], json!(39225));
+    assert_eq!(child_detail["artifacts"][0]["ref"], json!("/tmp/result.md"));
+    assert!(
+        child_detail["log"].as_str().unwrap().contains("artifact (api-anonymous): implementation/created /tmp/result.md"),
+        "artifact registration must be part of the task action history: {child_detail}"
+    );
+
+    // A retry is idempotent: it reports the existing plan instead of minting
+    // a second set of leaves after a client loses the first response.
+    let (st, _, retried) = send_with(
+        &app,
+        "POST",
+        "/api/board/ATE-1/decompose",
+        Some(plan),
+        &[("X-Amux-Worker", "amux-testing-e2e")],
+    )
+    .await;
+    assert_eq!(st, StatusCode::OK);
+    assert_eq!(retried["idempotent"], json!(true));
+    assert_eq!(retried["tasks"].as_array().unwrap().len(), 3);
+}
+
+#[tokio::test]
+async fn invalid_decomposition_creates_no_partial_children() {
+    let (app, store, _dir) = app_with_store();
+    store
+        .write(|conn| {
+            conn.execute(
+                "INSERT INTO issues \
+                 (id,title,desc,status,session,type,creator,owner_type,source,created,updated) \
+                 VALUES ('ATE-9','Captured request','**Prompt:** bad plan','doing','lane', \
+                         'code','amux','agent','capture',1,1)",
+                [],
+            )?;
+            Ok(amux_server::db::WriteOutcome {
+                applied: true,
+                events: vec![],
+            })
+        })
+        .unwrap();
+    let (st, _, body) = send_with(
+        &app,
+        "POST",
+        "/api/board/ATE-9/decompose",
+        Some(json!({"tasks":[
+            {"title":"First","priority":0,"depends_on":[],"next_action":"Implement the first step"},
+            {"title":"Second","priority":1,"depends_on":[2],"next_action":"Implement the second step"}
+        ]})),
+        &[("X-Amux-Worker", "lane")],
+    )
+    .await;
+    assert_eq!(st, StatusCode::BAD_REQUEST, "{body}");
+    let children: i64 = store
+        .read()
+        .unwrap()
+        .query_row("SELECT COUNT(*) FROM issues WHERE epic='ATE-9'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(children, 0);
+}
+
 // ---- List payload shapes: slim by default, prose on request --------------
 //
 // History, because this contract moved TWICE and each move was deliberate.

--- a/crates/amux-server/tests/dashboard_assets.rs
+++ b/crates/amux-server/tests/dashboard_assets.rs
@@ -216,3 +216,51 @@ fn the_auto_compact_copy_states_the_threshold_the_server_actually_uses() {
         "copy still names 50% while the constant is {pct}: {line}"
     );
 }
+
+#[test]
+fn board_create_uses_the_server_field_names() {
+    let app = asset("app.js");
+    let start = app
+        .find("async function addBoardItem(")
+        .expect("addBoardItem exists");
+    let tail = &app[start..];
+    let end = tail.find("\n}\n").expect("addBoardItem closes") + 3;
+    let body = &tail[..end];
+    assert!(
+        body.contains("session: worker || ''"),
+        "board create must send `session`: {body}"
+    );
+    assert!(
+        body.contains("tags: groups || []"),
+        "board create must send `tags`: {body}"
+    );
+    assert!(
+        !body.contains("worker: worker || ''") && !body.contains("groups: groups || []"),
+        "`worker`/`groups` are UI names, not POST /api/board fields; the server reports them ignored"
+    );
+}
+
+#[test]
+fn board_detail_hydration_refreshes_authoritative_state_and_relations() {
+    let app = asset("app.js");
+    let start = app
+        .find("async function _bdHydrate(")
+        .expect("_bdHydrate exists");
+    let tail = &app[start..];
+    let end = tail
+        .find("\n}\n\nfunction openBoardDetail")
+        .expect("_bdHydrate closes");
+    let body = &tail[..end];
+    for needle in [
+        "boardDetailStatus = full.status",
+        "_populateSessionSelect('bd-session', full.session",
+        "_bdRenderMeta(merged)",
+        "full.due_time",
+        "full.tags",
+    ] {
+        assert!(
+            body.contains(needle),
+            "hydration still leaves `{needle}` stale"
+        );
+    }
+}

--- a/crates/amux-server/tests/nudge_commands_exist.rs
+++ b/crates/amux-server/tests/nudge_commands_exist.rs
@@ -152,13 +152,16 @@ fn every_board_command_the_server_tells_a_lane_to_run_actually_dispatches() {
          broken, not the code"
     );
 
-    // And a POSITIVE control: the specimen this test was written for must be in
-    // the extraction. If `epic` stops being found, the extractor regressed.
+    // And a POSITIVE control: the current atomic multi-task exit must be in the
+    // extraction. If `decompose` stops being found, the extractor regressed.
     assert!(
-        named.iter().any(|(v, _)| v == "epic"),
-        "the AMUX-3707 specimen (`amux board epic`) is not in the extraction — extractor \
+        named.iter().any(|(v, _)| v == "decompose"),
+        "the capture-shell exit (`amux board decompose`) is not in the extraction — extractor \
          regressed.\nfound: {:?}",
-        named.iter().map(|(v, _)| v.as_str()).collect::<BTreeSet<_>>()
+        named
+            .iter()
+            .map(|(v, _)| v.as_str())
+            .collect::<BTreeSet<_>>()
     );
 
     // ...and the NEGATIVE control, which is the half that proves the test-module

--- a/frustrations.md
+++ b/frustrations.md
@@ -3477,3 +3477,68 @@ FIX: manually re-ran install.sh's own install_hook_from_head sequence for both
   real options (a systemd timer polling install.sh's hook block the way
   amux-builder.timer polls the Rust build, or the invariant self-healing since
   it already computes the right bytes) — a design choice, not made here.
+
+## A multi-part prompt became unrelated leaves and the message reported only the first leaf
+AREA: scheduler
+SEVERITY: blocks
+STATUS: fixed
+DATE: 2026-09-02
+SESSION: amux-testing-e2e
+CARD: ATE-1
+SYMPTOM: MSG-39225 captured as ATE-1, then the worker hand-created ATE-2 and
+  ATE-3 without an epic, structured dependency edge, or priority. The scheduler
+  selected ATE-3 before ATE-2, hit the WIP gate, and repaired the ordering only
+  after the refusal. The Messages chip stayed attached to ATE-1, which had been
+  reshaped as one leaf and reached done while the rest of the command remained open.
+COST: A supposedly automatic command required manual plan reconstruction; the
+  source message gave a false completion signal and work ran in the wrong order.
+FIX: e139be2d adds one attributed, idempotent decomposition transaction. The
+  capture remains the message-linked epic; children require p0-p3 priority,
+  earlier-step dependencies, concrete next actions and a common owner. The drive
+  loop completes the epic when all children are terminal.
+
+## Board create visibly selected an owner and groups, then the server discarded both
+AREA: board
+SEVERITY: blocks
+STATUS: fixed
+DATE: 2026-09-02
+SESSION: amux-testing-e2e
+CARD: AMUX-4047
+SYMPTOM: Creating a card in the dashboard with worker amux-testing-e2e and groups
+  selected produced `Not saved: server ignored groups, worker`; AMUX-4047 and
+  AMUX-4048 landed as duplicate, unowned backlog cards with no tags.
+COST: Two junk cards were created during one browser audit, and neither could be
+  driven by the worker the UI showed as selected.
+FIX: e139be2d makes both optimistic state and POST/PATCH payloads use the server's
+  real `session` and `tags` fields, with a static regression check at the wire boundary.
+
+## Opening a fresh board card showed older status, owner and history than the board itself
+AREA: board
+SEVERITY: slows
+STATUS: fixed
+DATE: 2026-09-02
+SESSION: amux-testing-e2e
+CARD: ATE-3
+SYMPTOM: The board list showed ATE-3 done, but its detail view showed To Do or In
+  Progress, owner none, `No status posted yet`, and empty History while Lineage
+  showed 29 events. The detail GET arrived, but hydration refreshed only desc/log.
+COST: The audit had to cross-check list, detail and lineage for every transition;
+  any single surface supported the wrong conclusion.
+FIX: e139be2d refreshes every authoritative detail field when the user has not
+  edited it, and renders one linked view of epic, children, dependencies, source
+  messages, work summary and artifacts.
+
+## Task artifacts existed outside the task's attributed action history
+AREA: attribution
+SEVERITY: slows
+STATUS: fixed
+DATE: 2026-09-02
+SESSION: amux-testing-e2e
+CARD: ATE-2
+SYMPTOM: The structured artifact API existed, but workers had no board CLI verb
+  for it and registering an artifact did not add an attributed action to the task log.
+COST: Files, URLs, commits and screenshots fell back to prose; the task could not
+  answer who attached an asset or expose it as a direct link in detail.
+FIX: e139be2d adds `amux board artifact`, validates artifact kind/state, appends an
+  attributed task-history event, emits a greppable registration log, and returns
+  artifacts in the authoritative task detail response.


### PR DESCRIPTION
## Summary

This fixes the end-to-end task lifecycle failures reproduced in the browser with worker amux-testing-e2e.

- Adds one atomic, attributed, idempotent board decomposition operation and CLI command.
- Preserves the captured prompt as the message-linked epic while creating ordered child tasks with p0-p3 priority, structured dependencies, concrete next actions, and the same worker owner.
- Drives root epics to done automatically once every child is terminal.
- Tells picked-up workers to post material actions, register artifacts, finish the card, and continue through ready todo/backlog work.
- Exposes epic/children, source messages, work summary, dependencies, and artifacts in authoritative task detail.
- Adds an artifact CLI command, validates artifact kind/state, and appends attributed artifact actions to task history.
- Fixes dashboard create/edit payloads to send the server fields session and tags.
- Makes detail hydration refresh status, owner, title, due date/time, gate, tags, history, summary, and relations without overwriting active user edits.
- Bumps dashboard and service-worker cache version to 0.9.773.

## Browser findings covered

1. ATE-1 / MSG-39225: a multi-part command became unrelated leaves. It had no epic, dependency graph, or priority; the scheduler selected ATE-3 before ATE-2, hit the WIP gate, and the Messages chip reported only the first leaf completion.
2. AMUX-4047 / AMUX-4048: board create showed a selected worker and groups but sent worker/groups; the server ignored both and created duplicate unowned backlog cards.
3. ATE-3: card detail showed older status, owner, and history than the board list and lineage because hydration refreshed only description and log.
4. ATE-2: artifacts existed as a disconnected API: no worker-facing CLI, no attributed task-history action, and no links in task detail.

The evidence and transition gates themselves behaved correctly during the audit. This PR routes the new lifecycle through those gates rather than weakening them.

## Verification

- cargo test -p amux-server --test board_api: 63 passed
- Atomic decomposition, invalid-plan rollback, retry idempotency, message linkage, child relations, artifact history and link tests
- Epic completion scheduler unit test
- Dashboard asset, field, and hydration tests: 8 passed
- CLI nudge command existence and discoverability tests: 2 passed
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- JavaScript and shell syntax checks
- frustrations audit: 29 passed
