### PR TITLE
fix(cloud): make provider workers actually runnable

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -220,9 +220,9 @@ and every endpoint they call is routed on the rust server (checked against
   human clicking hits immediately. Needs the container's chromium, which the
   image now ships.
 * **`tests/e2e_smoke.py`** — Clerk user → gateway auth → sessions per provider →
-  BYO key → logout. ⚠ it exercises Codex and Gemini; the image only installs the
-  **claude** CLI, so those two arms fail on a missing binary until `@openai/codex`
-  and `@google/gemini-cli` are added to the Dockerfile.
+  BYO key → verified model reply → logout. The image installs and build-checks
+  Claude, Codex, and Gemini; the test treats a missing binary, auth/onboarding
+  screen, unconfirmed submission, or missing deterministic reply as a failure.
 * **`tests/e2e_trial.py`** — trial provisioning, invite acceptance, budget 402 +
   session stop, pro upgrade. Purely gateway-level.
 * **`tests/godmode_walkthrough.py`** — signs in as an admin and collects evidence

--- a/cloud/docker/Dockerfile
+++ b/cloud/docker/Dockerfile
@@ -125,17 +125,22 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Claude Code. This MUST run its postinstall: it downloads the platform-native
-# binary. A previous build used `--ignore-scripts ... 2>/dev/null || true`,
-# which skipped that download and swallowed the error, so every cloud container
-# shipped a `claude` that failed at runtime with "native binary not installed".
-RUN npm install -g @anthropic-ai/claude-code
+# Every provider the New Worker UI advertises. These MUST run their postinstall
+# scripts: Claude and Codex download platform-native binaries. Shipping the
+# provider enum without its executable makes create/start/send all look healthy
+# while the pane contains only `command not found`.
+RUN npm install -g \
+      @anthropic-ai/claude-code \
+      @openai/codex \
+      @google/gemini-cli
 
 # Fail the BUILD, not the customer's session, if the CLI is not runnable.
 # Same reasoning for chromium: the browser primitive resolving to nothing is a
 # capability that silently does not exist, and this is the last moment it is
 # cheap to notice.
 RUN claude --version && echo "claude CLI verified at build time" \
+    && codex --version && echo "codex CLI verified at build time" \
+    && gemini --version && echo "gemini CLI verified at build time" \
     && chromium --version && echo "chromium verified at build time"
 
 # Chrome cannot start with the server's launch flags in a container: there is no

--- a/cloud/tests/e2e_smoke.py
+++ b/cloud/tests/e2e_smoke.py
@@ -4,13 +4,15 @@ amux cloud E2E smoke test — runs daily via amux scheduler.
 
 Creates a test user via Clerk Backend API, authenticates through the gateway,
 exercises sessions with each provider (Claude, Codex, Gemini), tests BYO API
-key flow, verifies logout/re-login, then cleans up.
+key flow, verifies a deterministic model reply, verifies logout/re-login, then
+cleans up.
 
 Env vars required (set in ~/.amux/server.env or shell):
   CLERK_SECRET_KEY   — Clerk backend key (sk_live_...)
   COOKIE_SECRET      — gateway HMAC secret for amux_session cookies
   ANTHROPIC_API_KEY  — for BYO key test (Claude)
   OPENAI_API_KEY     — for BYO key test (Codex)
+  GEMINI_API_KEY     — for BYO key test (Gemini; optional alias)
   GOOGLE_API_KEY     — for BYO key test (Gemini)
 
 Usage:
@@ -279,6 +281,7 @@ def test_api_keys(cookie):
     step("BYO API key flow — save and verify")
     anthropic_key = os.environ.get("ANTHROPIC_API_KEY", "")
     openai_key = os.environ.get("OPENAI_API_KEY", "")
+    gemini_key = os.environ.get("GEMINI_API_KEY", "")
     google_key = os.environ.get("GOOGLE_API_KEY", "")
 
     keys_to_set = {}
@@ -286,6 +289,8 @@ def test_api_keys(cookie):
         keys_to_set["ANTHROPIC_API_KEY"] = anthropic_key
     if openai_key:
         keys_to_set["OPENAI_API_KEY"] = openai_key
+    if gemini_key:
+        keys_to_set["GEMINI_API_KEY"] = gemini_key
     if google_key:
         keys_to_set["GOOGLE_API_KEY"] = google_key
 
@@ -308,7 +313,7 @@ def test_api_keys(cookie):
         for key_name in keys_to_set:
             masked = data.get(key_name, "")
             if masked and len(masked) > 4:
-                ok(f"{key_name} verified (masked: ...{masked[-4:]})")
+                ok(f"{key_name} verified (masked)")
             else:
                 fail(f"{key_name} not found or empty after save")
     else:
@@ -316,14 +321,20 @@ def test_api_keys(cookie):
 
 
 def test_sessions(cookie):
-    step("Create and interact with sessions — one per provider")
+    step("Create sessions and verify a real model reply — one per provider")
     providers = [
-        ("e2e-claude", "claude"),
-        ("e2e-codex", "codex"),
-        ("e2e-gemini", "gemini"),
+        ("e2e-claude", "claude", bool(os.environ.get("ANTHROPIC_API_KEY"))),
+        ("e2e-codex", "codex", bool(os.environ.get("OPENAI_API_KEY"))),
+        (
+            "e2e-gemini",
+            "gemini",
+            bool(os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")),
+        ),
     ]
     created = []
-    for name, provider in providers:
+    provider_by_name = {}
+    has_credentials = {}
+    for name, provider, credential_available in providers:
         code, body, _ = gw_request("POST", "/api/sessions", cookie=cookie, body={
             "name": name,
             "provider": provider,
@@ -332,12 +343,16 @@ def test_sessions(cookie):
         if code == 200 or code == 201:
             ok(f"Session '{name}' ({provider}) created")
             created.append(name)
+            provider_by_name[name] = provider
+            has_credentials[name] = credential_available
         else:
             # Session might already exist — try to start it
             code2, _, _ = gw_request("POST", f"/api/sessions/{name}/start", cookie=cookie)
-            if code2 == 200:
+            if code2 in (200, 202):
                 ok(f"Session '{name}' ({provider}) already exists, started")
                 created.append(name)
+                provider_by_name[name] = provider
+                has_credentials[name] = credential_available
             else:
                 fail(f"Session '{name}' ({provider}) create failed: {code} {body[:100]}")
 
@@ -345,21 +360,103 @@ def test_sessions(cookie):
     log("Waiting 15s for CLI initialization...")
     time.sleep(15)
 
-    # Peek at each session to verify it has output (CLI loaded)
+    def peek(name, lines=400):
+        code, body, _ = gw_request(
+            "GET", f"/api/sessions/{name}/peek?lines={lines}", cookie=cookie, timeout=60
+        )
+        if code != 200:
+            return code, ""
+        try:
+            data = json.loads(body)
+        except json.JSONDecodeError:
+            return code, ""
+        return code, (data.get("history") or "") + "\n" + (data.get("output") or "")
+
+    def failure_hint(provider, output):
+        low = output.lower()
+        if f"{provider}: command not found" in low or "command not found" in low:
+            return f"{provider} CLI is missing from the workspace image"
+        if provider == "codex" and "welcome to codex" in low and "sign in" in low:
+            return "Codex stopped at its authentication onboarding screen"
+        if provider == "claude" and ("not logged in" in low or "choose a theme" in low):
+            return "Claude stopped at its authentication/onboarding screen"
+        if provider == "gemini" and ("login" in low or "api key" in low):
+            return "Gemini stopped at its authentication/onboarding screen"
+        return "no verified assistant response appeared"
+
+    # A shell prompt, welcome screen, or eleven characters of terminal output
+    # is not an agent. Fail missing binaries immediately, then make each
+    # credentialed provider answer a challenge whose expected digest never
+    # appears in the prompt.
+    pending = {}
     for name in created:
-        code, body, _ = gw_request("GET", f"/api/sessions/{name}/peek?lines=20", cookie=cookie)
-        if code == 200:
-            try:
-                data = json.loads(body)
-                output = data.get("output", "")
-                if output.strip():
-                    ok(f"Session '{name}' running ({len(output)} chars output)")
-                else:
-                    warn(f"Session '{name}' has no output yet")
-            except json.JSONDecodeError:
-                warn(f"Session '{name}' peek returned non-JSON")
-        else:
-            warn(f"Session '{name}' peek returned {code}")
+        provider = provider_by_name[name]
+        code, output = peek(name, lines=80)
+        if code != 200:
+            fail(f"Session '{name}' ({provider}) peek returned {code}")
+            continue
+        if "command not found" in output.lower():
+            fail(f"Session '{name}' ({provider}): {failure_hint(provider, output)}")
+            continue
+        if not has_credentials[name]:
+            warn(f"Session '{name}' ({provider}) CLI present; active reply skipped (no test key)")
+            continue
+
+        challenge = f"amux-e2e-{provider}-{time.time_ns()}"
+        expected = hashlib.sha256(challenge.encode()).hexdigest()
+        prompt = (
+            "Compute the SHA-256 hex digest of the exact ASCII string "
+            f"{challenge!r}. Reply with the 64-character lowercase digest only."
+        )
+        code, body, _ = gw_request(
+            "POST",
+            f"/api/sessions/{name}/send",
+            body={
+                "text": prompt,
+                "record_history": True,
+                "deliver_now": True,
+                "no_board": True,
+            },
+            cookie=cookie,
+            timeout=60,
+        )
+        try:
+            sent = json.loads(body)
+        except json.JSONDecodeError:
+            sent = {}
+        if code != 200 or not sent.get("ok"):
+            fail(f"Session '{name}' ({provider}) send failed: HTTP {code}")
+            continue
+        if sent.get("submitted") is not True:
+            fail(
+                f"Session '{name}' ({provider}) did not confirm submission: "
+                f"{sent.get('submission') or sent.get('message') or 'unknown'}"
+            )
+            continue
+        pending[name] = {"provider": provider, "expected": expected, "last_output": output}
+
+    reply_timeout = max(30, int(os.environ.get("E2E_REPLY_TIMEOUT", "180")))
+    deadline = time.time() + reply_timeout
+    while pending and time.time() < deadline:
+        time.sleep(6)
+        for name in list(pending):
+            state = pending[name]
+            code, output = peek(name)
+            if code != 200:
+                state["last_code"] = code
+                continue
+            state["last_output"] = output
+            if state["expected"] in output.lower():
+                ok(f"Session '{name}' ({state['provider']}) returned the verified digest")
+                del pending[name]
+            elif "command not found" in output.lower():
+                fail(f"Session '{name}' ({state['provider']}): {failure_hint(state['provider'], output)}")
+                del pending[name]
+
+    for name, state in pending.items():
+        provider = state["provider"]
+        hint = failure_hint(provider, state.get("last_output", ""))
+        fail(f"Session '{name}' ({provider}) reply timed out after {reply_timeout}s: {hint}")
 
     # Stop sessions to save resources (don't delete — test deletion later)
     for name in created:
@@ -410,7 +507,7 @@ def test_cleanup_sessions(cookie, session_names):
     step("Cleanup — stop test sessions")
     for name in session_names:
         code, _, _ = gw_request("POST", f"/api/sessions/{name}/stop", cookie=cookie)
-        if code == 200:
+        if code in (200, 202):
             ok(f"Session '{name}' stopped")
         else:
             warn(f"Session '{name}' stop returned {code}")

--- a/crates/amux-server/src/api/session_verbs.rs
+++ b/crates/amux-server/src/api/session_verbs.rs
@@ -7069,18 +7069,34 @@ async fn start_session(state: &AppState, name: &str, extra_flags: &str, skip_con
     if provider != "codex" && provider != "gemini" && provider != "ollama" && has_oauth {
         shell_rc.push_str("unset ANTHROPIC_API_KEY; ");
     }
+    // Settings writes provider keys to server.env at runtime. Reading that file
+    // here is what makes the next worker actually inherit a key saved through
+    // the UI; std::env still contains only the values captured at server boot.
+    // Keep the values out of shell_rc/logs and pass them straight to tmux's
+    // child environment.
+    let runtime_provider_env = super::settings::runtime_provider_env(&home());
+    let provider_value = |key: &str| {
+        runtime_provider_env
+            .iter()
+            .find(|(name, _)| name == key)
+            .map(|(_, value)| value.clone())
+    };
     let mut env_args: Vec<String> = Vec::new();
     if has_oauth {
         env_args.push("-e".into());
         env_args.push("ANTHROPIC_API_KEY=".into());
-    } else if let Ok(v) = std::env::var("ANTHROPIC_API_KEY") {
-        if !v.is_empty() {
+    } else if let Some(v) = provider_value("ANTHROPIC_API_KEY") {
+        env_args.push("-e".into());
+        env_args.push(format!("ANTHROPIC_API_KEY={v}"));
+    }
+    for k in ["OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"] {
+        if let Some(v) = provider_value(k) {
             env_args.push("-e".into());
-            env_args.push(format!("ANTHROPIC_API_KEY={v}"));
+            env_args.push(format!("{k}={v}"));
         }
     }
     for k in [
-        "ANTHROPIC_API_BASE", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY",
+        "ANTHROPIC_API_BASE",
         "GOOGLE_GENAI_USE_VERTEXAI", "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION",
     ] {
         if let Ok(v) = std::env::var(k) {
@@ -7093,6 +7109,30 @@ async fn start_session(state: &AppState, name: &str, extra_flags: &str, skip_con
 
     let tmux_sess = tmux_name(name);
     let tmux_exists = tmux_sessions_set().await.contains(&tmux_sess);
+    if tmux_exists {
+        // A stopped worker keeps its tmux session and shell. Updating
+        // server.env and pressing Start must not reuse the credentials that
+        // shell inherited before the PATCH. Refresh tmux's session environment
+        // now; the shell imports it below without ever printing a value.
+        let target = st(name);
+        for key in super::settings::PROVIDER_ENV_KEYS {
+            let value = if has_oauth && key == "ANTHROPIC_API_KEY" {
+                None
+            } else {
+                provider_value(key)
+            };
+            let refreshed = match value {
+                Some(value) => tmux(&["set-environment", "-t", &target, key, &value]).await,
+                None => tmux(&["set-environment", "-u", "-t", &target, key]).await,
+            };
+            if !refreshed.map(|out| out.status.success()).unwrap_or(false) {
+                return (
+                    false,
+                    format!("could not refresh {key} for the existing tmux session"),
+                );
+            }
+        }
+    }
     if tmux_exists {
         // Reuse the surviving tmux session (py:24589).
         let output = tmux_capture(name, 10).await;
@@ -7125,6 +7165,20 @@ async fn start_session(state: &AppState, name: &str, extra_flags: &str, skip_con
                 poll_shell_prompt(name, 3000).await;
             }
         }
+        // `tmux set-environment` changes what future pane processes inherit;
+        // this shell already exists. Import the session environment through
+        // tmux's shell-escaped output. The typed command contains no values,
+        // so provider keys cannot land in terminal history or pane logs.
+        let target = st(name);
+        type_line(
+            name,
+            &format!(
+                "eval \"$(tmux show-environment -s -t {})\"",
+                sh_quote(&target)
+            ),
+        )
+        .await;
+        poll_shell_prompt(name, 3000).await;
     } else {
         // Fresh tmux session hosting the user's login shell (py:24647).
         let cols = tmux_cols();

--- a/crates/amux-server/src/api/session_verbs.rs
+++ b/crates/amux-server/src/api/session_verbs.rs
@@ -7130,7 +7130,14 @@ async fn start_session(state: &AppState, name: &str, extra_flags: &str, skip_con
         // server.env and pressing Start must not reuse the credentials that
         // shell inherited before the PATCH. Refresh tmux's session environment
         // now; the shell imports it below without ever printing a value.
-        let target = st(name);
+        // Bound as `st`, not `target`: tests/tmux_target_audit.rs whitelists the
+        // literal expressions ["st","pt","stq","ptq"] as a `-t` argument, so a
+        // correctly-derived target under any other name fails the audit. The
+        // VALUE was already exact here (st() is session_target(tmux_name(..)),
+        // i.e. "=amux-<n>"); only the binding's name was outside the list, and
+        // `let pt = pane_target(sess)` a few thousand lines down is the same
+        // convention.
+        let st = st(name);
         for key in super::settings::PROVIDER_ENV_KEYS {
             let value = if has_oauth && key == "ANTHROPIC_API_KEY" {
                 None
@@ -7138,8 +7145,8 @@ async fn start_session(state: &AppState, name: &str, extra_flags: &str, skip_con
                 provider_value(key)
             };
             let refreshed = match value {
-                Some(value) => tmux(&["set-environment", "-t", &target, key, &value]).await,
-                None => tmux(&["set-environment", "-u", "-t", &target, key]).await,
+                Some(value) => tmux(&["set-environment", "-t", &st, key, &value]).await,
+                None => tmux(&["set-environment", "-u", "-t", &st, key]).await,
             };
             if !refreshed.map(|out| out.status.success()).unwrap_or(false) {
                 return (

--- a/crates/amux-server/src/api/settings.rs
+++ b/crates/amux-server/src/api/settings.rs
@@ -16,10 +16,11 @@
 //!   go file-first instead: a non-empty server.env value wins, then process
 //!   env, then the default. Observable behavior matches Python: a PATCH is
 //!   immediately visible to the next GET without a restart.
-//! - The Python ANTHROPIC_API_KEY PATCH also re-inits claude config and
-//!   pushes the key into every running tmux session. That is the Python
-//!   server's runtime to manage — while it owns the tmux fleet (Phase 11
-//!   cutover pending), duplicating the push here would race it. Not ported.
+//! - Rust never mutates the process-global environment after startup. New
+//!   workers and web terminals resolve provider credentials from `server.env`
+//!   at launch instead, so a PATCH has live effect without a process restart
+//!   or a process-wide `set_var` race. Already-running workers still need an
+//!   explicit restart before they can inherit a changed credential.
 //! - `defaults.env` writes are atomic with mode 0600 (Python's
 //!   `_atomic_write_secure`); `server.env` writes are plain rewrites
 //!   (Python's are too).
@@ -467,8 +468,22 @@ async fn patch_task_guard(Json(body): Json<Value>) -> Response {
 
 /// The only keys the settings UI may read (masked) or write. Fixed array,
 /// not a set: response key order is stable.
-const ALLOWED_ENV_KEYS: [&str; 4] =
+pub(crate) const PROVIDER_ENV_KEYS: [&str; 4] =
     ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"];
+
+/// Provider credentials a newly spawned process should inherit.
+///
+/// Keep this derived from the settings allow-list: a key that the UI says it
+/// saved but no worker/terminal launch reads is the exact false-success shape
+/// this API must avoid. Values are never logged or returned by this helper.
+pub(crate) fn runtime_provider_env(home: &Path) -> Vec<(String, String)> {
+    PROVIDER_ENV_KEYS
+        .iter()
+        .filter_map(|key| {
+            effective_env(home, key).map(|value| ((*key).to_string(), value))
+        })
+        .collect()
+}
 
 /// Python's mask: >8 chars shows stars + last 4; short-but-set shows "set";
 /// unset shows "". Never the value itself.
@@ -487,7 +502,7 @@ pub(crate) fn mask_secret(v: &str) -> String {
 async fn get_env() -> Response {
     let home = amux_home();
     let mut out = Map::new();
-    for k in ALLOWED_ENV_KEYS {
+    for k in PROVIDER_ENV_KEYS {
         let v = effective_env(&home, k).unwrap_or_default();
         out.insert(k.to_string(), Value::String(mask_secret(&v)));
     }
@@ -499,7 +514,7 @@ async fn patch_env(Json(body): Json<Value>) -> Response {
         .as_object()
         .map(|o| {
             o.iter()
-                .filter(|(k, v)| ALLOWED_ENV_KEYS.contains(&k.as_str()) && v.is_string())
+                .filter(|(k, v)| PROVIDER_ENV_KEYS.contains(&k.as_str()) && v.is_string())
                 .map(|(k, v)| (k.clone(), v.as_str().unwrap_or("").to_string()))
                 .collect()
         })
@@ -513,8 +528,8 @@ async fn patch_env(Json(body): Json<Value>) -> Response {
             return err(StatusCode::INTERNAL_SERVER_ERROR, json!({ "error": e.to_string() }));
         }
     }
-    // Python also mutates os.environ and pushes ANTHROPIC_API_KEY into
-    // running tmux sessions; see the module doc for why neither is ported.
+    // Consumers read server.env at process launch through runtime_provider_env;
+    // no process-global environment mutation is needed here.
     Json(json!({ "ok": true })).into_response()
 }
 
@@ -1049,6 +1064,28 @@ mod tests {
         assert_eq!(mask_secret("short"), "set");
         assert_eq!(mask_secret("12345678"), "set");
         assert_eq!(mask_secret("sk-ant-api03-abcd"), "*************abcd");
+    }
+
+    #[test]
+    fn runtime_provider_env_reads_fresh_file_values_and_honours_clear() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path();
+        set_server_env_key(home, "OPENAI_API_KEY", "fixture-openai-value").unwrap();
+        // An explicit empty value is a clear, even when the process running the
+        // test happens to have a same-named key in its ambient environment.
+        set_server_env_key(home, "GOOGLE_API_KEY", "").unwrap();
+        set_server_env_key(home, "NOT_A_PROVIDER_KEY", "must-not-escape").unwrap();
+
+        let values = runtime_provider_env(home);
+        assert_eq!(
+            values
+                .iter()
+                .find(|(key, _)| key == "OPENAI_API_KEY")
+                .map(|(_, value)| value.as_str()),
+            Some("fixture-openai-value")
+        );
+        assert!(!values.iter().any(|(key, _)| key == "GOOGLE_API_KEY"));
+        assert!(!values.iter().any(|(key, _)| key == "NOT_A_PROVIDER_KEY"));
     }
 
     #[test]

--- a/crates/amux-server/src/api/terminal.rs
+++ b/crates/amux-server/src/api/terminal.rs
@@ -142,6 +142,15 @@ fn spawn_pty(cols: u16, rows: u16) -> Result<String, String> {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".into());
     let mut cmd = CommandBuilder::new(&shell);
     cmd.env("TERM", "xterm-256color");
+    // `/api/settings/env` is a runtime file update; it intentionally does not
+    // mutate Rust's process-global environment. Resolve the current file-backed
+    // values for every new terminal so a key the UI just saved is usable from
+    // the official shell as well as from a newly launched worker.
+    for (key, value) in
+        super::settings::runtime_provider_env(&super::settings::amux_home())
+    {
+        cmd.env(key, value);
+    }
     if let Ok(home) = std::env::var("HOME") {
         cmd.cwd(home);
     }


### PR DESCRIPTION
## Summary

- Install and build-check the Claude, Codex, and Gemini CLIs in the Cloud runtime image.
- Load file-backed BYO provider credentials into new workers, restarted workers, and web terminals without exposing values in pane history.
- Upgrade the Cloud smoke test from checking for terminal output to requiring a deterministic, verified model reply.

## Production evidence

Fresh-account Cloud E2E testing found that:

- Codex and Gemini workers failed with `command not found` in the production image.
- Provider keys saved and masked successfully in Settings, but fresh terminals did not inherit the saved OpenAI key.
- Worker create/start/send endpoints could report success without a usable model response.

This change addresses those runtime causes and makes the smoke suite fail if a CLI is missing, authentication falls back to onboarding, message submission is not acknowledged, or the expected reply never arrives.

## Validation

- `cargo test -p amux-server --lib api::settings::tests -- --nocapture` (11 passed)
- `cargo test -p amux-server --test dockerfile_build_inputs -- --nocapture`
- `python3 -m compileall -q cloud/tests`
- `docker build --check -f cloud/docker/Dockerfile .`
- `git diff --cached --check`
- Verified the tmux environment refresh/import command with a disposable local session.
- Verified npm package metadata exposes `claude`, `codex`, and `gemini` binaries with compatible Node requirements.

## Validation note

A disposable live Docker package-install check could not complete because local Docker Desktop stopped responding after pulling the base image. The Dockerfile syntax check passed, and the image build now executes each CLI's `--version` command so CI/build infrastructure will fail immediately if any runtime is unavailable.

## Out of scope

Scheduler shadow mode, pricing-copy inconsistency, polling versus local SSE, cold-start messaging, and schedule timing are separate findings and are intentionally not changed here.
