### PR TITLE
fix(gitignore): exclude RESUME.md -- per-lane handoff notes, never public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,12 @@ node_modules/
 package-lock.json
 scratch/
 
+# Per-lane session handoff notes (e.g. ahead of a host migration) — real
+# internal infra detail (IPs, secrets paths, unit names) belongs here, not
+# in a public repo. Filesystem-level backups can still cover this path;
+# it just never goes through git.
+RESUME.md
+
 # Compiled app binary (rebuild via ./desktop/build-desktop.sh)
 Amux.app/Contents/MacOS/amux
 


### PR DESCRIPTION
infra asked every lane to write a `RESUME.md` ahead of tonight's host migration (CT 250 → a new VM), summarizing in-flight state so a fresh session can resume cleanly if raw Claude Code session history doesn't survive the cutover. That note necessarily carries real internal infra detail (IPs, secrets file paths, systemd unit names, SSH key identities) — exactly the class of thing this repo's own `CLAUDE.local.md` pattern already exists to keep out of a public repo, just for a new, temporary file shape rather than a permanent one.

Gitignoring it structurally protects against an accidental `git add -A`/`git add RESUME.md` in this shared checkout picking it up. The file itself still exists on disk and is covered by the migration's own filesystem-level backup — it just never goes through git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)