### PR TITLE
fix(backup): restore scripts/amux-credential-backup.sh -- silently lost, service failing every run

### DIFF
--- a/scripts/amux-credential-backup.sh
+++ b/scripts/amux-credential-backup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Periodic backup of single-copy credential-shaped files under ~/.amux —
+# files this box has NO other recovery path for if they vanish (AMUX-76:
+# ~/.amux/gmail-oauth-client.json disappeared from disk with root cause
+# never determined; recovery only worked because its client_id/secret
+# happened to ALSO live in server.env under a different key — a lucky
+# coincidence this script exists so the next file doesn't need).
+#
+# Deliberately narrow: only files known to be (a) single-copy — nothing
+# else on this box holds their content, and (b) not already covered by
+# git or another backup path. Add to this list as new single-copy
+# credential files are introduced; do NOT widen it to "everything in
+# ~/.amux" — most of that is either regenerable, DB-backed (already has
+# its own durability story), or explicitly gitignored on purpose.
+#
+# No secret VALUES appear in this script or its own output — only paths.
+set -euo pipefail
+
+AMUX_HOME="${AMUX_HOME:-$HOME/.amux}"
+BACKUP_DIR="$AMUX_HOME/backups/credentials"
+KEEP=10 # prune to the last N backups per file, so this can't grow unbounded
+
+FILES=(
+  "$AMUX_HOME/gmail-oauth-client.json"
+)
+
+mkdir -p "$BACKUP_DIR"
+chmod 700 "$BACKUP_DIR"
+
+ts="$(date -u +%Y%m%dT%H%M%SZ)"
+backed_up=0
+for f in "${FILES[@]}"; do
+  name="$(basename "$f")"
+  if [ ! -f "$f" ]; then
+    echo "amux-credential-backup: $name is MISSING right now — cannot back up what is not there" >&2
+    continue
+  fi
+  dest="$BACKUP_DIR/${name}.${ts}"
+  cp "$f" "$dest"
+  chmod 600 "$dest"
+  backed_up=$((backed_up + 1))
+  # Prune: keep only the newest $KEEP backups for this file.
+  # shellcheck disable=SC2012
+  ls -1t "$BACKUP_DIR/${name}."* 2>/dev/null | tail -n +$((KEEP + 1)) | xargs -r rm -f
+done
+echo "amux-credential-backup: backed up $backed_up/${#FILES[@]} file(s) to $BACKUP_DIR"


### PR DESCRIPTION
Found while answering an infra peer's questions about migrating the shared box: `amux-credential-backup.service` (AMUX-76 — backs up single-copy credential files, specifically `~/.amux/gmail-oauth-client.json`, whose earlier unexplained disappearance is exactly what this service exists to guard against recurring) has been **failing on every single 6h run** since shortly after it was first installed:

```
systemd[...]: Unable to locate executable '/home/syseng/src/amux/scripts/amux-credential-backup.sh': No such file or directory
systemd[...]: Main process exited, code=exited, status=203/EXEC
```

The script was genuinely committed once (`a41dea63`, 2026-09-01) and its systemd unit + timer are both still correctly installed and enabled — but the script itself is absent from current `main` entirely, with **no delete commit** in its history. Most likely dropped silently during one of this session's many large multi-way merges rather than deliberately removed (the "clean merge, zero conflict markers, still wrong" class of defect `CLAUDE.local.md` already documents from a separate incident).

**Real exposure**: only ONE backup ever succeeded (`2026-09-01T11:04:23Z`, the very first run); every run since has 203/EXEC'd silently into the journal — nothing surfaces a `Type=oneshot` failure anywhere a session would see it by default. ~2 days with zero backup protection on a file whose own commit message says plainly "no other recovery path." The protected file itself is still present on disk (confirmed), so nothing was actually lost — but the safety net covering it was gone the whole time.

**Fix**: restored the script byte-for-byte from `a41dea63` (no drift to reconcile). Ran it live post-restore: `backed up 1/1 file(s)` — confirmed a fresh timestamped backup now exists, closing the exposure window immediately rather than waiting for the next scheduled tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)