### PR TITLE
fix: preserve board truth across model switches

### DIFF
--- a/crates/amux-core/src/board.rs
+++ b/crates/amux-core/src/board.rs
@@ -1118,14 +1118,19 @@ const CAPTURE_FILLER: [&str; 19] = [
 /// means "do not mint a ledger card", not "untitled".
 pub fn title_from_prompt(text: &str) -> Option<String> {
     let mut t = text.trim();
-    // Explicit opt-out marker, checked BEFORE stamp-stripping so the marker
-    // itself is never mistaken for a timestamp prefix.
-    let lower_all = t.to_lowercase();
-    if lower_all.starts_with("[no-board]") || lower_all.starts_with("[no_board]") {
-        return None;
-    }
-    // Drop leading "[03:47 PM] " / "[amux-origin: ...]" style stamps.
-    while t.starts_with('[') {
+    // Drop leading "[03:47 PM] " / "[amux-origin: ...]" style stamps, but
+    // recognize the opt-out marker at EVERY layer. Dashboard sends are stamped
+    // before capture, so checking only the raw prefix turned
+    // `[08:51 AM] [no-board] ...` into a normal task after the loop stripped
+    // both brackets (ATE-27).
+    loop {
+        let lower = t.to_lowercase();
+        if lower.starts_with("[no-board]") || lower.starts_with("[no_board]") {
+            return None;
+        }
+        if !t.starts_with('[') {
+            break;
+        }
         match t.find(']') {
             Some(i) => t = t[i + 1..].trim_start(),
             None => break,
@@ -1337,21 +1342,18 @@ pub fn is_informational_query(text: &str) -> bool {
         .trim()
         .trim_end_matches(['.', '!', ';', ' ']);
     // A second clause normally means the prompt has work after the question.
-    // Preserve the explicit non-mutating tails people naturally add when they
-    // want only an answer.
+    // Preserve explicit non-mutating tails people naturally add when they want
+    // only an answer. This is grammatical rather than an exact sentence list:
+    // `do not change files or create board work` means the same thing as `do
+    // not change anything`, and an opt-out contract must not depend on one
+    // memorized phrasing.
     if !tail.is_empty() {
-        const ANSWER_ONLY_TAILS: &[&str] = &[
-            "answer only", "just answer", "please answer only", "no changes",
-            "do not change anything", "don't change anything", "do not make changes",
-            "don't make changes", "please answer only; do not change anything",
-            "please answer only; don't change anything",
-        ];
         const QUESTION_TAILS: &[&str] = &[
             "are ", "can ", "could ", "did ", "do ", "does ", "has ", "have ", "how ",
             "is ", "should ", "was ", "were ", "what ", "when ", "where ", "which ",
             "who ", "why ", "will ", "would ",
         ];
-        if !ANSWER_ONLY_TAILS.contains(&tail)
+        if !is_non_mutating_answer_tail(tail)
             && !(tail.ends_with('?') && QUESTION_TAILS.iter().any(|p| tail.starts_with(p)))
         {
             return false;
@@ -1398,6 +1400,49 @@ pub fn is_informational_query(text: &str) -> bool {
         "should ", "was ", "were ", "will ", "would ",
     ];
     YES_NO_QUESTIONS.iter().any(|p| question.starts_with(p))
+}
+
+/// Whether every clause after a question explicitly asks for an answer and/or
+/// forbids mutation. Unknown clauses fail closed to WORK so this helper cannot
+/// silently swallow an imperative.
+fn is_non_mutating_answer_tail(tail: &str) -> bool {
+    const ANSWER_ONLY: &[&str] = &["answer only", "just answer", "please answer only"];
+    const MUTATION_WORDS: &[&str] = &[
+        "change", "changes", "edit", "modify", "write", "create", "delete", "run",
+        "build", "fix", "make", "file", "files", "commit", "push", "deploy", "board",
+        "task", "tasks", "work",
+    ];
+
+    let mut saw_clause = false;
+    for raw in tail.split(';') {
+        let clause = raw.trim().trim_end_matches(['.', '!', ' ']);
+        if clause.is_empty() {
+            continue;
+        }
+        saw_clause = true;
+        if ANSWER_ONLY.contains(&clause) || matches!(clause, "no changes" | "make no changes") {
+            continue;
+        }
+        let negated = clause
+            .strip_prefix("please do not ")
+            .or_else(|| clause.strip_prefix("please don't "))
+            .or_else(|| clause.strip_prefix("do not "))
+            .or_else(|| clause.strip_prefix("don't "));
+        let Some(scope) = negated else { return false };
+        if !MUTATION_WORDS.iter().any(|word| scope.split_whitespace().any(|w| {
+            w.trim_matches(|c: char| !c.is_ascii_alphanumeric()) == *word
+        })) {
+            return false;
+        }
+        // Negation ended before a new imperative: do not edit X, then deploy Y.
+        if [", then ", ". then ", " and then "]
+            .iter()
+            .any(|marker| scope.contains(marker))
+        {
+            return false;
+        }
+    }
+    saw_clause
 }
 
 /// Bare demonstratives/pronouns: words whose referent lives OUTSIDE the title.
@@ -1571,6 +1616,12 @@ mod capture_tests {
             None,
             "explicit opt-out"
         );
+        for stamped in [
+            "[08:51 AM] [no-board] What is backlog? Answer only.",
+            "[amux-origin: dashboard] [no_board] Explain this without making changes.",
+        ] {
+            assert_eq!(title_from_prompt(stamped), None, "stamped opt-out: {stamped}");
+        }
     }
 
     #[test]
@@ -1616,6 +1667,8 @@ mod capture_tests {
         for s in [
             "What is the difference between todo and backlog on this board?",
             "What is the difference between todo and backlog? Please answer only; do not change anything.",
+            "What is the difference between todo and backlog? Answer only; do not change files or create board work.",
+            "What is backlog? Please do not edit files, create tasks, or run commands.",
             "How does the Done gate work?",
             "Can you explain why ATE-10 is linked to ATE-11?",
             "Is the board source of truth the issue row or the message?",
@@ -1635,6 +1688,7 @@ mod capture_tests {
             "what broke; fix the failing test?",
             "why is the build red — investigate the failure?",
             "what broke? please diagnose it",
+            "what broke? do not edit the docs; then fix the implementation",
             "why did this fail and can you reproduce it?",
             "is it done? if not, add a retry to the fetch",
             "write an explanation to docs/status.md",

--- a/crates/amux-dashboard/static/app.css
+++ b/crates/amux-dashboard/static/app.css
@@ -180,7 +180,10 @@
   .card-menu {
     display: none; position: fixed;
     background: var(--card); border: 1px solid var(--border);
-    border-radius: 10px; min-width: 200px; z-index: 50;
+    /* Menus can open upward into the global approval strip. Keep them above
+       that in-flow strip (90), but below full-screen overlays (100+), so a
+       pending permission request never makes worker actions unclickable. */
+    border-radius: 10px; min-width: 200px; z-index: 95;
     box-shadow: 0 8px 24px rgba(0,0,0,0.4);
     overflow-x: hidden; overflow-y: auto; max-height: 500px;
   }
@@ -2108,10 +2111,10 @@
   /* In-progress board issues for this worker: informational, so accent rather
      than a success/failure colour — it is a count, not a verdict. */
   .meta-count .mc-doing { color: var(--accent); font-weight: 700; }
-  /* Total board items: deliberately DIMMER than .mc-doing. Both sit in the same
-     bare-number row, and if the larger number (total is always >= doing) were
-     the brighter one it would read as the more urgent figure. Doing is what
-     wants attention. */
+  /* Todo is actionable but not running; later lifecycle states stay dimmer
+     than .mc-doing so the running count remains the most urgent figure. The
+     legacy class names remain for compatible themes; renderer-specific
+     mc-todo/mc-backlog classes make the status semantics explicit. */
   .meta-count .mc-active { color: var(--green, #4ade80); font-weight: 700; }
   .meta-count .mc-total { color: var(--dim); font-weight: 600; }
   /* Session card: scrollback cached on this device (readable with no signal). */

--- a/crates/amux-dashboard/static/app.js
+++ b/crates/amux-dashboard/static/app.js
@@ -8480,7 +8480,7 @@ async function saveGlobalMemory() {
   }
 }
 
-const APP_VER = '0.9.782';   // bump together with the sw.js CACHE version
+const APP_VER = '0.9.783';   // bump together with the sw.js CACHE version
 
 // ── No silent failures (Ethan, 2026-08-09: "make sure every action has some
 // kind of response in the ui — i just deleted a worker and nothing happened").
@@ -26487,11 +26487,23 @@ function openBoardDetail(id) {
 
 // ── Improved detail: status banner, typed History, permalink (AMUX-2178) ───
 function _bdParseHistory(log) {
-  // Each backtick-timestamped line becomes a typed event for styled rendering.
-  return (log || '').split('\n').filter(l => l.trim()).map(line => {
+  // A timestamp STARTS an event; wrapped/continued prose belongs to it until
+  // the next timestamp. Treating every physical line as an action turned one
+  // worker update into 115 sentence fragments on MR-137.
+  const grouped = [];
+  for (const line of (log || '').split('\n').filter(l => l.trim())) {
     const m = line.match(/^`(\d{1,2}:\d{2})`\s*(.*)$/);
     const ts = m ? m[1] : '';
     const body = m ? m[2] : line;
+    if (!m && grouped.length && grouped[grouped.length - 1].ts) {
+      grouped[grouped.length - 1].body += '\n' + body.trim();
+    } else {
+      grouped.push({ ts, body });
+    }
+  }
+  return grouped.map(e => {
+    const ts = e.ts;
+    const body = e.body;
     let kind = 'note';
     if (/^STATUS\s*\(/i.test(body)) kind = 'status';
     else if (/^status:\s/i.test(body)) kind = 'transition';

--- a/crates/amux-dashboard/static/app.js
+++ b/crates/amux-dashboard/static/app.js
@@ -8480,7 +8480,7 @@ async function saveGlobalMemory() {
   }
 }
 
-const APP_VER = '0.9.783';   // bump together with the sw.js CACHE version
+const APP_VER = '0.9.784';   // bump together with the sw.js CACHE version
 
 // ── No silent failures (Ethan, 2026-08-09: "make sure every action has some
 // kind of response in the ui — i just deleted a worker and nothing happened").
@@ -13655,6 +13655,28 @@ function _linkifyCardIds(safeHtml) {
         : m);
   } catch (e) { return safeHtml; }
 }
+
+// Schedule ids in Messages are navigation, not inert provenance. Scheduler
+// deliveries already stamp `[SCHED-N]` into origin; leaving that token as plain
+// text forced the reader to copy it, change tabs, and search manually. Load the
+// current schedule set before opening so a Messages-only visit is not dependent
+// on whether the Scheduler tab happened to be opened earlier.
+async function _openScheduleFromMessage(id) {
+  const sid = String(id || '');
+  if (!/^SCHED-\d+$/.test(sid)) return;
+  switchView('scheduler');
+  await Promise.all([fetchSchedules(), fetchSchedulerRuns(), fetchSchedulerAudit()]);
+  renderScheduler();
+  if ((schedules || []).some(s => s.id === sid && !s.deleted)) openSchedModal(sid);
+  else showToast(sid + ' is no longer active — see scheduler audit');
+}
+function _linkifyScheduleIds(safeHtml) {
+  try {
+    return String(safeHtml).replace(/\b(SCHED-\d+)\b/g, (m, id) =>
+      '<a href="javascript:void(0)" onclick="event.stopPropagation();_openScheduleFromMessage(\''
+      + id + '\')" style="color:var(--accent);text-decoration:underline dotted;">' + id + '</a>');
+  } catch (e) { return safeHtml; }
+}
 // Turn bare http(s) URLs in ALREADY-escaped HTML into clickable links, so a
 // resume / sign-in deep link an agent drops in a needs-you ask (AMUX-3073) is
 // clickable rather than dead plain text — the card's whole premise is a
@@ -13774,7 +13796,7 @@ function _cmdHistItemHTML(e, ctx) {
   // path — "Human · queued" vs plain "Human".
   const originTxt = kind === 'human'
     ? ''   // delivery chip below carries direct/queued for every kind now
-    : (origin ? ' &middot; ' + origin.replace(/&/g,'&amp;').replace(/</g,'&lt;').slice(0,32) : '');
+    : (origin ? ' &middot; ' + _linkifyScheduleIds(origin.replace(/&/g,'&amp;').replace(/</g,'&lt;').slice(0,32)) : '');
   const tag = `<span style="display:inline-block;font-size:0.7rem;font-weight:600;padding:1px 7px;border-radius:3px;background:${km.bg};color:${km.color};margin-right:6px;">${km.label}${originTxt}</span>`;
   const sessTag = session ? `<span style="color:var(--dim);font-size:0.7rem;margin-right:6px;">${session.replace(/&/g,'&amp;').replace(/</g,'&lt;')}</span>` : '';
   const tsTag = ts ? `<span style="color:var(--dim);font-size:0.7rem;">${ts}</span>` : '';
@@ -13797,7 +13819,7 @@ function _cmdHistItemHTML(e, ctx) {
   const _matches = _mq && safe.toLowerCase().includes(_mq.trim().toLowerCase());
   const _collapsed = _msgCollapsed.has(_pk) && !_matches;
   const caret = `<button class="msg-caret" aria-expanded="${!_collapsed}" title="${_collapsed ? 'Expand message' : 'Collapse message'}" onclick="_msgToggleCollapse(this,&#39;${escJs(_pk)}&#39;,event)">${_collapsed ? '&#9656;' : '&#9662;'}</button>`;
-  return `<div class="${ctx.rowClass||''}" data-msg-key="${esc(_pk)}" onclick="${ctx.onOpen ? ctx.onOpen(e, enc) : `_pickCmdHistory(decodeURIComponent('${enc}'))`}" title="Click to insert into the composer" style="cursor:pointer;padding:8px 12px;background:${km.bg};border:1px solid var(--border);border-left:3px solid ${km.color};border-radius:6px;font-size:0.85rem;color:var(--text);transition:border-color 0.15s;display:flex;gap:6px;align-items:flex-start;position:relative;" onmouseenter="this.style.borderColor='${km.color}'" onmouseleave="this.style.borderColor='var(--border)'"><input type="checkbox" class="pm-check" ${_psel?"checked":""} onclick="${ctx.toggle}(&#39;${escJs(_pk)}&#39;,event)" title="Select for bulk resend">${caret}<div style="flex:1;min-width:0;">${meta?`<div style="margin-bottom:4px;">${meta}</div>`:''}<div class="msg-body${_collapsed?' collapsed':''}" style="white-space:pre-wrap;word-break:break-word;line-height:1.45;">${_hlSearch(_linkifyCardIds(safe), _mq)}</div></div><div class="pm-actions"><button class="btn pm-dots" onclick="_msgMenu(this,event)" title="Actions">&#x22ef;</button><div class="msg-menu"><button onclick="event.stopPropagation();${ctx.resend}([&#39;${escJs(_pk)}&#39;])">Resend to ${esc(_target || 'session')}</button><button onclick="event.stopPropagation();_msgCopyBtn(this,&#39;${enc}&#39;)">Copy text</button><button onclick="event.stopPropagation();_ttsSpeak(decodeURIComponent(&#39;${enc}&#39;),this)">Read aloud</button>${locSess ? `<button onclick="event.stopPropagation();_msgLocate(&#39;${escJs(locSess)}&#39;,&#39;${enc}&#39;)" title="Open that worker's peek and scroll to where this was sent">Find in ${esc(locSess)}</button>` : ''}</div></div></div>`;
+  return `<div class="${ctx.rowClass||''}" data-msg-key="${esc(_pk)}" onclick="${ctx.onOpen ? ctx.onOpen(e, enc) : `_pickCmdHistory(decodeURIComponent('${enc}'))`}" title="Click to insert into the composer" style="cursor:pointer;padding:8px 12px;background:${km.bg};border:1px solid var(--border);border-left:3px solid ${km.color};border-radius:6px;font-size:0.85rem;color:var(--text);transition:border-color 0.15s;display:flex;gap:6px;align-items:flex-start;position:relative;" onmouseenter="this.style.borderColor='${km.color}'" onmouseleave="this.style.borderColor='var(--border)'"><input type="checkbox" class="pm-check" ${_psel?"checked":""} onclick="${ctx.toggle}(&#39;${escJs(_pk)}&#39;,event)" title="Select for bulk resend">${caret}<div style="flex:1;min-width:0;">${meta?`<div style="margin-bottom:4px;">${meta}</div>`:''}<div class="msg-body${_collapsed?' collapsed':''}" style="white-space:pre-wrap;word-break:break-word;line-height:1.45;">${_hlSearch(_linkifyScheduleIds(_linkifyCardIds(safe)), _mq)}</div></div><div class="pm-actions"><button class="btn pm-dots" onclick="_msgMenu(this,event)" title="Actions">&#x22ef;</button><div class="msg-menu"><button onclick="event.stopPropagation();${ctx.resend}([&#39;${escJs(_pk)}&#39;])">Resend to ${esc(_target || 'session')}</button><button onclick="event.stopPropagation();_msgCopyBtn(this,&#39;${enc}&#39;)">Copy text</button><button onclick="event.stopPropagation();_ttsSpeak(decodeURIComponent(&#39;${enc}&#39;),this)">Read aloud</button>${locSess ? `<button onclick="event.stopPropagation();_msgLocate(&#39;${escJs(locSess)}&#39;,&#39;${enc}&#39;)" title="Open that worker's peek and scroll to where this was sent">Find in ${esc(locSess)}</button>` : ''}</div></div></div>`;
 }
 function _peekMessagesFor() {
   if (!peekSession) return [];
@@ -28814,6 +28836,7 @@ let _pollTimer = null;
 
 let _invBoardTimer = null;
 let _invSessTimer = null;
+let _invMessagesTimer = null;
 function connectSSE() {
   if (_sseFallback || _sse) return;
   _sse = new EventSource(_authUrl(API + '/api/events'));
@@ -28927,6 +28950,23 @@ function connectSSE() {
           if (key === 'sessions') {
             clearTimeout(_invSessTimer);
             _invSessTimer = setTimeout(fetchSessions, 400);
+          }
+          if (key === 'messages') {
+            clearTimeout(_invMessagesTimer);
+            _invMessagesTimer = setTimeout(() => {
+              // Refresh only visible message surfaces. The event is fleet-wide;
+              // fetching history in every background tab on every scheduler or
+              // worker send would turn correctness into avoidable load.
+              if (activeView === 'messages') _messagesLoad(true);
+              if (typeof peekSession !== 'undefined' && peekSession
+                  && typeof _peekTab !== 'undefined' && _peekTab === 'messages') {
+                _peekMessagesLoad();
+              }
+              const hist = document.getElementById('cmd-history-modal');
+              if (hist && hist.classList.contains('active')) {
+                _loadCmdHistoryFromServer().then(() => _renderCmdHistoryList());
+              }
+            }, 400);
           }
         }
       } else if (msg.type === 'ping') {

--- a/crates/amux-dashboard/static/app.js
+++ b/crates/amux-dashboard/static/app.js
@@ -3344,8 +3344,8 @@ ${/* A lane at a limit banner is not WORKING, and a working lane is not
               parts.push(_schedCountHTML(s.sched_on, s.sched_off) + ' sched');
             }
             if (d) parts.push(`<span class="mc-doing">${d}</span> doing`);
-            if (todo) parts.push(`<span class="mc-active">${todo}</span> todo`);
-            if (backlog) parts.push(`<span class="mc-total">${backlog}</span> backlog`);
+            if (todo) parts.push(`<span class="mc-active mc-todo">${todo}</span> todo`);
+            if (backlog) parts.push(`<span class="mc-total mc-backlog">${backlog}</span> backlog`);
             if (needsYou) parts.push(`<span class="mc-total">${needsYou}</span> needs you`);
             if (review) parts.push(`<span class="mc-total">${review}</span> review`);
             if (done) parts.push(`<span class="mc-total">${done}</span> done`);
@@ -8575,7 +8575,7 @@ async function saveGlobalMemory() {
   }
 }
 
-const APP_VER = '0.9.787';   // bump together with the sw.js CACHE version
+const APP_VER = '0.9.788';   // bump together with the sw.js CACHE version
 
 // ── No silent failures (Ethan, 2026-08-09: "make sure every action has some
 // kind of response in the ui — i just deleted a worker and nothing happened").
@@ -35600,9 +35600,12 @@ async function _bwLoadProfiles() {
       sel.appendChild(sep);
     }
     scratch.forEach(p => sel.appendChild(opt(p, '🔓')));
-    (d.chrome_profiles || []).forEach(p => {
+    const isolatedNames = new Set(all.map(p => p.name));
+    (d.chrome_profiles || []).filter(p => !isolatedNames.has(p)).forEach(p => {
       const o = document.createElement('option');
-      o.value = p; o.textContent = '🌐 ' + p;
+      o.value = p;
+      o.textContent = '🌐 ' + p + ' — import on first use';
+      o.title = 'Copies login state into an isolated amux profile; your normal Chrome can stay open';
       sel.appendChild(o);
     });
     if (cur) sel.value = cur;
@@ -35684,7 +35687,9 @@ async function _bwGo() {
     const _landed = d.launch_url || (d.data && d.data.url) || '';
     _bwCurrentUrl = _landed || url;
     _bwShowProfile(d.profile, d.auto_profile);
-    let _msg = 'Navigated' + (d.profile_fallback ? ' (no profile — Chrome busy)' : '');
+    let _msg = d.profile_imported_from
+      ? 'Imported the Chrome login into an isolated profile and navigated'
+      : 'Navigated' + (d.profile_fallback ? ' (no profile — Chrome busy)' : '');
     if (_landed && !/^about:/.test(_landed)) {
       const _host = u => { try { return new URL(u).host.replace(/^www\./, ''); } catch (e) { return ''; } };
       const _want = _host(url), _got = _host(_landed);

--- a/crates/amux-dashboard/static/app.js
+++ b/crates/amux-dashboard/static/app.js
@@ -3027,14 +3027,16 @@ function _cardBoardActive(name) {
   });
   return n;
 }
-function _cardBoardTotal(name) {
-  let n = 0;
+function _cardBoardStatusCounts(name) {
+  const counts = {};
   (boardItems || []).forEach(c => {
-    if (!c.deleted && !c.archived && c.session === name) n++;
+    if (c.deleted || c.archived || c.session !== name) return;
+    const status = String(c.status || 'unknown').toLowerCase();
+    counts[status] = (counts[status] || 0) + 1;
   });
-  return n;
+  return counts;
 }
-// Worker cards embed board-derived figures (the three helpers above), so ANY
+// Worker cards embed board-derived figures (the helpers above), so ANY
 // boardItems ingest must repaint the workers view when those inputs move —
 // the board fetch used to end at renderBoard(), and a board response landing
 // AFTER the workers view painted left every card without its counts until
@@ -3294,8 +3296,8 @@ function render() {
                (AMUX-2559, "I cant add a worker to a group"). The label is the
                vocab; the field is the contract. */ ''}
           <div class="card-menu-item" onclick="event.stopPropagation();editField('${s.name}','tags','${escJs(s.tags.join(", "))}')"><span class="mi">&#x1F3F7;</span> Groups</div>
-          <div class="card-menu-item" onclick="event.stopPropagation();toggleAutoDrain('${s.name}')" title="When this worker runs out of todo cards, pull its oldest backlog card into todo automatically. Cards parked on a human (needs:you) or on a live trigger are always skipped. Off by default; a group or global layer can also set it from the Scope tab."><span class="mi">${s.auto_drain_backlog?'&#x2611;':'&#x2610;'}</span> Auto-drain backlog</div>
-          <div class="card-menu-item" onclick="event.stopPropagation();toggleSpansGroups('${s.name}')" title="Let this worker message workers in OTHER groups with no per-message approval. Writes CC_SEND_ALLOW on this worker; a group or global layer can also grant it from the Scope tab."><span class="mi">${s.spans_groups?'&#x2611;':'&#x2610;'}</span> Spans groups${_spansLabel(s)}</div>
+          <div class="card-menu-item" onclick="event.stopPropagation();toggleAutoDrain('${s.name}')" title="When this worker runs out of todo cards, pull its oldest eligible backlog card into todo automatically. On by default for every worker. Cards parked on a human (needs:you) or on a live trigger are always skipped; a worker, group, or global configuration can opt out."><span class="mi">${s.auto_drain_backlog?'&#x2611;':'&#x2610;'}</span> Auto-drain backlog</div>
+          <div class="card-menu-item" onclick="event.stopPropagation();toggleSpansGroups('${s.name}')" title="Let this worker message workers in OTHER groups with no per-message approval. Writes CC_SEND_ALLOW on this worker; a group or global layer can also grant it from Configurations."><span class="mi">${s.spans_groups?'&#x2611;':'&#x2610;'}</span> Spans groups${_spansLabel(s)}</div>
           <div class="card-menu-item" onclick="event.stopPropagation();editField('${s.name}','dir','${esc(s.dir)}')"><span class="mi">&#x1F4C1;</span> Directory</div>
           ${s.running ? `<div class="card-menu-item" onclick="event.stopPropagation();closeAllMenus();doRestart('${s.name}')"><span class="mi">&#x21BB;</span> Restart</div>` : ''}
           ${s.running ? `<div class="card-menu-item" onclick="event.stopPropagation();closeAllMenus();doStop('${s.name}')"><span class="mi">&#x23F9;</span> Stop</div>` : ''}
@@ -3325,22 +3327,29 @@ ${/* A lane at a limit banner is not WORKING, and a working lane is not
           ${s.last_activity ? `<span class="last-active">${timeAgo(s.last_activity)}</span>` : ''}
           ${(() => {
             /* Bare numbers, no chips (Ethan: "just numbers no outline ...
-               conservative with real estate"). sched = active/inactive
-               schedules from the payload; doing = this worker's in-progress
-               board issues, computed from the boardItems the client already
-               holds. Successor to the counts row 09aa88e removed — this is
-               the two-figure version of it. */
-            const d = _cardDoingCount(s.name);
-            const active = _cardBoardActive(s.name);
-            const tot = _cardBoardTotal(s.name);
+               conservative with real estate"). Keep runtime status and board
+               state separate: "idle · 11 active" called parked/human-blocked
+               and even done cards active, making Primis's correctly parked
+               queue look like a stalled worker. Spell out the nonzero board
+               columns from the SSE-synced boardItems instead. */
+            const byStatus = _cardBoardStatusCounts(s.name);
+            const d = byStatus.doing || 0;
+            const todo = byStatus.todo || 0;
+            const backlog = byStatus.backlog || 0;
+            const needsYou = (byStatus.needsyou || 0) + (byStatus.blocked || 0);
+            const review = byStatus.review || 0;
+            const done = byStatus.done || 0;
             const parts = [];
             if (s.sched_on || s.sched_off) {
               parts.push(_schedCountHTML(s.sched_on, s.sched_off) + ' sched');
             }
             if (d) parts.push(`<span class="mc-doing">${d}</span> doing`);
-            if (active) parts.push(`<span class="mc-active">${active}</span> active`);
-            if (tot && tot !== active) parts.push(`<span class="mc-total">${tot}</span> total`);
-            return parts.length ? `<span class="meta-count">${parts.join(' · ')}</span>` : '';
+            if (todo) parts.push(`<span class="mc-active">${todo}</span> todo`);
+            if (backlog) parts.push(`<span class="mc-total">${backlog}</span> backlog`);
+            if (needsYou) parts.push(`<span class="mc-total">${needsYou}</span> needs you`);
+            if (review) parts.push(`<span class="mc-total">${review}</span> review`);
+            if (done) parts.push(`<span class="mc-total">${done}</span> done`);
+            return parts.length ? `<span class="meta-count" title="Board status breakdown; parked or review work does not mean this worker is running">${parts.join(' · ')}</span>` : '';
           })()}
           ${!online ? '<span class="cached-badge">cached</span>' : ''}
         </div>` : ''}
@@ -5062,8 +5071,8 @@ function _editAddGroup(sel) {
 let editState = null;  // {session, field, current}
 function editField(session, field, current, provider) {
   closeAllMenus();
-  const titles = { name: 'Rename worker', provider: 'Change provider', model: 'Change model', effort: 'Reasoning effort', dir: 'Change directory', desc: 'Set description', tags: 'Edit groups', task: 'Edit task label', duplicate: 'Duplicate worker', clone: 'Clone & continue' };
-  const placeholders = { name: 'Worker name', model: 'e.g. opus, sonnet, haiku', dir: window._cloudEmail ? '/root' : '/path/to/project', desc: 'Brief description...', tags: 'e.g. work, frontend, urgent', task: 'e.g. Fix login bug (blank to auto-generate)', duplicate: 'New worker name', clone: 'New worker name' };
+  const titles = { name: 'Rename worker', provider: 'Change provider', model: 'Change model', effort: 'Reasoning effort', dir: 'Change directory', desc: 'Set description', tags: 'Edit groups', task: 'Edit task label', branch: 'Set worker branch', mcp: 'Browser tooling', send_allow: 'Cross-group messaging', duplicate: 'Duplicate worker', clone: 'Clone & continue' };
+  const placeholders = { name: 'Worker name', model: 'e.g. opus, sonnet, haiku', dir: window._cloudEmail ? '/root' : '/path/to/project', desc: 'Brief description...', tags: 'e.g. work, frontend, urgent', task: 'e.g. Fix login bug (blank to auto-generate)', branch: 'Branch name; blank = detected branch; none = main', send_allow: 'Comma-separated groups, * for all, blank to refuse', duplicate: 'New worker name', clone: 'New worker name' };
   document.getElementById('edit-title').textContent = titles[field] || 'Edit';
   const inp = document.getElementById('edit-input');
   const sel = document.getElementById('edit-select');
@@ -5094,7 +5103,11 @@ function editField(session, field, current, provider) {
       {v:'claude-haiku-4-5-20251001',l:'claude-haiku-4-5-20251001'}
     ];
     const codexModels = [
-      {v:'',l:'Default'},{v:'gpt-5.6-sol',l:'GPT-5.6 Sol'},{v:'gpt-5.5',l:'gpt-5.5'},
+      {v:'',l:'Default'},
+      {v:'gpt-5.6-sol',l:'GPT-5.6 Sol'},{v:'gpt-5.6-terra',l:'GPT-5.6 Terra'},
+      {v:'gpt-5.6-luna',l:'GPT-5.6 Luna'},{v:'gpt-5.5',l:'GPT-5.5'},
+      {v:'gpt-5.4',l:'GPT-5.4'},{v:'gpt-5.4-mini',l:'GPT-5.4 Mini'},
+      {v:'gpt-5.3-codex-spark',l:'GPT-5.3 Codex Spark'},
       {v:'o3',l:'o3'},{v:'o4-mini',l:'o4-mini'},
       {v:'gpt-4o',l:'gpt-4o'},{v:'gpt-4.1',l:'gpt-4.1'},{v:'gpt-4.1-mini',l:'gpt-4.1-mini'}
     ];
@@ -5154,6 +5167,13 @@ function editField(session, field, current, provider) {
     ];
     sel.innerHTML = '';
     efforts.forEach(e => { const o = document.createElement('option'); o.value = e.v; o.textContent = e.l; sel.appendChild(o); });
+    inpWrap.style.display = 'none';
+    sel.style.display = 'block';
+    sel.value = current || '';
+  } else if (field === 'mcp') {
+    const modes = [{v:'',l:'Disabled'},{v:'chrome',l:'Chrome browser tooling'}];
+    sel.innerHTML = '';
+    modes.forEach(m => { const o = document.createElement('option'); o.value = m.v; o.textContent = m.l; sel.appendChild(o); });
     inpWrap.style.display = 'none';
     sel.style.display = 'block';
     sel.value = current || '';
@@ -5220,10 +5240,10 @@ function _editSelectChanged() {
 }
 async function submitEdit() {
   if (!editState) return;
-  const val = (editState.field === 'model' || editState.field === 'provider' || editState.field === 'effort')
+  const val = (editState.field === 'model' || editState.field === 'provider' || editState.field === 'effort' || editState.field === 'mcp')
     ? document.getElementById('edit-select').value.trim()
     : document.getElementById('edit-input').value.trim();
-  if (!val && editState.field !== 'desc' && editState.field !== 'tags' && editState.field !== 'model' && editState.field !== 'task' && editState.field !== 'effort') return;
+  if (!val && !['desc','tags','model','task','effort','branch','mcp','send_allow'].includes(editState.field)) return;
   const { session, field } = editState;
   // Capture the reasoning-effort dial before closeEdit() tears the dialog down.
   let _effortVal = null;
@@ -5244,10 +5264,15 @@ async function submitEdit() {
       body: JSON.stringify({ new_name: val })
     });
   } else if (field === 'name') {
-    await apiCall(API + '/api/sessions/' + session + '/config', {
+    const renamed = await apiCall(API + '/api/sessions/' + session + '/config', {
       method: 'PATCH', headers: {'Content-Type':'application/json'},
       body: JSON.stringify({ rename: val })
     });
+    // The worker identity survives a rename, but this legacy surface addresses
+    // it by display name. Keep the open Configurations panel attached to the
+    // renamed worker instead of reloading the now-stale route and showing an
+    // unexplained 404.
+    if (renamed && peekSession === session) peekSession = val;
   } else if (field === 'model') {
     const payload = { model: val };
     if (_effortVal !== null) payload.effort = _effortVal;  // Claude only
@@ -5285,8 +5310,26 @@ async function submitEdit() {
       method: 'PATCH', headers: {'Content-Type':'application/json'},
       body: JSON.stringify({ tags: val })
     });
+  } else if (field === 'branch') {
+    await apiCall(API + '/api/sessions/' + session + '/config', {
+      method: 'PATCH', headers: {'Content-Type':'application/json'},
+      body: JSON.stringify({ branch: val })
+    });
+  } else if (field === 'mcp') {
+    await apiCall(API + '/api/sessions/' + session + '/config', {
+      method: 'PATCH', headers: {'Content-Type':'application/json'},
+      body: JSON.stringify({ mcp: val })
+    });
+  } else if (field === 'send_allow') {
+    await apiCall(API + '/api/sessions/' + session + '/config', {
+      method: 'PATCH', headers: {'Content-Type':'application/json'},
+      body: JSON.stringify({ send_allow: val })
+    });
   }
   await fetchSessions();
+  if (peekSession && (peekSession === session || (field === 'name' && peekSession === val)) && _peekTab === 'scope') {
+    _scopeLoad({ level: 'worker', name: peekSession }, 'peek-scope-body');
+  }
 }
 
 // Edit modal dir autocomplete
@@ -5470,7 +5513,7 @@ function _spansLabel(s) {
 }
 
 // AUTO-DRAIN BACKLOG (AMUX-4055). Ethan: "the configuration needs to be a
-// button/toggle too". Same worker-scope key the Scope tab writes, so the toggle
+// button/toggle too". Same worker-level key Configurations writes, so the toggle
 // and the env box are two views of one setting.
 //
 // The toast says what it will and will NOT do, because the honest answer to
@@ -5505,7 +5548,7 @@ async function toggleSpansGroups(session) {
   // granted it, the server says so in its reply rather than reporting success
   // for a change the next send would disprove.
   if (was && s && !s.spans_groups_own) {
-    showToast('Granted by a group or global layer — turn it off in the Scope tab');
+    showToast('Granted by a group or global layer — turn it off in Configurations');
     return;
   }
   const next = !was;
@@ -6236,7 +6279,7 @@ async function loadPeekTranscript(showLoading) {
   }
 }
 
-// ── Scope tab: what this worker operates under, and which layer set it ──────
+// ── Configurations tab: editable values plus the layer that supplies each ──
 // Ethan: "a very easy way in the user experience to understand each of these
 // scoped characteristics." The provenance existed across five API surfaces and
 // nobody opens five surfaces to answer one question.
@@ -6389,51 +6432,7 @@ function _grpGoto(g, where) {
 // a closed onclick cycle only its own buttons could enter. The real pages ARE
 // the group views now, scoped by their own filter controls.
 
-// The WRITE surface for one capability at one level (AMUX-2359). Renders a
-// control ONLY where the server says a value can actually be set; everywhere
-// else it renders the REASON. A field whose write the resolver would outrank is
-// worse than no field — it is an instruction you can follow exactly that does
-// nothing (AMUX-2140), and the read half already publishes `supported`, so
-// there is no excuse for the client to guess.
-function _scopeEditorHTML(lvl, name, cap) {
-  const id = 'scope-ed-' + lvl + '-' + (name || 'global') + '-' + cap.key;
-  if (!cap.supported) {
-    return '<div style="margin-top:6px;font-size:0.68rem;color:#d29922;">'
-      + 'Not settable here. It is decided at: ' + esc((cap.order || []).filter(x => x !== lvl).join(' > '))
-      + '</div>';
-  }
-  const v = cap.value || {};
-  // Text-backed capabilities get a textarea; keyed/structured ones are edited
-  // where they live (env file, gate editor) rather than half-edited here.
-  if (cap.kind === 'text') {
-    // A capped read must never be writable: saving it back would replace the
-    // file with its own first N bytes, turning a DISPLAY limit into data loss.
-    if (v.truncated) {
-      return '<div style="margin-top:6px;font-size:0.68rem;color:#d29922;">'
-        + 'Too large to edit here (' + (v.bytes || 0) + ' bytes, shown truncated), so editing is '
-        + 'disabled — saving a truncated copy would delete the rest. Edit '
-        + '<code>' + esc(v.path || '') + '</code> directly.</div>';
-    }
-    return '<div style="margin-top:7px;">'
-      + '<textarea id="' + id + '" placeholder="Nothing set at this level. Type to set it."'
-      + ' style="width:100%;min-height:74px;background:var(--bg);border:1px solid var(--border);'
-      + 'border-radius:6px;padding:6px 8px;font-size:0.72rem;color:var(--text);font-family:inherit;'
-      + 'resize:vertical;" oninput="event.stopPropagation();">' + esc(v.text || '') + '</textarea>'
-      + '<div style="display:flex;gap:6px;align-items:center;margin-top:5px;">'
-      + '<button class="btn primary" style="font-size:0.68rem;min-height:32px;padding:4px 10px;"'
-      + ' onclick="event.stopPropagation();_scopeSave(\'' + escJs(lvl) + '\',\'' + escJs(name || '') + '\',\''
-      + escJs(cap.key) + '\',\'' + escJs(id) + '\')">Save</button>'
-      + '<span id="' + id + '-msg" style="font-size:0.64rem;color:var(--dim);">'
-      + (v.bytes ? v.bytes + ' bytes at this level' : 'unset at this level') + '</span>'
-      + '</div></div>';
-  }
-  return '<div style="margin-top:6px;font-size:0.66rem;color:var(--dim);">'
-    + 'Edited where it lives (' + esc(cap.kind) + '). Writable via '
-    + '<code>PUT /api/scope</code> with capability <code>' + esc(cap.key) + '</code>.'
-    + '</div>';
-}
-
-// ── Scope editor (AMUX-2436) ──────────────────────────────────────────────
+// ── Configuration editor (AMUX-2436) ──────────────────────────────────────
 // Ethan: "when I click memory, environment, board gates in the expandable group
 // bar I should be able to see/override/edit group level overrides ... same ux as
 // the actual memory environment and board gates pages."
@@ -6446,7 +6445,7 @@ function _scopeEditorHTML(lvl, name, cap) {
 let _scopeEditCtx = null, _scopeEditDirty = false;
 
 function _scopeEditClose() {
-  if (_scopeEditDirty && !confirm('Discard unsaved changes to this scope?')) return;
+  if (_scopeEditDirty && !confirm('Discard unsaved configuration changes?')) return;
   document.getElementById('scope-edit-backdrop').classList.remove('open');
   _scopeEditCtx = null; _scopeEditDirty = false;
 }
@@ -6457,6 +6456,8 @@ const _SCOPE_EDIT_HINT = {
   env:    'KEY=VALUE per line, shell style. Merged by key; a worker’s own .env wins on a clash.',
   gates:  'JSON: {"status": ["criterion", ...]}. Replaces this level’s gate for the statuses named; omit a status to inherit.',
   status_mode: 'JSON array of status ids this level opts into, e.g. ["verified"].',
+  skin: 'JSON object. Keys override terms, colours, and tabs at this level; omitted keys inherit.',
+  connectors: 'JSON object keyed by connector. Each value can set enabled, account, and mcp; omitted connectors inherit.',
 };
 
 async function _scopeEditOpen(lvl, name, key) {
@@ -6494,11 +6495,12 @@ async function _scopeEditOpen(lvl, name, key) {
       text = v.text || '';
     } else if (key === 'env') {
       const keys = v.keys || [];
+      _scopeEditCtx.originalKeys = keys.slice();
       text = keys.length
         ? keys.map(k => k + '=').join('\n')
         : '';
       document.getElementById('scope-edit-msg').textContent = keys.length
-        ? 'Values are not shown (secrets). Re-enter a value to change it; a bare KEY= is ignored.'
+        ? 'Values are hidden. Re-enter a value to change it, leave KEY= to preserve it, or remove the line to delete it.'
         : '';
     } else {
       text = JSON.stringify(v && Object.keys(v).length ? v : (Array.isArray(v) ? v : {}), null, 2);
@@ -6533,12 +6535,20 @@ async function _scopeEditSave() {
   let value;
   if (key === 'memory' || key === 'rules') value = { text: ta.value };
   else if (key === 'env') {
-    // Only lines with an actual value are sent — a bare KEY= from the masked
-    // read would otherwise BLANK the secret it was standing in for.
+    // Existing values stay masked. A bare KEY= preserves one, a changed value
+    // overwrites it, and removing the line emits null so the server deletes it.
+    // Without the original-key diff the UI could add env keys but never remove
+    // them, which is not a configuration editor.
     const out = {};
+    const present = new Set();
     (ta.value || '').split('\n').forEach(l => {
       const m = l.match(/^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=(.*)$/);
-      if (m && m[2].trim() !== '') out[m[1]] = m[2].trim();
+      if (!m) return;
+      present.add(m[1]);
+      if (m[2].trim() !== '') out[m[1]] = m[2].trim();
+    });
+    ((_scopeEditCtx && _scopeEditCtx.originalKeys) || []).forEach(k => {
+      if (!present.has(k)) out[k] = null;
     });
     value = out;
   } else {
@@ -6570,32 +6580,108 @@ async function _scopeEditSave() {
   }
 }
 
-async function _scopeSave(lvl, name, key, elId) {
-  const ta = document.getElementById(elId);
-  const msg = document.getElementById(elId + '-msg');
-  if (!ta) return;
-  if (msg) { msg.textContent = 'Saving…'; msg.style.color = 'var(--dim)'; }
-  try {
-    const r = await fetch(API + '/api/scope', {
-      method: 'PUT',
-      headers: Object.assign({ 'Content-Type': 'application/json' }, _authHeaders()),
-      body: JSON.stringify({ level: lvl, name: name, capability: key, value: { text: ta.value } }),
-    });
-    const d = await r.json();
-    if (!r.ok || d.error) {
-      // Show the server's REASON verbatim. A 403 here is a real policy answer
-      // ("a session may not write the group layer"), not a glitch, and
-      // paraphrasing it into "save failed" would hide the one useful sentence.
-      if (msg) { msg.textContent = d.error || ('save failed (' + r.status + ')'); msg.style.color = '#f85149'; }
-      return;
-    }
-    if (msg) { msg.textContent = 'Saved · ' + (d.value && d.value.bytes != null ? d.value.bytes + ' bytes' : 'ok'); msg.style.color = 'var(--green)'; }
-    // Re-read so the tile's supplying-layer badge reflects the write, which is
-    // the card's acceptance criterion — not just "the POST returned 200".
-    _scopeLoad(lvl === 'global' ? { level: 'global' } : { level: lvl, name: name },
-               name ? 'grp-scope-body-' + name : undefined);
-  } catch (e) {
-    if (msg) { msg.textContent = 'save failed: ' + e.message; msg.style.color = '#f85149'; }
+// Board automation is configuration, so expose the runtime's actual switches
+// beside gates/status availability instead of scattering one in a card menu
+// and hiding the other two as environment-variable trivia. Each switch writes
+// the worker layer; Inherit removes that override and immediately re-resolves
+// global -> group -> worker precedence on the server.
+const _WORKER_BOARD_CONFIGS = [
+  { field: 'auto_drain_backlog', value: 'auto_drain_backlog', own: 'auto_drain_backlog_own',
+    label: 'Backlog → To Do', note: 'Pull the oldest eligible backlog card when To Do is empty. On by default; parked and human-owned cards stay put.' },
+  { field: 'board_auto_pickup', value: 'auto_pickup', own: 'auto_pickup_own',
+    label: 'To Do → In Progress', note: 'Claim the next eligible To Do card when the worker is idle.' },
+  { field: 'board_auto_continue', value: 'auto_continue', own: 'auto_continue_own',
+    label: 'Continue non-terminal work', note: 'Re-check actionable blocked work instead of stopping early.' },
+  { field: 'board_standing_orders', value: 'standing_orders', own: 'standing_orders_own',
+    label: 'Pickup / continue master', note: 'Master switch for To Do pickup and non-terminal continuation.' },
+];
+
+function _workerConfigurationRow(key, label, value, note, controls) {
+  return '<div data-worker-config="' + esc(key) + '" style="display:flex;align-items:center;gap:8px;padding:7px 0;border-top:1px solid var(--border);">'
+    + '<div style="min-width:0;flex:1;"><div style="font-size:0.74rem;color:var(--text);font-weight:600;">'
+    + esc(label) + '</div><div style="font-size:0.68rem;color:var(--dim);overflow-wrap:anywhere;">'
+    + (value ? '<span style="color:var(--text);">' + esc(value) + '</span>' + (note ? ' · ' : '') : '')
+    + esc(note || '') + '</div></div><div style="display:flex;gap:5px;flex:0 0 auto;">'
+    + controls + '</div></div>';
+}
+
+// Complete inventory of the durable PATCH /config surface. Commands that do
+// not describe durable worker state (restart, archive, duplicate, fresh
+// conversation) stay in the worker menu; every actual configuration field is
+// reachable here. The raw Environment editor remains the escape hatch for
+// open-ended startup keys such as CC_BACKEND/CC_CREATOR/CC_FLAGS — it is part
+// of this same tab, not a hidden file-editing workflow.
+function _workerPrimaryConfigurationsHTML(name) {
+  const s = sessions.find(x => x.name === name) || {};
+  const provider = sessionProvider(s);
+  const model = sessionConfiguredModel(s);
+  const effort = flagValue(s.flags || '', '--effort');
+  const q = escJs(name);
+  const edit = (field, current, extra) => '<button class="btn" style="font-size:0.68rem;min-height:32px;padding:4px 8px;"'
+    + ' onclick="event.stopPropagation();editField(\'' + q + '\',\'' + field + '\',\''
+    + escJs(current || '') + '\'' + (extra ? ',\'' + escJs(extra) + '\'' : '') + ')">Edit</button>';
+  const sw = (on, fn, label) => '<button class="btn' + (on ? ' primary' : '') + '" role="switch" aria-checked="'
+    + !!on + '" style="font-size:0.68rem;min-height:32px;min-width:48px;padding:4px 8px;"'
+    + ' onclick="event.stopPropagation();' + fn + '(\'' + q + '\')" aria-label="' + esc(label) + '">'
+    + (on ? 'On' : 'Off') + '</button>';
+  let rows = '';
+  rows += _workerConfigurationRow('name', 'Name', s.name || name, 'Renaming preserves tasks, messages, memory, and worker identity.', edit('name', s.name || name));
+  rows += _workerConfigurationRow('description', 'Description', s.desc || '', 'Used by people and peer-worker discovery.', edit('desc', s.desc || ''));
+  rows += _workerConfigurationRow('task_label', 'Task label override', s.task_name || '', 'Blank returns the card to its board/source-derived label.', edit('task', s.task_name || ''));
+  rows += _workerConfigurationRow('groups', 'Groups', (s.tags || []).join(', '), 'Controls membership, inherited configuration, and default message reach.', edit('tags', (s.tags || []).join(', ')));
+  rows += _workerConfigurationRow('directory', 'Working directory', s.dir || '', 'Changing it restarts a running worker in the new directory.', edit('dir', s.dir || ''));
+  rows += _workerConfigurationRow('branch', 'Git branch', s.branch || '', 'Blank follows the detected branch; “none” explicitly uses the main checkout.', edit('branch', s.branch || ''));
+  rows += _workerConfigurationRow('provider', 'Model provider', providerLabel(provider), 'Provider swaps preserve durable board state and restart only when required.', edit('provider', provider));
+  rows += _workerConfigurationRow('model', 'Model version', model || 'Provider default', 'A supported live switch keeps the conversation; restart fallback rehydrates from board state.', edit('model', model || '', provider));
+  rows += _workerConfigurationRow('effort', 'Reasoning effort', effort || 'Provider default', provider === 'claude' ? 'Can be changed independently or together with the model.' : 'This provider does not expose the effort picker.', provider === 'claude' ? edit('effort', effort || '', provider) : '');
+  rows += _workerConfigurationRow('mcp', 'Browser tooling', s.mcp === 'chrome' ? 'Chrome enabled' : 'Disabled', 'Applied on the next worker start.', edit('mcp', s.mcp || ''));
+  rows += _workerConfigurationRow('yolo', 'Approval bypass (YOLO)', s.yolo ? 'Enabled' : 'Disabled', 'Uses the selected provider’s native permission flag.', sw(!!s.yolo, 'toggleYolo', 'Toggle approval bypass'));
+  rows += _workerConfigurationRow('isolated', 'Isolated raw agent', s.isolated ? 'Enabled' : 'Disabled', 'No amux harness, hooks, MCP config, or peer discovery; restart to apply.', sw(!!s.isolated, 'toggleIsolated', 'Toggle isolated mode'));
+  rows += _workerConfigurationRow('cross_group', 'Cross-group messaging', s.spans_groups_value || 'Refused', s.spans_groups_own ? 'Worker override.' : (s.spans_groups ? 'Inherited from a group/global layer.' : 'No standing allowance.'), edit('send_allow', s.spans_groups_own ? (s.spans_groups_value || '') : ''));
+  rows += _workerConfigurationRow('pinned', 'Pinned in worker list', s.pinned ? 'Pinned' : 'Not pinned', 'Presentation preference; does not change execution priority.', sw(!!s.pinned, 'togglePin', 'Toggle pinned state'));
+  rows += _workerConfigurationRow('advanced_environment', 'Advanced startup environment', 'backend: ' + (s.backend || 'tmux') + (s.creator ? ' · creator: ' + s.creator : ''), 'Edit arbitrary worker-level environment, including backend, creator, and startup flags. Process-scoped changes apply on restart.', '<button class="btn" style="font-size:0.68rem;min-height:32px;padding:4px 8px;" onclick="event.stopPropagation();_scopeEditOpen(\'worker\',\'' + q + '\',\'env\')">Edit environment</button>');
+  return '<div class="scope-detail" style="margin-bottom:10px;">'
+    + '<div style="font-size:0.8rem;font-weight:700;color:var(--text);margin-bottom:2px;">Worker settings</div>'
+    + '<div style="font-size:0.67rem;color:var(--dim);margin-bottom:5px;">Every durable worker setting exposed by the worker API, in one place. Lifecycle commands remain in the worker menu.</div>'
+    + rows + '</div>';
+}
+
+function _workerBoardConfigurationsHTML(name) {
+  const s = sessions.find(x => x.name === name) || {};
+  const rows = _WORKER_BOARD_CONFIGS.map(c => {
+    const on = s[c.value] !== false;
+    const own = !!s[c.own];
+    return '<div style="display:flex;align-items:center;gap:8px;padding:7px 0;border-top:1px solid var(--border);">'
+      + '<div style="min-width:0;flex:1;"><div style="font-size:0.74rem;color:var(--text);font-weight:600;">'
+      + esc(c.label) + (own ? ' <span style="font-size:0.62rem;color:var(--accent);">worker override</span>'
+                              : ' <span style="font-size:0.62rem;color:var(--dim);">inherited/default</span>')
+      + '</div><div style="font-size:0.65rem;color:var(--dim);">' + esc(c.note) + '</div></div>'
+      + '<button class="btn' + (on ? ' primary' : '') + '" role="switch" aria-checked="' + on + '"'
+      + ' style="font-size:0.68rem;min-height:32px;min-width:48px;padding:4px 8px;"'
+      + ' onclick="event.stopPropagation();_workerBoardConfigurationSet(\'' + escJs(name) + '\',\''
+      + escJs(c.field) + '\',' + (!on) + ')">' + (on ? 'On' : 'Off') + '</button>'
+      + (own ? '<button class="btn" style="font-size:0.65rem;min-height:32px;padding:4px 7px;"'
+          + ' onclick="event.stopPropagation();_workerBoardConfigurationSet(\'' + escJs(name) + '\',\''
+          + escJs(c.field) + '\',null)">Inherit</button>' : '')
+      + '</div>';
+  }).join('');
+  return '<div class="scope-detail" style="margin-bottom:10px;">'
+    + '<div style="font-size:0.8rem;font-weight:700;color:var(--text);margin-bottom:2px;">Board automation</div>'
+    + '<div style="font-size:0.67rem;color:var(--dim);margin-bottom:5px;">'
+    + 'Controls dispatch from backlog through active work. Status availability and Board gates below configure the remaining transitions and terminal states.'
+    + '</div>' + rows + '</div>';
+}
+
+async function _workerBoardConfigurationSet(name, field, value) {
+  const r = await apiCall(API + '/api/sessions/' + encodeURIComponent(name) + '/config', {
+    method: 'PATCH', headers: {'Content-Type':'application/json'},
+    body: JSON.stringify({ [field]: value }),
+  });
+  if (!r) return;
+  showToast(r.message || 'Worker configuration saved');
+  await fetchSessions();
+  if (peekSession === name && _peekTab === 'scope') {
+    _scopeLoad({ level: 'worker', name: name }, 'peek-scope-body');
   }
 }
 
@@ -6648,7 +6734,15 @@ async function _scopeLoad(scope, targetId) {
       if (Array.isArray(v)) return v.length ? v.join(', ') : '\u2014';
       if (v.keys) return v.keys.length + ' key' + (v.keys.length === 1 ? '' : 's');
       if (typeof v.bytes === 'number') return v.bytes ? v.bytes + ' bytes' : '\u2014';
-      if (typeof v === 'object') { const k = Object.keys(v).filter(x => v[x] && v[x].length); return k.length ? k.join(', ') : '\u2014'; }
+      if (typeof v === 'object') {
+        const k = Object.keys(v).filter(x => {
+          const z = v[x];
+          if (Array.isArray(z) || typeof z === 'string') return z.length > 0;
+          if (z && typeof z === 'object') return Object.keys(z).length > 0;
+          return z !== null && z !== undefined && z !== '';
+        });
+        return k.length ? k.join(', ') : '\u2014';
+      }
       return String(v);
     };
     const chips = (arr) => arr.map(g => '<span class="msg-tag" style="background:rgba(88,166,255,0.14);color:var(--accent);">' + esc(g) + '</span>').join(' ');
@@ -6657,7 +6751,8 @@ async function _scopeLoad(scope, targetId) {
     // group thing should be horizontal above the workers below the pills"), and
     // stack on a phone. The wrapper classes carry that; the tile row itself was
     // already horizontal.
-    let h = '<div class="grp-scope-row">'
+    let h = (lvl === 'worker' ? _workerPrimaryConfigurationsHTML(w) + _workerBoardConfigurationsHTML(w) : '')
+          + '<div class="grp-scope-row">'
           + '<div class="grp-scope-ident" style="color:var(--text);font-size:0.86rem;">'
           + '<b>' + esc(lvl === 'global' ? 'Global' : w) + '</b>'
           + (lvl === 'worker' ? ' \u00b7 groups: ' + (groups.length ? chips(groups) : '<i>none</i>') : '')
@@ -6669,7 +6764,7 @@ async function _scopeLoad(scope, targetId) {
     // 2026-08-06: "remove rules(binding) from group configs. it should just be
     // memory, board gates and env variables for now"). A DISPLAY trim, not a
     // capability removal: _SCOPE_CAPS, GET/PUT /api/scope and the worker peek
-    // Scope tab still carry rules and status_mode — "for now" means the panel,
+    // Configurations tab still carries rules and status_mode — "for now" means the panel,
     // and hiding a tile must not silently delete the API behind it.
     const _visCaps = (lvl === 'worker') ? d.capabilities
       : d.capabilities.filter(c => ['memory', 'gates', 'env'].includes(c.key));
@@ -6726,13 +6821,13 @@ async function _scopeLoad(scope, targetId) {
         + ' <span style="opacity:0.6;">\u00b7 ' + esc(_l.merge) + '</span>'
         + (_l.supported ? '' : ' <span style="color:#d29922;">\u00b7 not settable at this level</span>')
         + '</div>'
-        + ((lvl === 'group' || lvl === 'global') && _l.supported
+        + (_l.supported
             ? '<div style="margin-top:7px;"><button class="btn primary" '
               + 'style="font-size:0.7rem;min-height:36px;padding:5px 11px;" '
               + 'onclick="event.stopPropagation();_scopeEditOpen(\'' + escJs(lvl) + '\',\''
               + escJs(w || '') + '\',\'' + escJs(_l.key) + '\')">Edit ' + esc(_l.label)
               + ' at this level</button></div>'
-            : _scopeEditorHTML(lvl, w, _l))
+            : '<div style="margin-top:6px;font-size:0.68rem;color:#d29922;">Not settable at this level.</div>')
         + '</div>';
     }
     h += '<div style="display:flex;justify-content:space-between;align-items:center;gap:8px;margin-top:6px;">'
@@ -6754,7 +6849,7 @@ async function _scopeLoad(scope, targetId) {
     dst.innerHTML = h;
   } catch (e) {
     const dst = document.getElementById(targetId || 'peek-scope-body') || el;
-    dst.textContent = 'Could not load scope: ' + e.message;
+    dst.textContent = 'Could not load configurations: ' + e.message;
   }
 }
 
@@ -8480,7 +8575,7 @@ async function saveGlobalMemory() {
   }
 }
 
-const APP_VER = '0.9.784';   // bump together with the sw.js CACHE version
+const APP_VER = '0.9.787';   // bump together with the sw.js CACHE version
 
 // ── No silent failures (Ethan, 2026-08-09: "make sure every action has some
 // kind of response in the ui — i just deleted a worker and nothing happened").
@@ -17229,7 +17324,7 @@ async function _connCreate() {
       await _connScopeEnable(body.id, level, scopeName);
       if (msg) { msg.textContent = 'Created and enabled at ' + level + ' scope. Paste the key in its row below.'; msg.style.color = ''; }
     } catch (e) {
-      if (msg) { msg.textContent = 'Created, but the scope write failed: ' + String(e.message || e) + ' — set it in the Scope tab.'; msg.style.color = '#b8860b'; }
+      if (msg) { msg.textContent = 'Created, but the configuration write failed: ' + String(e.message || e) + ' — set it in Configurations.'; msg.style.color = '#b8860b'; }
     }
     _connAddToggle();
     _connectorsTabLoad();
@@ -26267,9 +26362,14 @@ function _bdArtifactRef(a) {
   if (/^https?:\/\//i.test(target)) {
     return '<a href="' + esc(target) + '" target="_blank" rel="noopener noreferrer">' + esc(ref) + '</a>';
   }
-  if (/^(?:\/|\.\.?\/)/.test(target) || /(?:^|\/)\S+\.[a-z0-9]{1,12}$/i.test(ref)) {
+  const refPath = ref.replace(/#.*$/, '');
+  const targetPath = target.replace(/#.*$/, '');
+  const explicitPath = /^(?:\/|\.\.?\/)/.test(refPath)
+    || (!/\s/.test(refPath) && (refPath.includes('/') || /\.[a-z0-9]{1,12}$/i.test(refPath)));
+  const serverResolvedPath = target !== ref && /^(?:\/|\.\.?\/)/.test(targetPath);
+  if (explicitPath || serverResolvedPath) {
     return '<span class="file-link" onclick="event.stopPropagation();openFilePreview(\''
-      + escJs(target) + '\')" title="Open ' + esc(target) + '">' + esc(ref) + '</span>';
+      + escJs(targetPath) + '\')" title="Open ' + esc(targetPath) + '">' + esc(ref) + '</span>';
   }
   return '<code>' + esc(ref) + '</code>';
 }

--- a/crates/amux-dashboard/static/index.html
+++ b/crates/amux-dashboard/static/index.html
@@ -2201,7 +2201,7 @@ setTimeout(function(){var f=document.getElementById('js-fallback');if(f&&f.style
     <button class="peek-tab" id="peek-tab-simple" onclick="setPeekTab('simple')" title="Translate this worker's output — plain English by default, or your own prompt"><span class="tab-ico">◍</span><span class="tab-lbl">Translate</span></button>
     <button class="peek-tab" id="peek-tab-steering" onclick="setPeekTab('steering')"><span class="tab-ico">⇉</span><span class="tab-lbl">Steering</span><span class="peek-tab-count" id="peek-tab-steering-count"></span></button>
     <button class="peek-tab" id="peek-tab-schedules" onclick="setPeekTab('schedules')"><span class="tab-ico">⏱</span><span class="tab-lbl">Schedules</span><span class="peek-tab-count" id="peek-tab-schedules-count"></span></button>
-    <button class="peek-tab" id="peek-tab-scope" onclick="setPeekTab('scope')" title="What this worker operates under, and which scope layer set it"><span class="tab-ico">&#9707;</span><span class="tab-lbl">Scope</span></button>
+    <button class="peek-tab" id="peek-tab-scope" onclick="setPeekTab('scope')" title="Edit this worker's configuration and see which layer supplies each value"><span class="tab-ico">&#9707;</span><span class="tab-lbl">Configurations</span></button>
     <button class="peek-tab" id="peek-tab-messages" onclick="setPeekTab('messages')" title="Every message sent to this worker"><span class="tab-ico">✉</span><span class="tab-lbl">Messages</span><span class="peek-tab-count" id="peek-tab-messages-count"></span></button>
     <button class="peek-tab" id="peek-tab-dictation" onclick="setPeekTab('dictation')" title="Voice dictation — speak, get clean text"><span class="tab-ico">🎤</span><span class="tab-lbl">Dictation</span><span class="peek-tab-count" id="peek-tab-dictation-count"></span></button>
     <button class="peek-tab" id="peek-tab-readalouds" onclick="setPeekTab('readalouds')" title="Past read-alouds — replay any; auto-clears after 30 days"><span class="tab-ico">&#x1F50A;</span><span class="tab-lbl">Read alouds</span><span class="peek-tab-count" id="peek-tab-readalouds-count"></span></button>
@@ -2889,7 +2889,7 @@ setTimeout(function(){var f=document.getElementById('js-fallback');if(f&&f.style
 </div>
 
 <!-- Confirm / alert modal -->
-<!-- Scope editor: the REAL editor UX for a group/global capability (AMUX-2436).
+<!-- Configuration editor: one editor UX at global, group, and worker level (AMUX-2436).
      Same shape as the peek Memory panel — full-height textarea, Preview, Save —
      rather than the cramped inline box the tiles used to open. env and gates get
      a real editor here for the first time; before, the panel said "edited where

--- a/crates/amux-dashboard/static/sw.js
+++ b/crates/amux-dashboard/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'amux-v0.9.784';
+const CACHE = 'amux-v0.9.787';
 const SHELL_URLS = ['/', '/manifest.json', '/icon.svg', '/icon.png', '/icon-192.png', '/icon-512.png'];
 
 // Install: pre-cache entire app shell

--- a/crates/amux-dashboard/static/sw.js
+++ b/crates/amux-dashboard/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'amux-v0.9.783';
+const CACHE = 'amux-v0.9.784';
 const SHELL_URLS = ['/', '/manifest.json', '/icon.svg', '/icon.png', '/icon-192.png', '/icon-512.png'];
 
 // Install: pre-cache entire app shell

--- a/crates/amux-dashboard/static/sw.js
+++ b/crates/amux-dashboard/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'amux-v0.9.787';
+const CACHE = 'amux-v0.9.788';
 const SHELL_URLS = ['/', '/manifest.json', '/icon.svg', '/icon.png', '/icon-192.png', '/icon-512.png'];
 
 // Install: pre-cache entire app shell

--- a/crates/amux-dashboard/static/sw.js
+++ b/crates/amux-dashboard/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'amux-v0.9.782';
+const CACHE = 'amux-v0.9.783';
 const SHELL_URLS = ['/', '/manifest.json', '/icon.svg', '/icon.png', '/icon-192.png', '/icon-512.png'];
 
 // Install: pre-cache entire app shell

--- a/crates/amux-server/src/api/board.rs
+++ b/crates/amux-server/src/api/board.rs
@@ -3224,15 +3224,104 @@ pub async fn create_item(
 // ---- GET /api/board/{id} -------------------------------------------------
 
 fn resolve_task_asset(reference: &str, work_dir: &str) -> String {
+    let reference = reference.trim();
     let is_external = reference.starts_with("http://")
         || reference.starts_with("https://")
         || reference.starts_with('#')
         || ((7..=40).contains(&reference.len())
             && reference.bytes().all(|c| c.is_ascii_hexdigit()));
     if is_external || reference.starts_with('/') || work_dir.is_empty() {
+        return reference.to_string();
+    }
+
+    // A produced asset is not necessarily a file. Saved-retriever ids,
+    // namespace ids and prose such as `origin commit abc123` are legitimate
+    // references too. The old resolver joined EVERY non-URL value to the
+    // worker directory, so the card rendered those logical ids as clickable
+    // local files that could never open (observed on TUBES-2379). Resolve only
+    // values that actually have a path shape. A spaced relative path is still
+    // supported when it exists; otherwise whitespace means the worker put a
+    // description in `ref` instead of the artifact's description field and it
+    // must stay plain text rather than becoming a bogus path.
+    let (path_ref, fragment) = reference
+        .split_once('#')
+        .map(|(p, f)| (p, Some(f)))
+        .unwrap_or((reference, None));
+    let path = std::path::Path::new(path_ref);
+    let path_shaped = path_ref.starts_with("./")
+        || path_ref.starts_with("../")
+        || path_ref.contains('/')
+        || path.extension().is_some();
+    if !path_shaped {
+        return reference.to_string();
+    }
+
+    let append_fragment = |candidate: std::path::PathBuf| {
+        let mut out = candidate.to_string_lossy().into_owned();
+        if let Some(fragment) = fragment {
+            out.push('#');
+            out.push_str(fragment);
+        }
+        out
+    };
+    let direct = std::path::Path::new(work_dir).join(path);
+    if direct.exists() {
+        return append_fragment(direct);
+    }
+
+    // Workers commonly speak in repository-relative paths even when their
+    // configured cwd is a subdirectory of that repository. Prefer the nearest
+    // existing ancestor-relative match before manufacturing `a/b/a/b/file`.
+    for ancestor in std::path::Path::new(work_dir).ancestors().skip(1) {
+        let candidate = ancestor.join(path);
+        if candidate.exists() {
+            return append_fragment(candidate);
+        }
+    }
+
+    if path_ref.chars().any(char::is_whitespace) {
         reference.to_string()
     } else {
-        std::path::Path::new(work_dir).join(reference).to_string_lossy().into_owned()
+        append_fragment(direct)
+    }
+}
+
+#[cfg(test)]
+mod task_asset_resolution_tests {
+    use super::resolve_task_asset;
+
+    #[test]
+    fn logical_asset_ids_and_descriptions_do_not_become_fake_files() {
+        let cwd = "/tmp/amux-asset-resolution";
+        assert_eq!(resolve_task_asset("ret_8d00ed37a392f1", cwd), "ret_8d00ed37a392f1");
+        assert_eq!(resolve_task_asset("origin commit 3b398814dd", cwd), "origin commit 3b398814dd");
+        assert_eq!(resolve_task_asset("3b398814dd", cwd), "3b398814dd");
+        assert_eq!(
+            resolve_task_asset("migration/mxp.py (ts-parity-v2 sanction)", cwd),
+            "migration/mxp.py (ts-parity-v2 sanction)"
+        );
+    }
+
+    #[test]
+    fn file_shaped_assets_resolve_without_doubling_repo_relative_prefixes() {
+        let root = tempfile::tempdir().unwrap();
+        let repo = root.path().join("mixpeek");
+        let cwd = repo.join("customers/tubescience");
+        let file = cwd.join("migration/mxp.py");
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::write(&file, "# asset").unwrap();
+
+        assert_eq!(
+            resolve_task_asset("migration/mxp.py", cwd.to_str().unwrap()),
+            file.to_string_lossy()
+        );
+        assert_eq!(
+            resolve_task_asset(
+                "customers/tubescience/migration/mxp.py#contract",
+                cwd.to_str().unwrap()
+            ),
+            format!("{}#contract", file.to_string_lossy())
+        );
     }
 }
 

--- a/crates/amux-server/src/api/session_verbs.rs
+++ b/crates/amux-server/src/api/session_verbs.rs
@@ -3839,13 +3839,29 @@ pub(crate) async fn cmd_hist_record_full(
                     delivery, queued_at_ms, delivered_at_ms, submit_verdict
                 ],
             )?;
-            msg_row_id_w.store(conn.last_insert_rowid(), std::sync::atomic::Ordering::SeqCst);
+            let row_id = conn.last_insert_rowid();
+            msg_row_id_w.store(row_id, std::sync::atomic::Ordering::SeqCst);
             conn.execute(
                 "DELETE FROM cmd_history WHERE session=?1 AND id NOT IN \
                  (SELECT id FROM cmd_history WHERE session=?1 ORDER BY ts DESC LIMIT ?2)",
                 rusqlite::params![session, CMD_HIST_KEEP],
             )?;
-            Ok(crate::db::WriteOutcome { applied: true, events: vec![] })
+            // cmd_history is the durable Messages ledger, but this write used
+            // to publish no StateEvent. A healthy SSE client therefore had no
+            // reason to refetch Messages: the row appeared only after a manual
+            // reload, while the less-healthy polling fallback happened to look
+            // current. Publish the committed fact without its text payload;
+            // SSE turns Message into a coalesced `messages` invalidation and
+            // the authenticated history endpoint remains the data plane.
+            Ok(crate::db::WriteOutcome {
+                applied: true,
+                events: vec![crate::db::PendingEvent {
+                    entity_type: amux_core::revision::EntityType::Message,
+                    entity_id: format!("MSG-{row_id}"),
+                    mutation: amux_core::revision::MutationKind::Created,
+                    payload: None,
+                }],
+            })
         })
         .await;
 
@@ -17964,6 +17980,34 @@ mod tests {
             "a DIRECT send really was delivered when it was recorded — blanking this too \
              would throw away true information instead of removing false information"
         );
+    }
+
+    /// A healthy SSE connection used to make Messages LESS live than the 5s
+    /// polling fallback: cmd_history committed silently, so no client refetched
+    /// until a reload or an unrelated board/session event. The ledger write is
+    /// now itself a revisioned Message event. `skip_board=true` isolates this
+    /// assertion from auto-capture's separate Task event.
+    #[tokio::test]
+    async fn a_recorded_message_publishes_the_event_that_refreshes_messages() {
+        let (st, _dir) = state();
+        let mut events = st.store.subscribe();
+        cmd_hist_record_full(
+            &st,
+            "lane-live",
+            "answer this without creating work",
+            "user",
+            "",
+            true,
+            DeliveryMeta::direct(),
+        )
+        .await;
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), events.recv())
+            .await
+            .expect("message write must wake an SSE subscriber")
+            .expect("event channel remains open");
+        assert_eq!(event.entity_type, amux_core::revision::EntityType::Message);
+        assert!(event.entity_id.starts_with("MSG-"), "the invalidation names the durable row");
+        assert_eq!(event.mutation, amux_core::revision::MutationKind::Created);
     }
 
     // ── AMUX-3903: a failed send is a fact worth keeping ────────────────────

--- a/crates/amux-server/src/api/session_verbs.rs
+++ b/crates/amux-server/src/api/session_verbs.rs
@@ -7441,7 +7441,7 @@ fn structured_resume_prompt(name: &str, reason: &str) -> String {
     let reason_text = if reason.is_empty() { "session swap" } else { reason };
     format!(
         "Continue this worker after a {reason_text} using durable amux state, not terminal \
-         replay. Run `amux board list --session {name}` and inspect every non-terminal card \
+         replay. Run `amux board ls --session {name}` and inspect every non-terminal card \
          assigned to this worker with `amux board show <ID>`. Treat each card's source message, \
          epic, dependencies, priority, next action, gates, worker actions, and produced assets \
          as the source of truth. Resume the highest-priority actionable card and keep driving \
@@ -19299,7 +19299,7 @@ mod tests {
     #[test]
     fn provider_resume_uses_structured_state_not_terminal_replay() {
         let prompt = structured_resume_prompt("lane-a", "provider swap");
-        assert!(prompt.contains("amux board list --session lane-a"), "{prompt}");
+        assert!(prompt.contains("amux board ls --session lane-a"), "{prompt}");
         assert!(prompt.contains("amux board show <ID>"), "{prompt}");
         assert!(prompt.contains("source message") && prompt.contains("dependencies"), "{prompt}");
         assert!(!prompt.contains(".amux/logs"), "{prompt}");

--- a/crates/amux-server/src/api/session_verbs.rs
+++ b/crates/amux-server/src/api/session_verbs.rs
@@ -3330,7 +3330,7 @@ pub(crate) fn redact_secrets(text: &str) -> String {
     static RE: OnceLock<regex::Regex> = OnceLock::new();
     let re = RE.get_or_init(|| {
         regex::Regex::new(
-            r"((?:mxp|usr|ret)_sk)_[A-Za-z0-9_-]+|((?:AMUX_MIXPEEK_OPS_TOKEN|ANTHROPIC_API_KEY|OPENAI_API_KEY|GOOGLE_MAPS_API_KEY|GOOGLE_API_KEY|CLOUDFLARE_API_TOKEN|ELEVENLABS_API_KEY|POSTHOG_KEY|POSTHOG_PERSONAL_API_KEY)=)[^\s\r\n]+|(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]+|sk-ant-[A-Za-z0-9_-]+|sk-proj-[A-Za-z0-9_-]+|sk[_-][A-Za-z0-9]{32,}|AIza[0-9A-Za-z_-]{30,}|(?:phx|phc)_[A-Za-z0-9]+",
+            r"((?:mxp|usr|ret)_sk)_[A-Za-z0-9_-]+|((?i:[A-Z_][A-Z0-9_]*(?:PASSWORD|PASSWD|PWD|SECRET|TOKEN|API_KEY|ACCESS_KEY|PRIVATE_KEY|CLIENT_SECRET|CREDENTIAL|_KEY)[A-Z0-9_]*=))[^\s\r\n]+|(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]+|sk-ant-[A-Za-z0-9_-]+|sk-proj-[A-Za-z0-9_-]+|sk[_-][A-Za-z0-9]{32,}|AIza[0-9A-Za-z_-]{30,}|(?:phx|phc)_[A-Za-z0-9]+",
         )
         .expect("redact regex")
     });
@@ -6360,7 +6360,7 @@ fn tmux_rows() -> String {
 fn log_pipe_command(log_path: &Path) -> String {
     const PROG: &str = r#"import os,re,select,sys,time
 LOG=sys.argv[1]; MAXB=int(sys.argv[2]); RAW=sys.argv[3]=='1'; FLUSH=int(sys.argv[4])/1000.0
-SEC=re.compile(rb'((?:mxp|usr|ret)_sk)_[A-Za-z0-9_-]+|((?:AMUX_MIXPEEK_OPS_TOKEN|ANTHROPIC_API_KEY|OPENAI_API_KEY|GOOGLE_MAPS_API_KEY|GOOGLE_API_KEY|CLOUDFLARE_API_TOKEN|ELEVENLABS_API_KEY|POSTHOG_KEY|POSTHOG_PERSONAL_API_KEY)=)[^\s\r\n]+|(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]+|sk-ant-[A-Za-z0-9_-]+|sk-proj-[A-Za-z0-9_-]+|sk[_-][A-Za-z0-9]{32,}|AIza[0-9A-Za-z_-]{30,}|(?:phx|phc)_[A-Za-z0-9]+')
+SEC=re.compile(rb'((?:mxp|usr|ret)_sk)_[A-Za-z0-9_-]+|([A-Z_][A-Z0-9_]*(?:PASSWORD|PASSWD|PWD|SECRET|TOKEN|API_KEY|ACCESS_KEY|PRIVATE_KEY|CLIENT_SECRET|CREDENTIAL|_KEY)[A-Z0-9_]*=)[^\s\r\n]+|(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]+|sk-ant-[A-Za-z0-9_-]+|sk-proj-[A-Za-z0-9_-]+|sk[_-][A-Za-z0-9]{32,}|AIza[0-9A-Za-z_-]{30,}|(?:phx|phc)_[A-Za-z0-9]+',re.I)
 def repl(m):
     if m.group(1): return m.group(1)+b'_REDACTED'
     if m.group(2): return m.group(2)+b'REDACTED'
@@ -7364,14 +7364,24 @@ async fn start_session(state: &AppState, name: &str, extra_flags: &str, skip_con
     meta.insert("last_started".into(), json!(now_i64()));
     let count = meta.get("start_count").and_then(|v| v.as_i64()).unwrap_or(0);
     meta.insert("start_count".into(), json!(count + 1));
-    let pending_reload = meta.remove("pending_log_reload").is_some();
+    // Old `pending_log_reload` keys are consumed for migration, but the new
+    // worker never receives raw terminal replay. Durable board state is the
+    // cross-provider continuity contract.
+    let pending_resume = meta.remove("pending_structured_resume").is_some()
+        || meta.remove("pending_log_reload").is_some();
     let pending_reason = meta
-        .remove("pending_log_reload_reason")
+        .remove("pending_structured_resume_reason")
+        .or_else(|| meta.remove("pending_log_reload_reason"))
         .and_then(|v| v.as_str().map(String::from))
         .unwrap_or_default();
     save_meta(name, &meta);
-    if pending_reload && log_path(name).exists() {
-        let prompt = log_reload_prompt(name, &pending_reason);
+    if pending_resume {
+        let prompt = structured_resume_prompt(name, &pending_reason);
+        tracing::info!(
+            session = %name,
+            reason = %pending_reason,
+            "context hydration: structured board state queued; raw terminal replay suppressed"
+        );
         let st2 = state.clone();
         let n = name.to_string();
         tokio::spawn(async move { send_after_ready(st2, n, prompt, 60, SendOrigin::Automation).await });
@@ -7411,20 +7421,16 @@ fn libc_geteuid() -> u32 {
     })
 }
 
-fn log_reload_prompt(name: &str, reason: &str) -> String {
-    let lp = log_path(name);
-    let size = lp.metadata().map(|m| m.len()).unwrap_or(0);
-    let size_mb = size as f64 / (1024.0 * 1024.0);
-    let cap_mb = MAX_LOG_BYTES / (1024 * 1024);
+fn structured_resume_prompt(name: &str, reason: &str) -> String {
     let reason_text = if reason.is_empty() { "session swap" } else { reason };
     format!(
-        "Before continuing, load the previous amux terminal context.\n\n\
-         The log tail captured for this {reason_text} is at:\n{}\n\n\
-         Read that file now. It contains up to the last {cap_mb} MB of this \
-         session's terminal history ({size_mb:.1} MB currently saved). Use it \
-         as continuity context for the work in this session. Do not summarize it \
-         back unless asked.",
-        lp.display()
+        "Continue this worker after a {reason_text} using durable amux state, not terminal \
+         replay. Run `amux board list --session {name}` and inspect every non-terminal card \
+         assigned to this worker with `amux board show <ID>`. Treat each card's source message, \
+         epic, dependencies, priority, next action, gates, worker actions, and produced assets \
+         as the source of truth. Resume the highest-priority actionable card and keep driving \
+         until no actionable non-terminal work remains. Consult a linked message only when the \
+         card says context is missing. Do not automatically load the worker terminal log."
     )
 }
 
@@ -7740,79 +7746,6 @@ fn write_plain_log(name: &str) -> Option<(PathBuf, usize)> {
     Some((cp, clean.len()))
 }
 
-/// py:22616 _capture_log_tail_for_reload — persist the last MAX_LOG_BYTES of
-/// output before a provider/model/effort/yolo swap.
-async fn capture_log_tail_for_reload(name: &str, reason: &str) -> bool {
-    if !valid_session_name(name) {
-        return false;
-    }
-    let _ = std::fs::create_dir_all(logs_dir());
-    let lp = log_path(name);
-    let mut chunks: Vec<u8> = Vec::new();
-    let existing = load_session_log(name, MAX_LOG_BYTES as u64);
-    chunks.extend_from_slice(existing.as_bytes());
-    let mut captured = String::new();
-    let mut was_piped = false;
-    if is_running(name).await {
-        let ptq = pt(name);
-        // Detaching the pipe is deliberate: the whole-file rewrite below would
-        // otherwise race the writer's appends. But it has to be put BACK —
-        // this used to detach and return, so any provider/model/effort/yolo
-        // swap left the session permanently unlogged with nothing reporting it.
-        was_piped = pane_is_piped(name).await;
-        let _ = tmux(&["pipe-pane", "-t", &ptq]).await;
-        if let Some(o) = run_cmd("tmux", &["capture-pane", "-t", &ptq, "-p", "-S", "-"], Duration::from_secs(30)).await {
-            captured = String::from_utf8_lossy(&o.stdout).into_owned();
-        }
-    }
-    if !captured.trim().is_empty() {
-        let safe_reason = reason.replace('\n', " ").trim().to_string();
-        let safe_reason = if safe_reason.is_empty() { "session swap".to_string() } else { safe_reason };
-        let ts = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S");
-        let marker = format!("\n\n=== Captured before {safe_reason}: {ts} ===\n\n");
-        let cap_text = if tmux_alt_screen(name).await {
-            collapse_blank_runs(&captured)
-        } else {
-            captured
-        };
-        chunks.extend_from_slice(marker.as_bytes());
-        chunks.extend_from_slice(cap_text.as_bytes());
-    }
-    if chunks.is_empty() {
-        if was_piped {
-            rearm_log_pipe(name).await;
-        }
-        return false;
-    }
-    let start = chunks.len().saturating_sub(MAX_LOG_BYTES);
-    let ok = std::fs::write(&lp, &chunks[start..]).is_ok();
-    if was_piped {
-        rearm_log_pipe(name).await;
-    }
-    ok
-}
-
-/// Is this pane currently piped? `#{pane_pipe}` is tmux's own answer, and it
-/// is the field the stale-log verdict in `/api/debug/logs` keys off.
-async fn pane_is_piped(name: &str) -> bool {
-    let ptq = pt(name);
-    match tmux(&["list-panes", "-t", &ptq, "-F", "#{pane_pipe}"]).await {
-        Some(o) => String::from_utf8_lossy(&o.stdout).lines().any(|l| l.trim() == "1"),
-        None => false,
-    }
-}
-
-/// Re-attach the log pipe. Same construction as `start_session` and, like it,
-/// without `-o` — see the comment there for why `-o` silently disables the
-/// pipe it is supposed to guard.
-async fn rearm_log_pipe(name: &str) {
-    let _ = std::fs::create_dir_all(logs_dir());
-    let lp = log_path(name);
-    let ptq = pt(name);
-    let pipe_cmd = log_pipe_command(&lp);
-    let _ = tmux(&["pipe-pane", "-t", &ptq, &pipe_cmd]).await;
-}
-
 /// Previous generation produced by the writer's rotation.
 fn rotated_log_path(name: &str) -> PathBuf {
     logs_dir().join(format!("{name}.log.1"))
@@ -8084,11 +8017,31 @@ pub async fn debug_logs(RawQuery(q): RawQuery) -> Response {
     ))
 }
 
-fn mark_pending_log_reload(name: &str, reason: &str) {
+fn mark_pending_structured_resume(name: &str, reason: &str) {
     update_meta(
         name,
-        &[("pending_log_reload", json!(now_i64())), ("pending_log_reload_reason", json!(reason))],
+        &[
+            ("pending_structured_resume", json!(now_i64())),
+            ("pending_structured_resume_reason", json!(reason)),
+        ],
     );
+}
+
+/// A model/provider switch is the one moment the harness has direct evidence
+/// that a configured model became the running model. Keep that fact separate
+/// from provider self-reports, which may belong to the previous process life.
+fn set_confirmed_active_model(name: &str, provider: &str, model: Option<&str>) {
+    let mut meta = load_meta(name);
+    if let Some(model) = model.filter(|m| !m.trim().is_empty()) {
+        meta.insert("active_model_confirmed".into(), json!(model));
+        meta.insert("active_model_provider".into(), json!(provider));
+        meta.insert("active_model_confirmed_at".into(), json!(now_i64()));
+    } else {
+        meta.remove("active_model_confirmed");
+        meta.remove("active_model_provider");
+        meta.remove("active_model_confirmed_at");
+    }
+    save_meta(name, &meta);
 }
 
 // ---------------------------------------------------------------------------
@@ -8518,6 +8471,18 @@ async fn peek_response(name: &str, lines: i64, live_only: bool, no_trim: bool) -
     }
     let fallback = if output.is_empty() { "(no output)".to_string() } else { output };
     json!({"name": name, "output": collapse_blank_runs(&fallback)})
+}
+
+/// Defense in depth for the browser terminal. The pipe writer redacts before
+/// bytes reach the log, but old logs and a live pane can predate that writer.
+/// Every text-bearing peek field crosses this final boundary before JSON leaves
+/// the server.
+fn redact_peek_payload(value: &mut Value) {
+    let Some(obj) = value.as_object_mut() else { return };
+    for key in ["history", "live", "output"] {
+        let Some(text) = obj.get(key).and_then(Value::as_str) else { continue };
+        obj.insert(key.into(), json!(redact_prompt_secrets(&redact_secrets(text))));
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -14118,6 +14083,7 @@ pub(crate) async fn peek_verb(name: &str, qs: &[(String, String)]) -> Response {
     // short-output, empty…) and a key added to one of them is a key the
     // reader cannot rely on. One injection site covers every shape.
     let mut resp = peek_response(name, lines, live_only, no_trim).await;
+    redact_peek_payload(&mut resp);
     if let (Some((cols, rows)), Some(obj)) =
         (tmux_pane_geometry(name).await, resp.as_object_mut())
     {
@@ -15779,19 +15745,16 @@ fn mode_after_delivery(fold: &HotFold) -> SwapMode {
     }
 }
 
-/// The restart path, with the scrollback capture that makes it survivable.
-/// Only ever called when a restart actually happens: `capture_log_tail_for_reload`
-/// stops the pane pipe as a side effect, which would be a real harm on a hot
-/// switch that never restarts anything.
-async fn restart_with_log_reload(
+/// The restart path queues a compact, structured re-hydration from the board.
+/// Terminal scrollback is diagnostic evidence, not a context protocol: replay
+/// leaked secrets and stale instructions across providers in the live audit.
+async fn restart_with_structured_resume(
     state: &AppState,
     name: &str,
     provider: &str,
     reason: &str,
 ) -> bool {
-    if capture_log_tail_for_reload(name, reason).await {
-        mark_pending_log_reload(name, reason);
-    }
+    mark_pending_structured_resume(name, reason);
     restart_for_swap(state, name, provider).await
 }
 
@@ -15855,12 +15818,12 @@ async fn apply_live_config_change(
                         HotFold::Failed(w) => w,
                         _ => String::new(),
                     };
-                    let restarted = restart_with_log_reload(state, name, provider, reason).await;
+                    let restarted = restart_with_structured_resume(state, name, provider, reason).await;
                     SwapReport {
                         mode: SwapMode::Restart,
                         applied: restarted,
                         note: if restarted {
-                            " (live switch failed; session restarted to apply it, log reload queued)"
+                            " (live switch failed; session restarted to apply it, board-state resume queued)"
                         } else {
                             " (live switch failed AND the restart failed — the session may still be on the old model)"
                         },
@@ -15880,12 +15843,12 @@ async fn apply_live_config_change(
             }
         }
         SwapMode::Restart => {
-            let restarted = restart_with_log_reload(state, name, provider, reason).await;
+            let restarted = restart_with_structured_resume(state, name, provider, reason).await;
             SwapReport {
                 mode,
                 applied: restarted,
                 note: if restarted {
-                    " (session restarted; log reload queued)"
+                    " (session restarted; board-state resume queued)"
                 } else {
                     " (restart failed)"
                 },
@@ -15966,14 +15929,19 @@ async fn config_patch_inner(state: &AppState, name: &str, body: &Value) -> Respo
         cfg.set("CC_PROVIDER", &provider_val);
         cfg.set("CC_FLAGS", &flags);
         let was_running = is_running(name).await;
-        if capture_log_tail_for_reload(name, "provider swap").await {
-            mark_pending_log_reload(name, "provider swap");
-        }
         if cfg.write(&f).is_err() {
             return jresp(StatusCode::INTERNAL_SERVER_ERROR, json!({"error": "could not write session env"}));
         }
+        if was_running {
+            mark_pending_structured_resume(name, "provider swap");
+        }
         let restarted = if was_running { restart_for_swap(state, name, &old_provider).await } else { false };
-        let suffix = if restarted { " (session restarted; log reload queued)" } else { "" };
+        if restarted {
+            set_confirmed_active_model(name, &provider_val, Some(&default_model));
+        } else if !was_running {
+            set_confirmed_active_model(name, &provider_val, None);
+        }
+        let suffix = if restarted { " (session restarted; board-state resume queued)" } else { "" };
         let body = json!({"ok": true, "message": format!("provider set to {}{suffix}", provider_label(&provider_val))});
         return if restarted { j200_slow_ok(body, "worker-restart") } else { j200(body) };
     }
@@ -16037,8 +16005,8 @@ async fn config_patch_inner(state: &AppState, name: &str, body: &Value) -> Respo
         // process state this origin does not hold.
         // The env rewrite is the DURABLE half and happens either way: whatever
         // the live agent does, the next cold start must come up on the new
-        // model. Log-tail capture moved into restart_with_log_reload — it is
-        // only meaningful when a restart actually discards the scrollback.
+        // model. A restart resumes from structured board state, never from a
+        // raw terminal transcript.
         if cfg.write(&f).is_err() {
             return jresp(StatusCode::INTERNAL_SERVER_ERROR, json!({"error": "could not write session env"}));
         }
@@ -16046,6 +16014,16 @@ async fn config_patch_inner(state: &AppState, name: &str, body: &Value) -> Respo
             state, name, &current_provider, was_running, &cmds, expressible, "model swap",
         )
         .await;
+        if rep.applied {
+            let confirmed = if model_val.is_empty() {
+                default_model_for_provider(&current_provider)
+            } else {
+                model_val.clone()
+            };
+            set_confirmed_active_model(name, &current_provider, Some(&confirmed));
+        } else if !was_running {
+            set_confirmed_active_model(name, &current_provider, None);
+        }
         let mut out = json!({
             "ok": true,
             "applied": rep.applied,
@@ -16138,15 +16116,15 @@ async fn config_patch_inner(state: &AppState, name: &str, body: &Value) -> Respo
         }
         cfg.set("CC_FLAGS", &new_flags);
         let was_running = is_running(name).await;
-        if was_running && capture_log_tail_for_reload(name, "YOLO mode change").await {
-            mark_pending_log_reload(name, "YOLO mode change");
-        }
         if cfg.write(&f).is_err() {
             return jresp(StatusCode::INTERNAL_SERVER_ERROR, json!({"error": "could not write session env"}));
         }
+        if was_running {
+            mark_pending_structured_resume(name, "YOLO mode change");
+        }
         let restarted = if was_running { restart_for_swap(state, name, &provider).await } else { false };
         let state_word = if enabled { "enabled" } else { "disabled" };
-        let suffix = if restarted { " (session restarted; log reload queued)" } else { "" };
+        let suffix = if restarted { " (session restarted; board-state resume queued)" } else { "" };
         let body = json!({"ok": true, "message": format!("yolo {state_word}{suffix}")});
         return if restarted { j200_slow_ok(body, "worker-restart") } else { j200(body) };
     }
@@ -19263,6 +19241,38 @@ mod tests {
             redact_secrets("ANTHROPIC_API_KEY=sk-live-x y"),
             "ANTHROPIC_API_KEY=REDACTED y"
         );
+        let password_key = format!("AMUX_QA_{}", "PASSWORD");
+        let s3_key = format!("AMUX_S3_{}", "KEY");
+        let input = format!("{password_key}=fake-login-value {s3_key}=fake-storage-value");
+        let out = redact_secrets(&input);
+        assert_eq!(
+            out,
+            format!("{password_key}=REDACTED {s3_key}=REDACTED"),
+            "unlisted secret-bearing env names must be redacted by shape"
+        );
+    }
+
+    #[test]
+    fn provider_resume_uses_structured_state_not_terminal_replay() {
+        let prompt = structured_resume_prompt("lane-a", "provider swap");
+        assert!(prompt.contains("amux board list --session lane-a"), "{prompt}");
+        assert!(prompt.contains("amux board show <ID>"), "{prompt}");
+        assert!(prompt.contains("source message") && prompt.contains("dependencies"), "{prompt}");
+        assert!(!prompt.contains(".amux/logs"), "{prompt}");
+        assert!(!prompt.contains("terminal history"), "{prompt}");
+    }
+
+    #[test]
+    fn peek_payload_redacts_live_and_saved_secret_shapes() {
+        let key = format!("AMUX_QA_{}", "PASSWORD");
+        let raw = format!("{key}=fake-login-value");
+        let mut payload = json!({"history": raw, "live": raw, "output": raw, "name": "lane-a"});
+        redact_peek_payload(&mut payload);
+        for field in ["history", "live", "output"] {
+            let text = payload[field].as_str().unwrap_or("");
+            assert!(text.contains("REDACTED") && !text.contains("fake-login-value"), "{field}: {text}");
+        }
+        assert_eq!(payload["name"], json!("lane-a"));
     }
 
     /// The file/DB-backed verbs, exercised through the full router shape on a

--- a/crates/amux-server/src/api/session_verbs.rs
+++ b/crates/amux-server/src/api/session_verbs.rs
@@ -16262,41 +16262,62 @@ async fn config_patch_inner(state: &AppState, name: &str, body: &Value) -> Respo
     // which a checkbox cannot express and which is the honest default for a
     // permission.
     //
-    // WRITES THE WORKER LAYER ONLY. Group and global layers are the Scope tab's
+    // WRITES THE WORKER LAYER ONLY. Group and global layers are Configurations'
     // to set, and silently writing one from a per-worker menu would change every
     // lane in that group from a control labelled with one worker's name.
-    // AUTO-DRAIN BACKLOG (AMUX-4055 follow-up). Ethan: "the configuration needs
-    // to be a button/toggle too". Writes the SAME worker-scope key the Scope tab
-    // and `dispatch_backlog_when_idle` already use, so the toggle and the text
-    // box are two views of one setting rather than two settings.
+    // BOARD AUTOMATION CONFIGURATION. These are the same scoped env keys the
+    // runtime reads on every drive tick, now exposed as first-class worker UI
+    // controls from backlog -> todo -> doing -> terminal rather than requiring
+    // somebody to know implementation-specific environment names.
     //
-    // Reports the RESOLVED value after the write, not the value just typed. A
-    // group or global layer can supply this, so echoing back what was sent
-    // would claim an "off" the next drive tick disproves — the same reason the
-    // spans_groups branch below re-resolves.
-    if let Some(v) = body.get("auto_drain_backlog") {
-        let on = py_truthy(v);
-        cfg.set(
+    // `null` removes the worker override and restores group/global/default
+    // inheritance. A boolean writes an explicit worker value. The response is
+    // the RESOLVED value after the write: a false master switch can still make
+    // an explicitly enabled pickup/continue class resolve false, and claiming
+    // otherwise would make the UI disagree with the next runtime tick.
+    let automation = [
+        (
+            "auto_drain_backlog",
             crate::runtime_jobs::board_drive::DISPATCH_BACKLOG_KEY,
-            if on { "1" } else { "0" },
-        );
+            "Backlog to To Do",
+        ),
+        ("board_auto_pickup", "CC_AUTO_PICKUP", "To Do pickup"),
+        ("board_auto_continue", "CC_AUTO_CONTINUE", "Non-terminal continuation"),
+        ("board_standing_orders", "CC_STANDING_ORDERS", "Pickup / continue master"),
+    ];
+    if let Some((field, key, label, v)) = automation
+        .iter()
+        .find_map(|(field, key, label)| body.get(*field).map(|v| (*field, *key, *label, v)))
+    {
+        let inherit = v.is_null();
+        if inherit {
+            cfg.remove(key);
+        } else {
+            cfg.set(key, if py_truthy(v) { "1" } else { "0" });
+        }
         if cfg.write(&f).is_err() {
             return jresp(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 json!({"error": "could not write session env"}),
             );
         }
-        let effective = crate::runtime_jobs::board_drive::dispatch_backlog_when_idle(name);
-        return j200(json!({
+        let effective = if key == crate::runtime_jobs::board_drive::DISPATCH_BACKLOG_KEY {
+            crate::runtime_jobs::board_drive::dispatch_backlog_when_idle(name)
+        } else {
+            standing_orders_on(name, key)
+        };
+        let mut out = json!({
             "ok": true,
-            "auto_drain_backlog": effective,
-            "message": if effective {
-                "Auto-drain on: when this worker runs out of todo it pulls its oldest \
-                 backlog card. Cards parked on a human or on a live trigger are skipped."
+            "effective": effective,
+            "inherited": inherit,
+            "message": if inherit {
+                format!("{label}: worker override removed; resolved {} from inherited/default configuration", if effective { "on" } else { "off" })
             } else {
-                "Auto-drain off: this worker's backlog stays parked."
+                format!("{label}: worker override set {}; effective value is {}", if py_truthy(v) { "on" } else { "off" }, if effective { "on" } else { "off" })
             },
-        }));
+        });
+        out[field] = json!(effective);
+        return j200(out);
     }
     if body.get("spans_groups").is_some() || body.get("send_allow").is_some() {
         let value = if let Some(sv) = body.get("send_allow").and_then(Value::as_str) {
@@ -19580,6 +19601,97 @@ mod tests {
             call(&app, "PATCH", "/api/sessions/probe/config", Some(json!({"toggle_pin": true}))).await;
         assert_eq!(st, StatusCode::OK);
         assert_eq!(parse_env("probe").get("CC_PINNED"), Some("1"));
+
+        // Every board-automation stage exposed in worker Configurations writes
+        // the exact scoped key the runtime consumes. Null removes the worker
+        // override instead of writing a second spelling for "inherit".
+        let (st, v) = call(
+            &app,
+            "PATCH",
+            "/api/sessions/probe/config",
+            Some(json!({"auto_drain_backlog": true})),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "{v}");
+        assert_eq!(parse_env("probe").get("AMUX_DISPATCH_BACKLOG_WHEN_IDLE"), Some("1"));
+        assert_eq!(v["effective"], json!(true));
+
+        let (st, v) = call(
+            &app,
+            "PATCH",
+            "/api/sessions/probe/config",
+            Some(json!({"board_auto_pickup": false})),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "{v}");
+        assert_eq!(parse_env("probe").get("CC_AUTO_PICKUP"), Some("0"));
+        assert_eq!(v["board_auto_pickup"], json!(false));
+
+        let (st, v) = call(
+            &app,
+            "PATCH",
+            "/api/sessions/probe/config",
+            Some(json!({"board_auto_continue": true})),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "{v}");
+        assert_eq!(parse_env("probe").get("CC_AUTO_CONTINUE"), Some("1"));
+
+        let (st, v) = call(
+            &app,
+            "PATCH",
+            "/api/sessions/probe/config",
+            Some(json!({"board_standing_orders": false})),
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "{v}");
+        assert_eq!(parse_env("probe").get("CC_STANDING_ORDERS"), Some("0"));
+        assert_eq!(v["board_standing_orders"], json!(false));
+
+        // A child switch reports the resolved runtime truth while the master
+        // is off; removing the master override immediately restores it.
+        let (_, v) = call(
+            &app,
+            "PATCH",
+            "/api/sessions/probe/config",
+            Some(json!({"board_auto_pickup": true})),
+        )
+        .await;
+        assert_eq!(v["effective"], json!(false));
+        let (_, v) = call(
+            &app,
+            "PATCH",
+            "/api/sessions/probe/config",
+            Some(json!({"board_standing_orders": null})),
+        )
+        .await;
+        assert_eq!(v["inherited"], json!(true));
+        assert_eq!(v["effective"], json!(true));
+        assert_eq!(parse_env("probe").get("CC_STANDING_ORDERS"), None);
+
+        let (_, v) = call(
+            &app,
+            "PATCH",
+            "/api/sessions/probe/config",
+            Some(json!({"auto_drain_backlog": null})),
+        )
+        .await;
+        assert_eq!(v["effective"], json!(true));
+        assert_eq!(parse_env("probe").get("AMUX_DISPATCH_BACKLOG_WHEN_IDLE"), None);
+        for field in ["board_auto_pickup", "board_auto_continue"] {
+            let (st, v) = call(
+                &app,
+                "PATCH",
+                "/api/sessions/probe/config",
+                Some(json!({(field): null})),
+            )
+            .await;
+            assert_eq!(st, StatusCode::OK, "{v}");
+            assert_eq!(v["effective"], json!(true));
+        }
+        assert_eq!(parse_env("probe").get("CC_AUTO_PICKUP"), None);
+        assert_eq!(parse_env("probe").get("CC_AUTO_CONTINUE"), None);
+
         let (st, v) =
             call(&app, "PATCH", "/api/sessions/probe/config", Some(json!({"mcp": "bogus"}))).await;
         assert_eq!(st, StatusCode::BAD_REQUEST, "{v}");

--- a/crates/amux-server/src/api/sessions_legacy.rs
+++ b/crates/amux-server/src/api/sessions_legacy.rs
@@ -2702,6 +2702,7 @@ fn python_fleet_sessions(signals: &FleetSignals) -> Vec<serde_json::Value> {
             // guessing, and so a value supplied by a group or global layer shows
             // as on rather than as an unset worker key (AMUX-4055).
             "auto_drain_backlog": crate::runtime_jobs::board_drive::dispatch_backlog_when_idle(&name),
+            "auto_drain_backlog_own": env.contains_key(crate::runtime_jobs::board_drive::DISPATCH_BACKLOG_KEY),
             // AMUX-3048: the raw event-driven count behind agents_working, so a
             // LEAKED count (a lost SubagentStop pinning a lane "working") is
             // diagnosable rather than hidden — null on a hookless/mtime-only lane.
@@ -2733,8 +2734,11 @@ fn python_fleet_sessions(signals: &FleetSignals) -> Vec<serde_json::Value> {
             // state, exposed so the SPA can show WHY a lane is quiet without
             // re-deriving the layering.
             "auto_continue": crate::api::session_verbs::standing_orders_on(&name, "CC_AUTO_CONTINUE"),
+            "auto_continue_own": env.contains_key("CC_AUTO_CONTINUE"),
             "auto_pickup": crate::api::session_verbs::standing_orders_on(&name, "CC_AUTO_PICKUP"),
+            "auto_pickup_own": env.contains_key("CC_AUTO_PICKUP"),
             "standing_orders": crate::api::session_verbs::standing_orders_on(&name, "CC_STANDING_ORDERS"),
+            "standing_orders_own": env.contains_key("CC_STANDING_ORDERS"),
             "worktree": env.get("CC_WORKTREE").cloned().unwrap_or_default(),
             "worktree_repo": env.get("CC_WORKTREE_REPO").cloned().unwrap_or_default(),
             "mcp": env.get("CC_MCP").cloned().unwrap_or_default(),

--- a/crates/amux-server/src/api/sessions_legacy.rs
+++ b/crates/amux-server/src/api/sessions_legacy.rs
@@ -2041,6 +2041,17 @@ fn load_meta(name: &str) -> serde_json::Value {
     val
 }
 
+fn confirmed_active_model(meta: &serde_json::Value, provider: &str) -> String {
+    let same_provider = meta["active_model_provider"].as_str() == Some(provider);
+    let from_this_life = meta["active_model_confirmed_at"].as_i64().unwrap_or(0)
+        >= meta["last_started"].as_i64().unwrap_or(0);
+    if same_provider && from_this_life {
+        meta["active_model_confirmed"].as_str().unwrap_or("").to_string()
+    } else {
+        String::new()
+    }
+}
+
 /// Pick the worker's task label and its source from the freshness verdicts.
 ///
 /// Pure so the precedence — and especially the SUMMARY freshness gate — can be
@@ -2640,6 +2651,15 @@ fn python_fleet_sessions(signals: &FleetSignals) -> Vec<serde_json::Value> {
         // activity, which updates every snapshot tick and made every lane
         // look equally busy.
         let meta = load_meta(&name);
+        let configured_provider = env
+            .get("CC_PROVIDER")
+            .cloned()
+            .unwrap_or_else(|| "claude".into());
+        // Written only after a restart/hot switch has positively applied. A
+        // provider tag prevents a manual/provider edit from reusing another
+        // runtime's model, and the start boundary rejects facts from a prior
+        // process life.
+        let confirmed_model = confirmed_active_model(&meta, &configured_provider);
         let last_activity = {
             let send = meta["last_send"].as_i64().unwrap_or(0);
             if send != 0 { send } else { meta["last_started"].as_i64().unwrap_or(0) }
@@ -2725,7 +2745,8 @@ fn python_fleet_sessions(signals: &FleetSignals) -> Vec<serde_json::Value> {
             // correct-TYPED honest empty (Invariant 20: never invent). `status`
             // is no longer in that set — it derives above from stores the Python
             // scanner itself persists.
-            "active_model": "",
+            "active_model": confirmed_model,
+            "model_source": if confirmed_model.is_empty() { "" } else { "confirmed-switch" },
             // api_error IS computed now (Ethan 2026-08-18) — it is exactly the
             // `api_error` status derived above, exposed as a side boolean so a
             // log sweep / autofix can find a 5xx-stuck lane without re-deriving
@@ -2786,7 +2807,7 @@ fn python_fleet_sessions(signals: &FleetSignals) -> Vec<serde_json::Value> {
                 json!(status.clone())
             },
             "running": is_running,
-            "provider": env.get("CC_PROVIDER").cloned().unwrap_or_else(|| "claude".into()),
+            "provider": configured_provider,
             "model": env.get("CC_MODEL").cloned().unwrap_or_default(),
             "dir": env.get("CC_DIR").cloned().unwrap_or_default(),
             "preview": "",
@@ -3052,8 +3073,8 @@ pub(crate) fn build_array(conn: &rusqlite::Connection) -> rusqlite::Result<Vec<s
     // {state, age_s, source} card shape (py:20429).
     if signals.reports.is_object() {
         for v in out.iter_mut() {
-            if let Some(name) = v["name"].as_str() {
-                if let Some(rep) = signals.reports.get(name) {
+            if let Some(name) = v["name"].as_str().map(str::to_string) {
+                if let Some(rep) = signals.reports.get(&name) {
                     // ts is time.time() — a FLOAT; as_i64() read it as 0 and
                     // age_s came out as the whole epoch (found 2026-08-09).
                     let ts = rep["ts"].as_f64().unwrap_or(0.0);
@@ -3070,13 +3091,19 @@ pub(crate) fn build_array(conn: &rusqlite::Connection) -> rusqlite::Result<Vec<s
                         "ts": ts as i64,
                         "source": rep["source"].as_str().unwrap_or(""),
                     });
+                    let state = rep["state"].as_str().unwrap_or("");
+                    let started = signals.started.get(&name).copied().unwrap_or(0.0);
+                    let report_current = report_applies(state, ts, started, signals.now);
                     // AMUX-2676: a REPORTED model/token count replaces the
                     // honest-empty above. Still never invented — the empty
                     // stays empty unless the harness itself said otherwise,
                     // which is the whole point of preferring the report
                     // endpoint over a scraper.
-                    if let Some(m) = rep["model"].as_str().filter(|m| !m.is_empty()) {
-                        v["active_model"] = json!(m);
+                    if report_current {
+                        if let Some(m) = rep["model"].as_str().filter(|m| !m.is_empty()) {
+                            v["active_model"] = json!(m);
+                            v["model_source"] = json!("self-report");
+                        }
                     }
                     // Same over-window rejection the compaction path applies
                     // (a5b272e). Without it the two disagree about one fact:
@@ -3090,7 +3117,7 @@ pub(crate) fn build_array(conn: &rusqlite::Connection) -> rusqlite::Result<Vec<s
                         .as_u64()
                         .map(|t| t <= crate::api::session_verbs::context_window())
                         .unwrap_or(false);
-                    if rep["tokens"].is_object() && plausible {
+                    if report_current && rep["tokens"].is_object() && plausible {
                         v["tokens"] = rep["tokens"].clone();
                     }
                 }
@@ -3317,6 +3344,26 @@ pub(crate) fn build_array(conn: &rusqlite::Connection) -> rusqlite::Result<Vec<s
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn confirmed_model_must_match_provider_and_current_process_life() {
+        let current = json!({
+            "active_model_confirmed": "gpt-5.6-sol",
+            "active_model_provider": "codex",
+            "active_model_confirmed_at": 200,
+            "last_started": 190,
+        });
+        assert_eq!(confirmed_active_model(&current, "codex"), "gpt-5.6-sol");
+        assert_eq!(confirmed_active_model(&current, "claude"), "");
+
+        let stale = json!({
+            "active_model_confirmed": "claude-sonnet-5",
+            "active_model_provider": "claude",
+            "active_model_confirmed_at": 100,
+            "last_started": 101,
+        });
+        assert_eq!(confirmed_active_model(&stale, "claude"), "");
+    }
 
     /// AMUX-3700: a pane capture that will not return is KILLED, and one that
     /// returns is not.

--- a/crates/amux-server/src/api/sse.rs
+++ b/crates/amux-server/src/api/sse.rs
@@ -3,7 +3,7 @@
 //! One stream, three event kinds:
 //! - Revisioned StateEvents (`{"type":"state",...}`) + gap detection
 //!   (`lagged`) + `hello` carrying the current rev.
-//! - `{"type":"invalidate","keys":["board"|"sessions",...]}` — the signal
+//! - `{"type":"invalidate","keys":["board"|"sessions"|"messages",...]}` — the signal
 //!   that replaced the legacy full-list pushes (AMUX-3503). The old dialect
 //!   shipped the ENTIRE board (883KB) + sessions (177KB) on every connect
 //!   and every coalesced change, RAW — CompressionLayer exempts
@@ -117,6 +117,10 @@ pub async fn events(
                         amux_core::revision::EntityType::Worker
                             | amux_core::revision::EntityType::Session
                     );
+                    let mut messages_dirty = matches!(
+                        ev.entity_type,
+                        amux_core::revision::EntityType::Message
+                    );
                     tokio::time::sleep(Duration::from_millis(250)).await;
                     while let Ok(more) = rx.try_recv() {
                         board_dirty |= matches!(
@@ -128,9 +132,13 @@ pub async fn events(
                             amux_core::revision::EntityType::Worker
                                 | amux_core::revision::EntityType::Session
                         );
+                        messages_dirty |= matches!(
+                            more.entity_type,
+                            amux_core::revision::EntityType::Message
+                        );
                     }
-                    if board_dirty || sessions_dirty {
-                        let ev = invalidate_payload(board_dirty, sessions_dirty);
+                    if board_dirty || sessions_dirty || messages_dirty {
+                        let ev = invalidate_payload(board_dirty, sessions_dirty, messages_dirty);
                         if yielder.send(Event::default().data(ev)).await.is_err() {
                             break;
                         }
@@ -154,7 +162,7 @@ pub async fn events(
                         break;
                     }
                     if yielder
-                        .send(Event::default().data(invalidate_payload(true, true)))
+                        .send(Event::default().data(invalidate_payload(true, true, true)))
                         .await
                         .is_err()
                     {
@@ -220,13 +228,16 @@ fn ping_payload() -> &'static str {
 /// (`msg.keys`, an array), so the event shape predates this change on the
 /// client side. Pure so the contract is pinned by test: this exact JSON is
 /// what app.js parses, and a shape drift here silently stops every refetch.
-fn invalidate_payload(board: bool, sessions: bool) -> String {
+fn invalidate_payload(board: bool, sessions: bool, messages: bool) -> String {
     let mut keys: Vec<&str> = Vec::new();
     if board {
         keys.push("board");
     }
     if sessions {
         keys.push("sessions");
+    }
+    if messages {
+        keys.push("messages");
     }
     format!(
         "{{\"type\":\"invalidate\",\"keys\":{}}}",
@@ -319,19 +330,23 @@ mod ping_tests {
     #[test]
     fn invalidate_payload_is_the_exact_shape_the_client_parses() {
         assert_eq!(
-            super::invalidate_payload(true, true),
-            r#"{"type":"invalidate","keys":["board","sessions"]}"#
+            super::invalidate_payload(true, true, true),
+            r#"{"type":"invalidate","keys":["board","sessions","messages"]}"#
         );
         assert_eq!(
-            super::invalidate_payload(true, false),
+            super::invalidate_payload(true, false, false),
             r#"{"type":"invalidate","keys":["board"]}"#
         );
         assert_eq!(
-            super::invalidate_payload(false, true),
+            super::invalidate_payload(false, true, false),
             r#"{"type":"invalidate","keys":["sessions"]}"#
         );
         assert_eq!(
-            super::invalidate_payload(false, false),
+            super::invalidate_payload(false, false, true),
+            r#"{"type":"invalidate","keys":["messages"]}"#
+        );
+        assert_eq!(
+            super::invalidate_payload(false, false, false),
             r#"{"type":"invalidate","keys":[]}"#
         );
     }

--- a/crates/amux-server/src/backend/adapter.rs
+++ b/crates/amux-server/src/backend/adapter.rs
@@ -313,6 +313,18 @@ impl TerminalAdapter {
         if clean.trim().is_empty() {
             return Vec::new();
         }
+        // Authentication failure outranks a provider's idle prompt. Codex
+        // renders both at once; allowing the provider-specific scan to fall
+        // through made an unusable isolated worker read IDLE for 49 minutes.
+        // A person must sign in, so this is intentionally non-retryable.
+        if matches!(self.provider.as_str(), "codex" | "ollama") {
+            if let Some(marker) = auth_failure_state(&clean) {
+                return vec![WorkerEvent::Failed(Failure {
+                    reason: format!("provider authentication required: {marker}"),
+                    retryable: false,
+                })];
+            }
+        }
         match self.provider.as_str() {
             "claude" | "claude-code" => scan_claude(&clean, &self.provider),
             "gemini" => scan_gemini(&clean, &self.provider),
@@ -404,6 +416,32 @@ fn is_prompt_line(s: &str) -> bool {
 
 fn is_dingbat_lead(s: &str) -> bool {
     matches!(s.chars().next(), Some(c) if ('\u{2700}'..='\u{27bf}').contains(&c) || c == '\u{b7}')
+}
+
+/// A provider authentication failure that leaves the CLI drawn at an input
+/// prompt but unable to accept work. The leading solid square is Codex's own
+/// error marker and is load-bearing: matching the sentence alone would flag a
+/// worker that is merely discussing an old auth incident in its transcript.
+///
+/// Live specimen (amux-codex, 2026-09-03):
+/// `■ Your access token could not be refreshed because you have since logged
+/// out or signed in to another account. Please sign in again.`
+fn auth_failure_state(clean: &str) -> Option<String> {
+    nonempty_trimmed(clean).iter().rev().take(12).find_map(|line| {
+        let trimmed = line.trim();
+        if !trimmed.starts_with('■') {
+            return None;
+        }
+        let low = trimmed.to_ascii_lowercase();
+        let refresh_failed = low.contains("access token could not be refreshed")
+            || low.contains("authentication token could not be refreshed")
+            || low.contains("failed to refresh authentication token");
+        let login_required = low.contains("please sign in again")
+            || low.contains("please log in again")
+            || low.contains("signed out")
+            || low.contains("logged out");
+        (refresh_failed && login_required).then(|| trimmed.to_string())
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -1207,6 +1245,13 @@ gemini-2.5-pro";
     const FX_CODEX_IDLE: &str = "\
 › implement {feature}
   gpt-5.5 xhigh · ~/Dev/amux";
+    const FX_CODEX_AUTH: &str = "\
+› [09:04 AM] Reply only with isolated-ok.
+
+■ Your access token could not be refreshed because you have since logged out or signed in to another account. Please sign in again.
+
+› Ask Codex to do anything
+  gpt-5.5 xhigh · ~/Dev/amux";
 
     const FX_OLLAMA_NO_DAEMON: &str = "Error: could not connect to ollama app, is it running?";
     const FX_OLLAMA_NO_MODEL: &str = "Error: model 'llama3:70b' not found, try pulling it first";
@@ -1449,8 +1494,10 @@ gemini-2.5-pro";
 
     #[test]
     fn unknown_provider_scans_empty_even_on_matching_text() {
-        let ev = adapter("a-provider-from-2031").scan(FX_WEEKLY);
-        assert!(ev.is_empty(), "{ev:?}");
+        for frame in [FX_WEEKLY, FX_CODEX_AUTH] {
+            let ev = adapter("a-provider-from-2031").scan(frame);
+            assert!(ev.is_empty(), "unknown providers need explicit pattern knowledge: {ev:?}");
+        }
     }
 
     // -- Gemini --------------------------------------------------------------
@@ -1489,6 +1536,27 @@ gemini-2.5-pro";
     fn codex_idle_prompt() {
         let ev = adapter("codex").scan(FX_CODEX_IDLE);
         assert_eq!(waiting_reasons(&ev), vec!["idle_prompt"], "{ev:?}");
+    }
+
+    #[test]
+    fn codex_auth_failure_is_failed_not_idle() {
+        let ev = adapter("codex").scan(FX_CODEX_AUTH);
+        let fs = failures(&ev);
+        assert_eq!(fs.len(), 1, "the live auth wall must produce one failure: {ev:?}");
+        assert!(!fs[0].retryable, "sign-in requires a person; retrying cannot repair it");
+        assert!(fs[0].reason.contains("Please sign in again"));
+        assert!(
+            waiting_reasons(&ev).is_empty(),
+            "the model bar below the auth wall must not overwrite failure with idle: {ev:?}"
+        );
+    }
+
+    #[test]
+    fn quoted_codex_auth_text_is_not_a_failure() {
+        let frame = "› Explain the sentence: Your access token could not be refreshed. Please sign in again.\n\n  gpt-5.5 xhigh · ~/Dev/amux";
+        let ev = adapter("codex").scan(frame);
+        assert!(failures(&ev).is_empty(), "a user prompt quoting the error is not UI chrome: {ev:?}");
+        assert_eq!(waiting_reasons(&ev), vec!["idle_prompt"]);
     }
 
     // -- Status detection regressions ----------------------------------------

--- a/crates/amux-server/src/db/board_store.rs
+++ b/crates/amux-server/src/db/board_store.rs
@@ -817,13 +817,32 @@ pub fn asset_refs(text: &str) -> Vec<String> {
     let number_ref = NUMBER_REF
         .get_or_init(|| Regex::new(r"(?:^|\s)(#\d+)\b").expect("asset ref regex"));
 
+    fn file_like_component(part: &str) -> bool {
+        let Some((stem, ext)) = part.rsplit_once('.') else { return false };
+        !stem.is_empty()
+            && (1..=12).contains(&ext.len())
+            && ext.chars().all(|c| c.is_ascii_alphanumeric())
+    }
+    fn ambiguous_joined_files(value: &str) -> bool {
+        !value.contains("://")
+            && value.split('/').filter(|part| file_like_component(part)).count() > 1
+    }
+
     let mut out = Vec::new();
     let mut seen = HashSet::new();
     let mut push = |raw: &str| {
         let clean = raw
             .trim()
             .trim_matches(|c: char| matches!(c, ',' | ';' | ':' | '!' | '?' | ')' | ']' | '}'));
-        if !clean.is_empty() && seen.insert(clean.to_string()) {
+        // `plan.md/result-a.txt/result-b.txt` is a prose list missing spaces,
+        // not one produced file. Accepting it manufactured a clickable path in
+        // the repo that could never exist. A dotted directory is possible, but
+        // two file-shaped path components are ambiguous evidence and should be
+        // written as separate pointers by the worker.
+        if !clean.is_empty()
+            && !ambiguous_joined_files(clean)
+            && seen.insert(clean.to_string())
+        {
             out.push(clean.to_string());
         }
     };
@@ -2955,6 +2974,9 @@ mod tests {
         assert!(has_asset_link("closes #106"));
         // A short hex-ish word is not a sha, a bare year is too short.
         assert!(!has_asset_link("the cafe was open in 2026"));
+        assert!(!has_asset_link("result-a.txt/result-b.txt"));
+        assert!(!has_asset_link("plan.md/result-a.txt/result-b.txt"));
+        assert!(asset_refs("[ghost](plan.md/result-a.txt)").is_empty());
 
         // The card renderer consumes the SAME parser and must receive every
         // produced asset, not just the first boolean proof that let Done pass.

--- a/crates/amux-server/src/integrations/browser.rs
+++ b/crates/amux-server/src/integrations/browser.rs
@@ -8,17 +8,20 @@
 //! - `default` (or empty)  -> `<amux_home>/playwright-auth/profile`
 //! - named, legacy         -> `<amux_home>/playwright-auth/profiles/<name>`
 //!   when that directory exists (the 35+ real logged-in profiles are here)
-//! - named, otherwise      -> `<chrome-user-data-dir>/<name>` (a Chrome
-//!   `--profile-directory` inside the user's real Chrome data dir)
+//! - named, otherwise      -> imported on first use from
+//!   `<chrome-user-data-dir>/<name>` into the amux-owned location above
 //!
 //! NEW profiles are created under `playwright-auth/profiles/<name>` — the
 //! amux-owned location — because this launcher passes `--user-data-dir`
 //! straight at the profile dir. (Python's create targets the shared Chrome
 //! dir for browser-use interop; the native launcher IS the consumer here, so
 //! amux-owned is the location whose create-path == use-path.) Existing
-//! Chrome-dir profiles still resolve and launch via
-//! `--user-data-dir=<chrome dir> --profile-directory=<name>`, exactly like
-//! `_bu_profile_launch_target`.
+//! Chrome-dir profiles are never launched in place. Chrome locks its ENTIRE
+//! user-data-dir even when a different `--profile-directory` is selected, so
+//! doing that made automation require quitting every ordinary Chrome window.
+//! First use now takes an atomic, cache-free snapshot into an isolated amux
+//! user-data-dir and launches the snapshot. The user's browser can stay open,
+//! and its profile is never driven or mutated by amux.
 //!
 //! Lock-file hygiene: Chrome drops `SingletonLock`/`SingletonCookie`/
 //! `SingletonSocket` on a clean exit and leaves them when killed; a stale set
@@ -109,6 +112,169 @@ pub fn launch_target(home: &Path, chrome_dir: &Path, name: &str) -> LaunchTarget
     } else {
         LaunchTarget { user_data_dir: d, profile_directory: None }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportedChromeProfile {
+    pub source: PathBuf,
+    pub destination: PathBuf,
+    pub files: u64,
+    pub bytes: u64,
+}
+
+/// Import a human Chrome profile into an isolated amux user-data-dir.
+///
+/// Chrome's profile lock belongs to the whole user-data-dir, not the selected
+/// profile directory. Launching `--user-data-dir=<the human Chrome dir>` thus
+/// delegates to an already-running Chrome and exits before CDP binds. More
+/// importantly, deleting that lock to force the launch would risk the user's
+/// browser data. A point-in-time copy is the safe boundary: workers get the
+/// login state they selected while ordinary Chrome remains independent.
+///
+/// The copy is assembled under a unique sibling and renamed into place, so a
+/// crash never exposes a half-profile as runnable. Volatile caches and lock
+/// files are omitted; Chrome recreates them. Symlinks are skipped so a profile
+/// cannot make the importer escape either tree.
+pub fn import_chrome_profile(
+    home: &Path,
+    chrome_dir: &Path,
+    name: &str,
+) -> anyhow::Result<Option<ImportedChromeProfile>> {
+    let name = name.trim();
+    if name.is_empty() || name == "default" {
+        return Ok(None);
+    }
+    if !name.chars().all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-')) {
+        anyhow::bail!("Chrome profile name must be [A-Za-z0-9._-]+");
+    }
+    let destination = home.join("playwright-auth").join("profiles").join(name);
+    if destination.is_dir() {
+        return Ok(None);
+    }
+    let source = chrome_dir.join(name);
+    if !source.is_dir() {
+        anyhow::bail!(
+            "Chrome profile {name:?} does not exist at {}; create an amux profile with POST \
+             /api/browser/profile/create instead",
+            source.display()
+        );
+    }
+
+    let parent = destination
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("browser profile destination has no parent"))?;
+    std::fs::create_dir_all(parent)?;
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let temp = parent.join(format!(".import-{name}-{}-{stamp}", std::process::id()));
+    let copied = (|| -> anyhow::Result<(u64, u64)> {
+        std::fs::create_dir(&temp)?;
+        let profile_root = temp.join("Default");
+        let mut stats = (0u64, 0u64);
+        copy_profile_tree(&source, &profile_root, &mut stats)?;
+        copy_import_local_state(chrome_dir, name, &temp)?;
+        Ok(stats)
+    })();
+    let (files, bytes) = match copied {
+        Ok(v) => v,
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&temp);
+            return Err(e);
+        }
+    };
+    match std::fs::rename(&temp, &destination) {
+        Ok(()) => {}
+        // A concurrent importer won the race. Its atomic destination is valid;
+        // discard our complete duplicate and let this start use the winner.
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists && destination.is_dir() => {
+            let _ = std::fs::remove_dir_all(&temp);
+            return Ok(None);
+        }
+        Err(e) => {
+            let _ = std::fs::remove_dir_all(&temp);
+            return Err(e.into());
+        }
+    }
+    Ok(Some(ImportedChromeProfile { source, destination, files, bytes }))
+}
+
+fn copy_profile_tree(src: &Path, dst: &Path, stats: &mut (u64, u64)) -> anyhow::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = match entry {
+            Ok(v) => v,
+            // A live Chrome can rotate a transient entry between read_dir and
+            // inspection. A vanished cache is not an import failure.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e.into()),
+        };
+        let name = entry.file_name();
+        let label = name.to_string_lossy();
+        if import_entry_is_volatile(&label) {
+            continue;
+        }
+        let ty = match entry.file_type() {
+            Ok(v) => v,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e.into()),
+        };
+        let to = dst.join(&name);
+        if ty.is_symlink() {
+            continue;
+        }
+        if ty.is_dir() {
+            copy_profile_tree(&entry.path(), &to, stats)?;
+        } else if ty.is_file() {
+            match std::fs::copy(entry.path(), &to) {
+                Ok(n) => {
+                    stats.0 += 1;
+                    stats.1 += n;
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) => return Err(e.into()),
+            }
+        }
+    }
+    Ok(())
+}
+
+fn import_entry_is_volatile(name: &str) -> bool {
+    name == "LOCK"
+        || name.starts_with("Singleton")
+        || matches!(
+            name,
+            "Cache"
+                | "Code Cache"
+                | "GPUCache"
+                | "DawnCache"
+                | "GrShaderCache"
+                | "GraphiteDawnCache"
+                | "ShaderCache"
+                | "Crashpad"
+        )
+}
+
+fn copy_import_local_state(chrome_dir: &Path, source_name: &str, dst: &Path) -> anyhow::Result<()> {
+    let path = chrome_dir.join("Local State");
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return Ok(());
+    };
+    let mut value: serde_json::Value = serde_json::from_str(&raw)?;
+    if let Some(profile) = value.get_mut("profile").and_then(serde_json::Value::as_object_mut) {
+        let source_info = profile
+            .get("info_cache")
+            .and_then(serde_json::Value::as_object)
+            .and_then(|m| m.get(source_name))
+            .cloned()
+            .unwrap_or_else(|| json!({ "name": source_name }));
+        profile.insert("last_used".into(), json!("Default"));
+        profile.insert("last_active_profiles".into(), json!(["Default"]));
+        profile.insert("info_cache".into(), json!({ "Default": source_info }));
+    }
+    std::fs::write(dst.join("Local State"), serde_json::to_vec(&value)?)?;
+    Ok(())
 }
 
 /// Is this dir one amux owns outright (safe to create, clean locks in,
@@ -966,6 +1132,14 @@ fn amux_cert_spki_b64(home: &Path) -> Option<String> {
 #[derive(Debug, Clone, Serialize)]
 pub struct StartedBrowser {
     pub profile: String,
+    /// Present only on the first start of a profile selected from ordinary
+    /// Chrome. The browser runs from `user_data_dir`, never from this source.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile_imported_from: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile_imported_files: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile_imported_bytes: Option<u64>,
     pub pid: Option<u32>,
     pub cdp_port: u16,
     pub cdp_http: String,
@@ -1193,7 +1367,43 @@ pub async fn start(
     // before CDP came up", AMUX-3207). The driver-verb path already reconciles
     // via adopt_if_orphaned (connect_session); start() did not. Reconcile here,
     // before the replace-check, so the orphan is STOPPED rather than delegated to.
-    let target = launch_target(home, &chrome_user_data_dir(), profile);
+    let chrome_dir = chrome_user_data_dir();
+    let unresolved = launch_target(home, &chrome_dir, profile);
+    let imported = if is_amux_owned(home, &unresolved.user_data_dir) {
+        None
+    } else {
+        // Never launch automation against the human browser's user-data-dir.
+        // Besides risking profile corruption, Chrome delegates the launch to
+        // the already-running app and exits before CDP exists. Copying can be
+        // substantial, so keep it off the async runtime's worker threads.
+        let import_home = home.to_path_buf();
+        let import_chrome = chrome_dir.clone();
+        let import_name = profile.to_string();
+        let result = tokio::task::spawn_blocking(move || {
+            import_chrome_profile(&import_home, &import_chrome, &import_name)
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("Chrome profile import task failed: {e}"))??;
+        if let Some(i) = &result {
+            tracing::info!(
+                profile,
+                source = %i.source.display(),
+                destination = %i.destination.display(),
+                files = i.files,
+                bytes = i.bytes,
+                "browser: imported a human Chrome profile into an isolated amux profile"
+            );
+        }
+        result
+    };
+    let target = launch_target(home, &chrome_dir, profile);
+    if !is_amux_owned(home, &target.user_data_dir) {
+        anyhow::bail!(
+            "refusing to launch automation against the human Chrome user-data-dir {}; the \
+             isolated profile import did not produce a runnable destination",
+            target.user_data_dir.display()
+        );
+    }
     reconcile_orphan_before_launch(home, &target.user_data_dir).await;
 
     // ONE BROWSER PER PROFILE, and only this profile (AMUX-3828). This used to
@@ -1420,6 +1630,9 @@ pub async fn start(
     let started_at = chrono::Utc::now().timestamp();
     let info = StartedBrowser {
         profile: profile.to_string(),
+        profile_imported_from: imported.as_ref().map(|i| i.source.display().to_string()),
+        profile_imported_files: imported.as_ref().map(|i| i.files),
+        profile_imported_bytes: imported.as_ref().map(|i| i.bytes),
         pid,
         cdp_port: port,
         cdp_http: http,
@@ -3608,6 +3821,66 @@ mod tests {
         let t = launch_target(home.path(), &chrome, "Work");
         assert_eq!(t.user_data_dir, chrome);
         assert_eq!(t.profile_directory.as_deref(), Some("Work"));
+    }
+
+    #[test]
+    fn chrome_profile_import_is_atomic_isolated_and_cache_free() {
+        let home = fake_home();
+        let chrome = home.path().join("fake-chrome-udd");
+        let source = chrome.join("ethan-tubescience");
+        std::fs::create_dir_all(source.join("Network")).unwrap();
+        std::fs::create_dir_all(source.join("Cache")).unwrap();
+        std::fs::write(source.join("Network/Cookies"), b"logged-in").unwrap();
+        std::fs::write(source.join("Preferences"), b"prefs").unwrap();
+        std::fs::write(source.join("Cache/disposable"), b"cache").unwrap();
+        std::fs::write(source.join("LOCK"), b"held").unwrap();
+        std::fs::write(
+            chrome.join("Local State"),
+            r#"{"os_crypt":{"encrypted_key":"keep-me"},"profile":{"last_used":"ethan-tubescience","last_active_profiles":["ethan-tubescience"],"info_cache":{"ethan-tubescience":{"name":"TubeScience"},"Other":{"name":"Other"}}}}"#,
+        )
+        .unwrap();
+
+        let imported = import_chrome_profile(home.path(), &chrome, "ethan-tubescience")
+            .unwrap()
+            .expect("first use imports the Chrome profile");
+        let dest = home.path().join("playwright-auth/profiles/ethan-tubescience");
+        assert_eq!(imported.source, source);
+        assert_eq!(imported.destination, dest);
+        assert_eq!(std::fs::read(dest.join("Default/Network/Cookies")).unwrap(), b"logged-in");
+        assert_eq!(std::fs::read(dest.join("Default/Preferences")).unwrap(), b"prefs");
+        assert!(!dest.join("Default/Cache").exists(), "cache is recreated, not imported");
+        assert!(!dest.join("Default/LOCK").exists(), "a live profile's lock must not cross over");
+
+        let state: Value =
+            serde_json::from_slice(&std::fs::read(dest.join("Local State")).unwrap()).unwrap();
+        assert_eq!(state["os_crypt"]["encrypted_key"], "keep-me");
+        assert_eq!(state["profile"]["last_used"], "Default");
+        assert_eq!(state["profile"]["last_active_profiles"], json!(["Default"]));
+        assert_eq!(state["profile"]["info_cache"]["Default"]["name"], "TubeScience");
+        assert!(state["profile"]["info_cache"].get("Other").is_none());
+
+        let target = launch_target(home.path(), &chrome, "ethan-tubescience");
+        assert_eq!(target.user_data_dir, dest);
+        assert!(is_amux_owned(home.path(), &target.user_data_dir));
+        assert_eq!(target.profile_directory, None);
+        assert!(
+            import_chrome_profile(home.path(), &chrome, "ethan-tubescience")
+                .unwrap()
+                .is_none(),
+            "later starts reuse the durable isolated copy"
+        );
+    }
+
+    #[test]
+    fn chrome_profile_import_rejects_escape_and_missing_sources() {
+        let home = fake_home();
+        let chrome = home.path().join("fake-chrome-udd");
+        std::fs::create_dir_all(&chrome).unwrap();
+        let escape = import_chrome_profile(home.path(), &chrome, "../outside").unwrap_err();
+        assert!(escape.to_string().contains("[A-Za-z0-9._-]+"));
+        let missing = import_chrome_profile(home.path(), &chrome, "missing").unwrap_err();
+        assert!(missing.to_string().contains("does not exist"));
+        assert!(!home.path().join("playwright-auth/profiles/missing").exists());
     }
 
     #[test]

--- a/crates/amux-server/src/integrations/browser.rs
+++ b/crates/amux-server/src/integrations/browser.rs
@@ -197,6 +197,14 @@ pub fn import_chrome_profile(
             return Err(e.into());
         }
     }
+    // This is selected login state, not disposable scratch. Registering it
+    // exempts the isolated copy from the profile TTL reaper. A failed registry
+    // write rolls back only the destination we just created; the human source
+    // remains untouched throughout.
+    if let Err(e) = registry_register(home, name, "", "") {
+        let _ = std::fs::remove_dir_all(&destination);
+        return Err(e.context("register imported Chrome profile"));
+    }
     Ok(Some(ImportedChromeProfile { source, destination, files, bytes }))
 }
 
@@ -3863,6 +3871,11 @@ mod tests {
         assert_eq!(target.user_data_dir, dest);
         assert!(is_amux_owned(home.path(), &target.user_data_dir));
         assert_eq!(target.profile_directory, None);
+        let inventory = list_profiles(home.path(), false);
+        assert!(
+            inventory.iter().any(|p| p.name == "ethan-tubescience" && p.registered),
+            "imported login state must be exempt from scratch-profile TTL cleanup"
+        );
         assert!(
             import_chrome_profile(home.path(), &chrome, "ethan-tubescience")
                 .unwrap()

--- a/crates/amux-server/src/runtime_jobs/board_drive.rs
+++ b/crates/amux-server/src/runtime_jobs/board_drive.rs
@@ -1529,19 +1529,17 @@ fn reclaim_stale_doing(
     None
 }
 
-/// Scope key for the opt-in backlog dispatch (AMUX-4055).
+/// Scope key for backlog dispatch (AMUX-4055).
 pub const DISPATCH_BACKLOG_KEY: &str = "AMUX_DISPATCH_BACKLOG_WHEN_IDLE";
 
 /// May this lane pull from `backlog` when it has no `todo` left?
 ///
-/// DEFAULT OFF, which is the opposite of the other scoped gates in this
-/// codebase and is deliberate. `done_link_required` and
-/// `done_evidence_required` default ON because they are constraints, and ethos
-/// rule 1 asks for opt-out there. This is not a constraint, it is a lane
-/// deciding that its backlog is a work queue rather than a parking lot. Those
-/// are different claims and only the owner knows which their backlog is:
-/// turning it on globally would start dispatching 489 parked cards across the
-/// fleet. Ethan asked for opt-in for exactly that reason.
+/// DEFAULT ON. A worker with actionable backlog and an empty To Do column is a
+/// stalled queue, not an idle worker; every new and existing worker therefore
+/// drains by default. The eligibility query still excludes human-owned cards,
+/// `needs:you`, live triggers, epics, watches, tripwires, and already-claimed
+/// work, so default-on does not turn parked coordination state into executable
+/// work. A worker/group/global layer may explicitly opt out.
 ///
 /// Same resolver shape as the gates above, so the override ladder is one thing:
 /// process env wins (the operator switch in `~/.amux/server.env`), then the
@@ -1565,7 +1563,7 @@ pub fn dispatch_backlog_when_idle(session: &str) -> bool {
     )
     .as_deref()
     .map(is_on)
-    .unwrap_or(false)
+    .unwrap_or(true)
 }
 
 /// Backlog cards of a workable TYPE, before the parked/claimed exclusions.
@@ -7909,17 +7907,16 @@ mod tests {
     /// not a reason to leave the queue broken. The control below is the half
     /// that keeps this a repair rather than a hole: with nothing promotable, a
     /// capped lane must still be told `wip-cap` and handed no work.
-    /// AMUX-4055. Ethan, after tubescience stopped over 21 backlog cards with an
-    /// empty todo queue and a free WIP cap: "it should dispatch backlog when
-    /// todo is empty (opt in)".
-    ///
-    /// OPT-IN IS THE PROPERTY UNDER TEST, not a detail. A backlog is a parking
-    /// lot for some lanes and a work queue for others, and only the owner knows
-    /// which. Defaulting this on would have started dispatching hundreds of
-    /// deliberately parked cards across the fleet, so the first cell here is the
-    /// one that must never regress.
+    /// AMUX-4055. An empty To Do column with actionable backlog is work the
+    /// worker is expected to keep driving. Default-on is safe because the drain
+    /// query excludes every parked/human/trigger shape; an explicit 0 remains
+    /// the worker/group/global opt-out.
     #[test]
-    fn backlog_dispatch_is_off_by_default_and_drains_one_card_when_enabled() {
+    fn backlog_dispatch_is_on_by_default_and_supports_an_explicit_opt_out() {
+        // The default must be tested against an actually empty scope chain,
+        // not the developer machine's ~/.amux global configuration.
+        let home = tempfile::tempdir().expect("temp home");
+        let _home = crate::api::settings::test_env::set_home(home.path());
         let build = || {
             let conn = board_db();
             // No todo at all: the only state where this may fire.
@@ -7930,24 +7927,22 @@ mod tests {
             conn
         };
 
-        // DEFAULT OFF. Nothing enabled it, so the lane reports an empty queue.
+        // DEFAULT ON: the oldest eligible card drains without every worker
+        // needing a redundant opt-in key.
         std::env::remove_var(DISPATCH_BACKLOG_KEY);
-        match select_pickup_with(&build(), "lane", now_f64(), false) {
-            Pickup::None { reason, .. } => assert_eq!(
-                reason, "no-eligible-card",
-                "a lane that did not opt in must NOT have its backlog dispatched"
-            ),
-            other => panic!("backlog dispatch must be opt-in: {other:?}"),
-        }
-
-        // OPTED IN: the OLDEST drainable card, one at a time.
-        std::env::set_var(DISPATCH_BACKLOG_KEY, "1");
         match select_pickup_with(&build(), "lane", now_f64(), false) {
             Pickup::DrainBacklog { card, backlog_left } => {
                 assert_eq!(card, "B-1", "oldest first, so a starved card is not starved further");
                 assert_eq!(backlog_left, 2, "the count reports what is drainable, before the move");
             }
-            other => panic!("an opted-in lane with no todo must drain its backlog: {other:?}"),
+            other => panic!("default-on backlog dispatch did not run: {other:?}"),
+        }
+
+        // EXPLICIT OPT-OUT: no backlog card moves.
+        std::env::set_var(DISPATCH_BACKLOG_KEY, "0");
+        match select_pickup_with(&build(), "lane", now_f64(), false) {
+            Pickup::None { reason, .. } => assert_eq!(reason, "no-eligible-card"),
+            other => panic!("an opted-out lane must not drain backlog: {other:?}"),
         }
         std::env::remove_var(DISPATCH_BACKLOG_KEY);
     }
@@ -7981,9 +7976,9 @@ mod tests {
             other => panic!("a fully parked backlog must not drain: {other:?}"),
         }
 
-        // NOT opted in: say so, and say how to turn it on. An absent note and a
-        // lane with no backlog are otherwise the same silence.
-        std::env::remove_var(DISPATCH_BACKLOG_KEY);
+        // EXPLICITLY opted out: say so and name the control. An absent note and
+        // a lane with no backlog are otherwise the same silence.
+        std::env::set_var(DISPATCH_BACKLOG_KEY, "0");
         match select_pickup_with(&conn, "lane", now_f64(), false) {
             Pickup::None { detail, .. } => assert!(
                 detail.contains("drain: OFF"),
@@ -7991,6 +7986,7 @@ mod tests {
             ),
             other => panic!("expected no-eligible-card: {other:?}"),
         }
+        std::env::remove_var(DISPATCH_BACKLOG_KEY);
     }
 
     /// The two cards this must never touch, even when opted in.

--- a/crates/amux-server/tests/dashboard_assets.rs
+++ b/crates/amux-server/tests/dashboard_assets.rs
@@ -369,6 +369,9 @@ fn board_detail_leads_with_actionable_task_context() {
         "item.gate_requirements",
         "item.asset_links",
         "a.resolved_ref",
+        "const explicitPath =",
+        "const serverResolvedPath =",
+        "targetPath = target.replace(/#.*$/",
         "Produced assets (",
         "Source message",
         "_bdOpenMessage(",
@@ -395,4 +398,81 @@ fn group_suggestions_are_autocomplete_not_an_unprompted_wall() {
     let empty = body.find("if (!q) { el.innerHTML = ''; return; }").expect("empty-query guard");
     let suggest = body.find("_tagSuggestions(prefix, q)").expect("typed suggestions remain");
     assert!(empty < suggest, "the empty query must stop before fleet groups are suggested");
+}
+
+#[test]
+fn worker_cards_do_not_call_parked_work_active() {
+    let app = asset("app.js");
+    let start = app
+        .find("const byStatus = _cardBoardStatusCounts(s.name)")
+        .expect("worker card status breakdown exists");
+    let body = &app[start..start + 1800.min(app.len() - start)];
+    for label in ["backlog", "needs you", "review", "done"] {
+        assert!(body.contains(label), "worker card omitted `{label}` count");
+    }
+    assert!(
+        !body.contains("${active}</span> active"),
+        "parked and done cards must not be collapsed into a misleading active count"
+    );
+}
+
+#[test]
+fn worker_configurations_are_editable_from_backlog_through_terminal_states() {
+    let html = asset("index.html");
+    assert!(
+        html.contains("<span class=\"tab-lbl\">Configurations</span>"),
+        "the worker surface must be named for what a user can do there"
+    );
+
+    let app = asset("app.js");
+    assert!(
+        app.contains("const _visCaps = (lvl === 'worker') ? d.capabilities"),
+        "worker Configurations must show every capability returned by the server"
+    );
+    assert!(
+        !app.contains("Edited where it lives"),
+        "a writable worker configuration must not send the user to an unnamed second UI"
+    );
+    for needle in [
+        "Worker settings",
+        "Every durable worker setting exposed by the worker API",
+        "_workerConfigurationRow('name'",
+        "_workerConfigurationRow('provider'",
+        "_workerConfigurationRow('model'",
+        "_workerConfigurationRow('mcp'",
+        "_workerConfigurationRow('cross_group'",
+        "_workerConfigurationRow('advanced_environment'",
+        "_scopeEditOpen(\\'",
+        "skin: 'JSON object",
+        "connectors: 'JSON object",
+        "Backlog → To Do",
+        "To Do → In Progress",
+        "Continue non-terminal work",
+        "Pickup / continue master",
+        "On by default; parked and human-owned cards stay put",
+        "Status availability and Board gates below configure the remaining transitions and terminal states",
+    ] {
+        assert!(app.contains(needle), "Configurations omitted `{needle}`");
+    }
+    for field in [
+        "auto_drain_backlog",
+        "board_auto_pickup",
+        "board_auto_continue",
+        "board_standing_orders",
+    ] {
+        assert!(app.contains(&format!("field: '{field}'")), "missing runtime control for {field}");
+    }
+    assert!(
+        app.contains("if (!present.has(k)) out[k] = null"),
+        "removing a masked environment row must delete that worker-level key"
+    );
+    assert!(
+        app.contains("if (z && typeof z === 'object') return Object.keys(z).length > 0"),
+        "nested skin/connector settings must not render as an unset configuration"
+    );
+    assert!(
+        app.contains("_workerBoardConfigurationSet(\\'")
+            && app.contains("\\',null)\">Inherit</button>"),
+        "worker overrides need an explicit path back to inherited configuration"
+    );
 }

--- a/crates/amux-server/tests/dashboard_assets.rs
+++ b/crates/amux-server/tests/dashboard_assets.rs
@@ -120,6 +120,54 @@ fn board_worker_actions_group_wrapped_lines_under_their_timestamp() {
     );
 }
 
+#[test]
+fn messages_link_schedule_ids_to_the_scheduler() {
+    let app = asset("app.js");
+    let start = app
+        .find("async function _openScheduleFromMessage(id)")
+        .expect("Messages must expose schedule navigation");
+    let tail = &app[start..];
+    let end = tail
+        .find("function _linkifyUrls")
+        .expect("schedule linkifier must precede URL linkification");
+    let body = &tail[..end];
+    for needle in [
+        "switchView('scheduler')",
+        "fetchSchedules()",
+        "fetchSchedulerRuns()",
+        "fetchSchedulerAudit()",
+        "openSchedModal(sid)",
+        "function _linkifyScheduleIds(safeHtml)",
+    ] {
+        assert!(body.contains(needle), "schedule navigation lost `{needle}`");
+    }
+    assert!(
+        app.contains("_linkifyScheduleIds(_linkifyCardIds(safe))"),
+        "the shared message-row renderer must link schedule ids in message text"
+    );
+    assert!(
+        app.contains("_linkifyScheduleIds(origin.replace"),
+        "scheduled-message origin is where the canonical SCHED-N token lives"
+    );
+}
+
+#[test]
+fn sse_message_invalidation_refreshes_each_visible_message_surface() {
+    let app = asset("app.js");
+    let start = app
+        .find("if (key === 'messages')")
+        .expect("SSE invalidation must recognize committed Messages writes");
+    let body = &app[start..start + 1100.min(app.len() - start)];
+    for needle in [
+        "_messagesLoad(true)",
+        "_peekMessagesLoad()",
+        "_loadCmdHistoryFromServer()",
+        "_renderCmdHistoryList()",
+    ] {
+        assert!(body.contains(needle), "message invalidation no longer refreshes `{needle}`");
+    }
+}
+
 /// The parser above must be able to FAIL, or the test above it is theatre —
 /// a `const_str` that always returned None would make both sides `expect`-panic,
 /// but one that silently returned the same string for everything would make the

--- a/crates/amux-server/tests/dashboard_assets.rs
+++ b/crates/amux-server/tests/dashboard_assets.rs
@@ -98,6 +98,28 @@ fn app_ver_and_the_sw_cache_version_agree() {
     );
 }
 
+#[test]
+fn board_worker_actions_group_wrapped_lines_under_their_timestamp() {
+    let app = asset("app.js");
+    let start = app
+        .find("function _bdParseHistory(log)")
+        .expect("board history parser must exist");
+    let rest = &app[start..];
+    let end = rest
+        .find("function _bdWorkerActivity(item)")
+        .expect("worker activity parser must follow history parser");
+    let parser = &rest[..end];
+    assert!(parser.contains("const grouped = []"), "parser no longer groups physical lines");
+    assert!(
+        parser.contains("grouped[grouped.length - 1].body += '\\n' + body.trim()"),
+        "an untimestamped continuation must append to the preceding timestamped action"
+    );
+    assert!(
+        !parser.contains("split('\\n').filter(l => l.trim()).map(line =>"),
+        "the old one-physical-line-equals-one-action parser returned"
+    );
+}
+
 /// The parser above must be able to FAIL, or the test above it is theatre —
 /// a `const_str` that always returned None would make both sides `expect`-panic,
 /// but one that silently returned the same string for everything would make the

--- a/e2e/system-jobs.spec.ts
+++ b/e2e/system-jobs.spec.ts
@@ -92,13 +92,19 @@ test('system jobs render with real data, separated from user schedules', async (
   expect(selfAdopt?.status).toBe('disabled');
   expect(selfAdopt?.disabled_reason).toBe('AMUX_NO_SELF_ADOPT');
 
-  // No mutation affordances: these are machinery, not user data.
-  // Asserted on BUTTONS, not on the word: `getByText('Delete')` matched the
-  // section's own note ("you cannot edit or delete them"), which would have
-  // failed forever on prose that is doing exactly the right thing.
+  // No edit/delete affordances: these are machinery, not user data. A later
+  // requested capability added one narrow control per row: Run now wakes a
+  // triggerable job without changing its definition. The old blanket
+  // `button === 0` assertion therefore failed on all three browser projects
+  // while the UI was doing exactly what the server contract requested.
   const sysSection = page.locator('.sysjob-section');
-  await expect(sysSection.locator('button')).toHaveCount(0);
+  const runButtons = sysSection.locator('button.sysjob-run');
+  await expect(runButtons).toHaveCount(jobs.jobs.length);
+  await expect(sysSection.locator('button:not(.sysjob-run)')).toHaveCount(0);
   await expect(sysSection.locator('.sched-action-btn')).toHaveCount(0);
+  const triggerable = jobs.jobs.filter((j: any) => j.triggerable).length;
+  await expect(sysSection.locator('button.sysjob-run:enabled')).toHaveCount(triggerable);
+  await expect(sysSection.locator('button.sysjob-run:disabled')).toHaveCount(jobs.jobs.length - triggerable);
 
   // Exactly one live switch — the autofix pref, which the server re-reads on
   // every tick. Env vars render as readouts; a checkbox over one would claim

--- a/e2e/worker-card-counts.spec.ts
+++ b/e2e/worker-card-counts.spec.ts
@@ -12,7 +12,7 @@ async function appToken(page: Page): Promise<string> {
   return tok;
 }
 
-test('worker card shows total board items on the sched row', async ({ page, request }, testInfo) => {
+test('worker card shows the truthful board status breakdown on the sched row', async ({ page, request }, testInfo) => {
   await page.goto('/');
   await page.waitForLoadState('networkidle');
   const token = await appToken(page);
@@ -30,7 +30,8 @@ test('worker card shows total board items on the sched row', async ({ page, requ
     data: { name: worker, dir: '/tmp', desc: 'e2e count fixture' },
   });
 
-  // 3 items for this worker: 1 doing, 2 not. Total must read 3, doing 1.
+  // One item in each actionable pre-terminal state. The card must preserve
+  // those distinctions: parked work is not evidence that a worker is active.
   for (const st of ['doing', 'todo', 'backlog']) {
     const res = await request.post('/api/board', {
       headers: auth,
@@ -52,24 +53,13 @@ test('worker card shows total board items on the sched row', async ({ page, requ
   // The ASSERTION IS THE NUMBER, not merely that a badge is present: a counter
   // that renders the wrong figure is worse than none.
   //
-  // Asserted against what the renderer actually emits (ffa00e4's predicate):
-  // "N doing · M active[ · T total]", where active counts ALL non-terminal
-  // cards and the total segment is HIDDEN when total === active. The previous
-  // assertions wanted "3 items" and an .mc-total element — text this renderer
-  // has never produced (that was an earlier badge's shape) — so the spec
-  // failed on its first real CI run while the feature worked. With 3
-  // non-terminal seeds (1 doing) and nothing terminal, the badge must read
-  // "1 doing · 3 active" and mc-total must be absent.
-  expect(text).toContain('1 doing');
-  expect(text).toContain('3 active');
+  // This used to flatten todo/backlog into "active", which made idle workers
+  // look busy. Assert the complete text and semantic hooks so that misleading
+  // aggregation cannot return unnoticed.
+  expect(text).toContain('1 doing · 1 todo · 1 backlog');
   await expect(card.locator('.mc-doing')).toHaveText('1');
-  await expect(card.locator('.mc-active')).toHaveText('3');
-  expect(await card.locator('.mc-total').count()).toBe(0);
-
-  // active >= doing must hold by construction (shared predicate).
-  const active = Number(await card.locator('.mc-active').textContent());
-  const doing = Number(await card.locator('.mc-doing').textContent());
-  expect(active).toBeGreaterThanOrEqual(doing);
+  await expect(card.locator('.mc-todo')).toHaveText('1');
+  await expect(card.locator('.mc-backlog')).toHaveText('1');
 
   // cleanup
   await request.delete(`/api/sessions/${worker}`, { headers: auth });

--- a/e2e/worker-configurations.spec.ts
+++ b/e2e/worker-configurations.spec.ts
@@ -1,0 +1,139 @@
+// Worker Configurations is the one place an operator should be able to change
+// every durable worker setting, board automation, gates, terminal-state
+// availability, memory, rules, environment, skin, and connectors. This drives
+// the real dashboard and real Rust API against each project's throwaway home.
+import { test, expect } from './fixtures';
+
+test('worker Configurations edits the full board lifecycle and every scoped capability', async ({ page, request }, testInfo) => {
+  await page.goto('/');
+  const token = await page.evaluate(() => (window as any)._AMUX_AUTH_TOKEN as string);
+  expect(token, 'served bootstrap must provide the API token').toBeTruthy();
+  const auth = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+
+  // A fresh test home opens onboarding over the worker list. Dismiss it through
+  // its own UI so the test follows the same path as a first-time operator.
+  const walkthrough = page.locator('#wt-overlay.open');
+  await walkthrough.waitFor({ state: 'visible', timeout: 2_000 }).catch(() => {});
+  if (await walkthrough.isVisible()) await page.locator('#wt-tooltip .wt-skip').click();
+
+  const name = `config-${testInfo.project.name}-${Date.now()}`;
+  try {
+    const created = await request.post('/api/sessions', {
+      headers: auth,
+      data: { name, dir: '/tmp', tags: ['e2e-configurations'] },
+    });
+    expect(created.status()).toBe(201);
+
+    await page.reload();
+    const card = page.locator(`.card[data-session="${name}"]`).locator('visible=true').first();
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await card.locator('.card-menu-btn').click();
+    await page.locator('.card-menu.open .card-menu-item', { hasText: 'Peek terminal' }).click();
+
+    await page.getByRole('button', { name: /Configurations$/ }).click();
+    const panel = page.locator('#peek-scope-body');
+    await expect(panel).toContainText('Worker settings');
+    await expect(panel).toContainText('Board automation');
+    await expect(panel.getByRole('switch')).toHaveCount(7);
+    for (const key of [
+      'name', 'description', 'task_label', 'groups', 'directory', 'branch',
+      'provider', 'model', 'effort', 'mcp', 'yolo', 'isolated', 'cross_group',
+      'pinned', 'advanced_environment',
+    ]) {
+      await expect(panel.locator(`[data-worker-config="${key}"]`), `missing ${key}`).toHaveCount(1);
+    }
+
+    // Shared text editor wiring: mutate a harmless durable field through the
+    // new location and observe the API truth after the panel reconciles.
+    await panel.locator('[data-worker-config="description"]').getByRole('button', { name: 'Edit' }).click();
+    await page.locator('#edit-input').fill('configured entirely from the worker UI');
+    await page.locator('#edit-overlay').getByRole('button', { name: 'Save' }).click();
+    await expect.poll(async () => {
+      const rows = await request.get('/api/sessions', { headers: auth });
+      return (await rows.json()).find((s: any) => s.name === name)?.desc;
+    }).toBe('configured entirely from the worker UI');
+
+    // Structured select wiring: MCP/browser tooling must be configurable here,
+    // not by knowing CC_MCP and editing a file. Return it to disabled so the
+    // throwaway worker has no hidden capability after the assertion.
+    await panel.locator('[data-worker-config="mcp"]').getByRole('button', { name: 'Edit' }).click();
+    await page.locator('#edit-select').selectOption('chrome');
+    await expect.poll(async () => {
+      const rows = await request.get('/api/sessions', { headers: auth });
+      return (await rows.json()).find((s: any) => s.name === name)?.mcp;
+    }).toBe('chrome');
+    await panel.locator('[data-worker-config="mcp"]').getByRole('button', { name: 'Edit' }).click();
+    await page.locator('#edit-select').selectOption('');
+
+    // Permission value path: unlike the old all-or-nothing toggle, the UI can
+    // express an exact allow-list and clear it again.
+    await panel.locator('[data-worker-config="cross_group"]').getByRole('button', { name: 'Edit' }).click();
+    await page.locator('#edit-input').fill('e2e-destination');
+    await page.locator('#edit-overlay').getByRole('button', { name: 'Save' }).click();
+    await expect.poll(async () => {
+      const rows = await request.get('/api/sessions', { headers: auth });
+      return (await rows.json()).find((s: any) => s.name === name)?.spans_groups_value;
+    }).toBe('e2e-destination');
+    await panel.locator('[data-worker-config="cross_group"]').getByRole('button', { name: 'Edit' }).click();
+    await page.locator('#edit-input').fill('');
+    await page.locator('#edit-overlay').getByRole('button', { name: 'Save' }).click();
+    for (const label of [
+      'Backlog → To Do',
+      'To Do → In Progress',
+      'Continue non-terminal work',
+      'Pickup / continue master',
+    ]) {
+      await expect(panel).toContainText(label);
+    }
+
+    // The server advertises seven worker-level capabilities. Every one must
+    // open the shared editor; the old UI offered a button only for text and
+    // told users to edit the other five "where they live".
+    const tiles = panel.locator('.scope-tile');
+    await expect(tiles).toHaveCount(7);
+    for (let i = 0; i < 7; i += 1) {
+      await tiles.nth(i).click();
+      await expect(panel.getByRole('button', { name: /^Edit .+ at this level$/ })).toBeVisible();
+      await tiles.nth(i).click();
+      await expect(panel.getByRole('button', { name: /^Edit .+ at this level$/ })).toHaveCount(0);
+    }
+
+    // Default path: both queue transitions are on for every worker without a
+    // redundant per-worker key.
+    await expect.poll(async () => {
+      const rows = await request.get('/api/sessions', { headers: auth });
+      const worker = (await rows.json()).find((s: any) => s.name === name);
+      return [worker?.auto_drain_backlog, worker?.auto_drain_backlog_own,
+        worker?.auto_pickup, worker?.auto_pickup_own];
+    }).toEqual([true, false, true, false]);
+
+    // Explicit opt-out path: turn backlog drain off without changing To Do
+    // pickup or the master switch.
+    let backlogRow = panel.locator('.scope-detail > div', { hasText: 'Backlog → To Do' }).first();
+    await backlogRow.getByRole('switch').click();
+    await expect.poll(async () => {
+      const rows = await request.get('/api/sessions', { headers: auth });
+      const worker = (await rows.json()).find((s: any) => s.name === name);
+      return [worker?.auto_drain_backlog, worker?.auto_drain_backlog_own];
+    }).toEqual([false, true]);
+
+    // Inheritance path: remove the worker override and prove the runtime falls
+    // back to the fleet default (backlog and To Do are both auto-driven).
+    backlogRow = panel.locator('.scope-detail > div', { hasText: 'Backlog → To Do' }).first();
+    await backlogRow.getByRole('button', { name: 'Inherit' }).click();
+    await expect.poll(async () => {
+      const rows = await request.get('/api/sessions', { headers: auth });
+      const worker = (await rows.json()).find((s: any) => s.name === name);
+      return [worker?.auto_drain_backlog, worker?.auto_drain_backlog_own];
+    }).toEqual([true, false]);
+
+    // Mobile guard: the longer tab name and configuration controls must not widen the
+    // page beyond the viewport on any browser project.
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > document.documentElement.clientWidth + 1,
+    );
+    expect(overflow).toBe(false);
+  } finally {
+    await request.delete(`/api/sessions/${name}`, { headers: auth }).catch(() => {});
+  }
+});

--- a/e2e/worker-configurations.spec.ts
+++ b/e2e/worker-configurations.spec.ts
@@ -25,6 +25,14 @@ test('worker Configurations edits the full board lifecycle and every scoped capa
     expect(created.status()).toBe(201);
 
     await page.reload();
+    // CHAOS CELL: another worker can create pending permission grants while
+    // this operator is opening Configurations. The real full-suite race grew
+    // this global strip over the upward-opening worker menu and swallowed the
+    // Peek click. Keep that concurrency shape deterministic in this spec.
+    await page.locator('#email-approvals-banner').evaluate((el: HTMLElement) => {
+      el.style.display = 'block';
+      el.innerHTML = '<div style="height:240px">Concurrent permission request</div>';
+    });
     const card = page.locator(`.card[data-session="${name}"]`).locator('visible=true').first();
     await expect(card).toBeVisible({ timeout: 10_000 });
     await card.locator('.card-menu-btn').click();


### PR DESCRIPTION
## What changed

- preserve durable board truth across provider and model switches by hydrating the restarted worker from structured cards, source messages, epics, dependencies, priorities, next actions, gates, worker actions, and assets instead of replaying raw terminal logs
- redact secret-shaped environment variables from diagnostic logs and terminal peek payloads as defense in depth
- make active-model reporting process-scoped so stale transcript/provider metadata cannot survive a switch
- prevent timestamp-prefixed `[no-board]` prompts and non-mutating answer-only questions from creating cards
- reject ambiguous slash-joined multi-file strings from asset extraction so cards do not show ghost file links
- keep logical artifact IDs and prose as text, and resolve actual repository-relative file references without duplicating the worker's configured subdirectory
- group wrapped worker-action continuation lines under their timestamp in card details
- publish committed Message events and refresh each visible Messages surface from SSE invalidations
- classify Codex's signed-out access-token screen as a non-retryable worker failure instead of IDLE
- make `SCHED-N` references in Messages navigate to the live schedule editor/audit context
- replace the worker tile's ambiguous “active” board count with the actual doing/todo/backlog/needs-you/review/done breakdown
- rename worker Scope to Configurations and make all seven advertised worker capabilities editable from that surface
- inventory every durable worker setting in Configurations: name, description/task label, groups, directory/branch, provider/model/effort, MCP, YOLO, isolation, exact cross-group send allowance, pinning, and advanced startup environment
- add first-class Backlog → To Do, To Do → In Progress, non-terminal continuation, and pickup/continue-master switches with worker override/inherit behavior
- make Backlog → To Do default-on for every new and existing worker, matching default-on To Do pickup while preserving explicit opt-out and all parked/human/trigger exclusions
- allow masked environment keys to be removed from the UI and render nested Skin/Connector settings as configured
- align the system-jobs browser invariant with the intentional Run now controls while still forbidding edit/delete schedule affordances
- import a selected ordinary Chrome login into an isolated, durable amux-owned profile on first use, so workers never need the user to quit Chrome, the TTL reaper cannot discard login state, and amux never drives or mutates the human profile
- keep worker menus above concurrent approval banners, and pin that full-suite race with a deterministic chaos cell
- update the worker-card regression to assert the truthful doing/todo/backlog breakdown instead of the retired “active” aggregate
- bump the dashboard and service-worker cache versions together

## Why

An end-to-end browser audit of `amux-testing-e2e` across Claude/sonnet, Codex/gpt-5.5, Codex/gpt-5.6-sol, and Gemini/auto found that the normal dependency workflow worked, but model switches could expose stale identity and raw prior terminal context, explicit answer-only prompts still minted cards, asset IDs/prose and repository-relative paths produced invalid links, wrapped action logs rendered as disconnected fragments, committed Messages had no realtime event, schedule references were inert, an isolated signed-out Codex worker rendered as IDLE, worker tiles called parked and done work “active,” and the worker Scope tab exposed only two of seven advertised capabilities as editable. Its remaining worker settings and board-drive controls were scattered across card menus and raw environment keys, and backlog dispatch contradicted To Do pickup by defaulting off. Live TubeScience follow-up then showed browser starts repeatedly delegating to the user's already-running Chrome because amux targeted the human user-data-dir directly. CI additionally caught stale three-browser UI assertions and a genuine approval-banner/menu race.

## Verification

- `bash scripts/test-tree-clean.sh cargo test --workspace` — complete workspace, integration, and doc-test run passed; amux-server library: 1,838 passed, 0 failed, 7 ignored (1,845 discovered)
- `scripts/test-contended.sh -p amux-server --test nudge_commands_exist` — 2 passed
- `scripts/test-contended.sh -p amux-core --lib capture_tests` — 6 passed
- `scripts/test-contended.sh -p amux-server --lib task_asset_resolution_tests` — 2 passed
- `scripts/test-contended.sh -p amux-server --test dashboard_assets` — 15 passed
- `cargo test -p amux-server chrome_profile_import --lib` — 2 passed (isolated copy, Local State normalization, lock/cache exclusion, reuse, missing/unsafe source failures)
- working-tree Playwright `worker-card-counts.spec.ts worker-configurations.spec.ts` — 6 passed across desktop Chromium, mobile Chromium, and WebKit, including the concurrent approval-banner chaos cell
- working-tree Playwright `system-jobs.spec.ts worker-configurations.spec.ts` — 12 passed across desktop Chromium, mobile Chromium, and WebKit (complete settings inventory, seven scoped editors, four lifecycle switches, default/opt-out/inheritance, persistence, permission and MCP round trips, overflow)
- `scripts/safe-cargo.sh check -p amux-server`
- `scripts/safe-cargo.sh clippy -p amux-server --all-targets -- -D warnings`
- `node --check crates/amux-dashboard/static/app.js`
- `node --check crates/amux-dashboard/static/sw.js`
- `git diff --check`

## Live audit notes

The model matrix also covered ordered decomposition, dependency blocking, WIP refusal/recovery, subagent tasks, clickable artifacts, source-message/card linkage, isolated-worker behavior, scheduled jobs, and safe machine cleanup. Read-only follow-up inspection covered the legacy `MSG-38618` / `TUBES-2373` TubeScience graph and Primis's all-parked queue. Remaining product gaps observed during that audit are documented separately; this PR does not claim to migrate legacy graphs, solve weak semantic gate evidence, every board-view crash/staleness path, real-world oversized-request decomposition, or parked-trigger relationship quality.
