### PR TITLE
fix(autofix): AMUX-112 -- GET /api/gmail/accounts is LONG_BY_DESIGN, budget 30s

### DIFF
--- a/crates/amux-server/src/runtime_jobs/autofix.rs
+++ b/crates/amux-server/src/runtime_jobs/autofix.rs
@@ -233,6 +233,24 @@ const LONG_BY_DESIGN: &[(&str, f64)] = &[
     // exactly what a design-bounded quota wait looks like from outside.
     // 30s matches /api/email/inbox's own reasoning (2x worst measured).
     ("/api/gmail/inbox", 30_000.0),
+    // GET /api/gmail/accounts (AMUX-112, third filing on the same residual —
+    // AMUX-84/90 before it). A DIFFERENT route from /api/gmail/inbox above (a
+    // health-probe rollup, not a message list) but the SAME shape once
+    // AMUX-84 fixed its own N+1: `accounts()`'s per-account `account_health`
+    // calls run through `buffered(8)` — with only 3 connected accounts today
+    // that is effectively full concurrency, so total latency is bounded by
+    // whichever ONE account's probe is slowest, not by the account count.
+    // `probe_health`'s own comment already measured this: "24.3s across 3
+    // connected accounts" — a real, accepted worst case baked into the code
+    // BEFORE this entry existed, not a guess made here. That number comes
+    // from the same `ReqwestTransport` this whole gmail integration shares
+    // (integrations/email.rs, `.timeout(Duration::from_secs(30))`), and
+    // `probe_health` can chain up to two such calls (a profile GET, then a
+    // token-refresh POST on a 401) — so a single wedged call still hits the
+    // SAME 30s per-call bound the sibling entries above already reason from.
+    // 30s, not 2x 24.3s: matches the transport's own timeout directly, the
+    // same choice /api/gmail/inbox made for the identical reason.
+    ("/api/gmail/accounts", 30_000.0),
     // GET /api/email/search (AMUX-3690). THE ARGUMENT IS NOT "it is also slow",
     // it is that this route and the one above are the SAME CODE: both call
     // `email::inbox_messages`, so both inherit its 8-wide concurrency, its
@@ -12347,6 +12365,58 @@ mod tests {
         let (f2, _) = detect_latency(&st.store.read().unwrap(), now + 1.0);
         assert!(
             f2.iter().any(|x| x.signature.contains("/api/gmail/inbox")),
+            "past the 30s budget this is a hang, not a design duration, and must still file: {f2:?}"
+        );
+    }
+
+    /// AMUX-112: /api/gmail/accounts is a health-probe rollup (a DIFFERENT
+    /// function, `accounts()`, from `list_messages` above) but shares the
+    /// same transport (`ReqwestTransport`, 30s timeout) and the same
+    /// bounded-concurrency shape AMUX-84 gave it — with today's 3 connected
+    /// accounts under `buffered(8)`, total latency is bounded by the single
+    /// slowest account's probe, and `probe_health`'s own comment already
+    /// measured that worst case at 24.3s.
+    #[tokio::test]
+    async fn gmail_accounts_is_judged_against_its_own_measured_worst_case() {
+        let (st, _d) = state();
+        let now = unix_now();
+        log_row(
+            &st,
+            Row {
+                ts: now - 300.0,
+                method: "GET",
+                path: "/api/gmail/accounts",
+                family: "/api/gmail",
+                status: 200,
+                body: "",
+                worker: "",
+                ua: "curl/8",
+                ms: 24_300.0, // probe_health's own documented worst measured
+            },
+        );
+        let (f, _) = detect_latency(&st.store.read().unwrap(), now);
+        assert!(
+            !f.iter().any(|x| x.signature.contains("/api/gmail/accounts")),
+            "inside its 30s design budget, a health-probe rollup must not file: {f:?}"
+        );
+
+        log_row(
+            &st,
+            Row {
+                ts: now - 100.0,
+                method: "GET",
+                path: "/api/gmail/accounts",
+                family: "/api/gmail",
+                status: 200,
+                body: "",
+                worker: "",
+                ua: "curl/8",
+                ms: 45_000.0,
+            },
+        );
+        let (f2, _) = detect_latency(&st.store.read().unwrap(), now + 1.0);
+        assert!(
+            f2.iter().any(|x| x.signature.contains("/api/gmail/accounts")),
             "past the 30s budget this is a hang, not a design duration, and must still file: {f2:?}"
         );
     }


### PR DESCRIPTION
Third filing on the same residual (AMUX-84/90 before it). The card's own occurrence (20015ms) is comfortably inside the worst case already measured and documented in the code itself: `probe_health`'s own comment says "24.3s across 3 connected accounts" — a real production measurement, not a guess made here.

**Root cause of the recurring filing:** this route shares `/api/gmail/inbox`'s exact shape (a bounded-concurrency fix from AMUX-84, the same `ReqwestTransport` with its 30s per-call timeout in `integrations/email.rs`) but never got the matching `LONG_BY_DESIGN` entry `gmail/inbox` already has — so the detector's flat 10s floor kept firing on every legitimate slow-account health check.

**Fix:** added `("/api/gmail/accounts", 30_000.0)`, same reasoning `gmail/inbox`'s own entry already uses (matches the transport's own timeout directly, not a padded guess), plus a test that pins the lookup and asserts the entry still files past 30s (a real transport hang stays a real hang).

Verified via Woodpecker CI (clone/check/clippy/test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)