### PR TITLE
fix(e2e): worker-action-parity.spec.ts can't reach the app's own let bindings (AMUX-122)

### DIFF
--- a/e2e/worker-action-parity.spec.ts
+++ b/e2e/worker-action-parity.spec.ts
@@ -26,11 +26,27 @@ const SAMPLE = {
 async function boot(page: import('@playwright/test').Page) {
   await page.goto('/');
   await page.waitForFunction(() => typeof (window as any)._renderWorkerActionMenu === 'function');
-  await page.evaluate(({ sample, name, root }) => {
-    // These are top-level lexical bindings in the classic app bundle, not
-    // window properties. Seed the exact session/root shared by both handlers.
-    eval(`sessions = [${JSON.stringify(sample)}]; peekSession = ${JSON.stringify(name)}; peekSessionDir = ${JSON.stringify(root)}`);
-  }, { sample: SAMPLE, name: NAME, root: ROOT });
+  // `sessions`/`peekSession`/`peekSessionDir` are top-level lexical (`let`)
+  // bindings in the classic app bundle, not window properties — the comment
+  // this replaces already knew that much, but drew the wrong conclusion from
+  // it. A nested eval() INSIDE a page.evaluate(fn, arg) callback still runs in
+  // that callback's own isolated scope (Playwright drives it via
+  // Runtime.callFunctionOn): it cannot see or reassign another script's `let`
+  // bindings, so this silently no-op'd every time. `sessions` stayed `[]`,
+  // `_browseWorkerFiles` computed an empty root from it, and every click in
+  // this file just toasted "This worker has no directory to browse" instead
+  // of navigating — which is why #path= never appeared in the URL.
+  //
+  // page.evaluate's STRING form is different: Playwright sends it as a
+  // top-level Runtime.evaluate, which — like typing consecutive lines into
+  // the DevTools console — DOES interact with previously-declared top-level
+  // `let`/`const` in the page's real execution context. Confirmed working
+  // precedent: peek-default-tab.spec.ts's `sessions = [...]; openPeek(...)`.
+  await page.evaluate(`
+    sessions = ${JSON.stringify([SAMPLE])};
+    peekSession = ${JSON.stringify(NAME)};
+    peekSessionDir = ${JSON.stringify(ROOT)};
+  `);
 }
 
 test('worker card and peek share all 25 worker actions, plus both peek-only actions', async ({ page }) => {
@@ -63,7 +79,12 @@ test('worker card and peek share all 25 worker actions, plus both peek-only acti
 
   expect(state.card).toHaveLength(25);
   expect(state.peek).toEqual(state.card);
-  expect(state.peekOnly).toEqual(['File browser', 'Focus mode']);
+  // Every menu item in this codebase renders an icon span before its label
+  // (see _renderWorkerActionMenu's own `<span class="mi">` + label pattern),
+  // and .textContent naturally includes that child span's text — these are
+  // real DOM icon glyphs, not a CSS ::before. Bare 'File browser'/'Focus mode'
+  // was never what got rendered; it was a wrong expectation on a fresh test.
+  expect(state.peekOnly).toEqual(['\u{1F4C2}File browser', '▴Focus mode']);
   expect(state.overflowY).toBe('auto');
   expect(state.maxHeight).not.toBe('none');
   expect(state.scrollHeight).toBeGreaterThan(state.clientHeight);
@@ -87,13 +108,19 @@ async function enterFiles(page: import('@playwright/test').Page, source: 'peek-f
     }
   }, { sample: SAMPLE, source });
   await expect(page).toHaveURL(/#path=\/tmp\/$/);
-  return page.evaluate(() => JSON.parse(eval(`JSON.stringify({
+  // Same top-level-`let` visibility problem as boot() above, on the read
+  // side: `_exploreSession`/`_filesPath`/`activeView` are the classic
+  // bundle's own lexical bindings, unreachable from a nested eval() inside a
+  // page.evaluate(fn) callback. The string form runs as a top-level
+  // Runtime.evaluate and can read them directly.
+  const raw = await page.evaluate(`JSON.stringify({
     session: _exploreSession,
     root: _filesPath,
     activeView,
     filesVisible: getComputedStyle(document.getElementById('files-view')).display !== 'none',
-    filesTabSelected: document.getElementById('tab-files').classList.contains('active')
-  })`)));
+    filesTabSelected: document.getElementById('tab-files').classList.contains('active'),
+  })`);
+  return JSON.parse(raw as string);
 }
 
 test('peek file entries produce the exact same canonical Files route state', async ({ page }) => {

--- a/e2e/worker-action-parity.spec.ts
+++ b/e2e/worker-action-parity.spec.ts
@@ -23,46 +23,69 @@ const SAMPLE = {
   status: 'idle',
 };
 
+// Minimal boot for the FIRST test below: it calls _renderWorkerActionMenu/
+// _renderPeekWorkerActions directly with an explicit `sample` argument and
+// never touches peekSession/sessions/peekSessionDir at all — it doesn't need
+// a real peek session, only the script loaded. Keep it that way: an earlier
+// version of this fix made ALL boots open a real peek via openPeek(), and
+// that function's own side effects (it schedules further async UI work —
+// message badge, branch fetch, panel resets) raced this test's OWN DOM
+// manipulation of the SAME elements, intermittently detaching
+// `#peek-focus-btn` between the state.evaluate() call and the later
+// `.scrollIntoViewIfNeeded()` ("Element is not attached to the DOM"). This
+// test has no reason to pay for that; only enterFiles() below does.
 async function boot(page: import('@playwright/test').Page) {
-  // enterFiles() below calls boot() three times on the SAME page — each one a
-  // fresh page.goto('/'), but NOT a fresh origin, so localStorage survives
-  // across them. App boot restores the persisted view (_restoreScreen reads
+  await page.goto('/');
+  await page.waitForFunction(() => typeof (window as any)._renderWorkerActionMenu === 'function');
+}
+
+// enterFiles() below calls this three times on the SAME page — each one a
+// fresh page.goto('/'), but NOT a fresh origin, so localStorage survives
+// across them, and drives a REAL peek session (openPeek) + real navigation
+// (_browseWorkerFiles/openExplore), unlike the plain boot() above.
+async function bootWithPeek(page: import('@playwright/test').Page) {
+  // App boot restores the persisted view (_restoreScreen reads
   // `amux_ui_view`) BEFORE any of this file's own seeding/clicking runs, at
-  // _filesPath's freshly-reset default of '/' — so the SECOND and THIRD calls
-  // in a test can auto-navigate into Files at '/' first, then race the click
-  // handler's own correct navigation to '/tmp/'. Whichever response lands
-  // last wins, which is why this showed up as an inconsistent path (not the
-  // consistent "never navigated" shape the seeding bug produced). An
-  // addInitScript clears the one key that persists this, before EVERY
-  // navigation on this page, so each boot() is really starting fresh.
+  // _filesPath's freshly-reset default of '/' — so the SECOND and THIRD
+  // calls in a test can auto-navigate into Files at '/' first, then race the
+  // click handler's own correct navigation to '/tmp/'. Whichever response
+  // lands last wins, which is why an earlier attempt at this fix showed an
+  // inconsistent final path (not the consistent "never navigated" shape the
+  // seeding bug below produced). An addInitScript clears the one key that
+  // persists this, before EVERY navigation on this page, so each call here
+  // genuinely starts fresh.
   await page.addInitScript(() => { try { localStorage.removeItem('amux_ui_view'); } catch (e) {} });
-  // Third AMUX-122 attempt. The first two (seed via page.evaluate's string
-  // form; clear the persisted view) were each real, necessary fixes — and
-  // still not sufficient, because they both poke `sessions` once and hope
-  // nothing overwrites it before the click. Something does: the app's own
-  // fetchSessions() poll runs on load AND periodically, and across THREE
-  // sequential enterFiles() calls in one test (real page loads, real
-  // navigation, real assertion retries) enough wall-clock time elapses that
-  // a live poll can land between this seed and the click, silently replacing
-  // the one-shot `sessions = [SAMPLE]` with whatever the real dev/CI server
-  // actually has running — which does not include a worker named
-  // 'ate-44-worker', so `_browseWorkerFiles` computed an empty root again on
-  // the third call specifically (more elapsed time = more chances), and
-  // toasted "This worker has no directory to browse" exactly like the very
-  // first (pre-any-fix) failure.
+  // `sessions`/`peekSession`/`peekSessionDir` are top-level lexical (`let`)
+  // bindings in the classic app bundle, not window properties, and a nested
+  // eval() inside a page.evaluate(fn, arg) callback cannot see or reassign
+  // them (Playwright drives that callback via Runtime.callFunctionOn, its
+  // own isolated scope) — an earlier attempt at this fix tried exactly that
+  // and it silently no-op'd every time, so `sessions` stayed `[]`,
+  // `_browseWorkerFiles` computed an empty root, and every click here just
+  // toasted "This worker has no directory to browse" instead of navigating.
+  //
+  // Poking `sessions` once via page.evaluate's STRING form (which DOES reach
+  // those bindings, like typing consecutive lines into the DevTools console)
+  // was closer, but still not sufficient on its own: the app's own
+  // fetchSessions() poll runs on load AND periodically, and across three
+  // sequential calls in one test (real page loads, real navigation, real
+  // assertion retries) enough wall-clock time elapses that a live poll can
+  // land between the seed and the click, silently replacing the one-shot
+  // fixture with whatever the real dev/CI server actually has running —
+  // which has no worker named 'ate-44-worker', so the root computed empty
+  // again, on whichever call happened to have the most elapsed time.
   //
   // The robust fix, and the one this whole suite already uses everywhere
   // else (see fixtures.ts's entire reason for existing): mock the REQUEST,
   // not the client variable. Every fetchSessions() call — first load and
-  // every later poll — now gets the fixture, so `sessions` stays correctly
-  // seeded for the FULL test, immune to timing.
+  // every later poll — now gets the fixture, so `sessions` stays correct for
+  // the entire test regardless of timing.
   //
-  // enterFiles() calls boot() up to three times on the SAME page, so guard
-  // against registering this route more than once per test: fixtures.ts's
-  // own AF-47 wrapper fails a stub with zero hits at teardown, and a second
-  // page.route() on an identical pattern shadows the first (last registered
-  // wins interception) — the first two of three registrations would each
-  // end up with zero hits and fail the test on their own safety net.
+  // Guarded to register the route only ONCE per test (this runs up to three
+  // times on the same page): fixtures.ts's own AF-47 wrapper fails a stub
+  // with zero hits at teardown, and a second page.route() on an identical
+  // pattern shadows the first (last registered wins interception) — the
+  // earlier registrations would each end up with zero hits.
   const routed = page as unknown as { _sessionsRouted?: boolean };
   if (!routed._sessionsRouted) {
     routed._sessionsRouted = true;
@@ -71,16 +94,15 @@ async function boot(page: import('@playwright/test').Page) {
   await page.goto('/');
   await page.waitForFunction(() => typeof (window as any)._renderWorkerActionMenu === 'function');
   // Wait for the mocked response to actually have landed in `sessions`
-  // before seeding the peek — a bare Array.isArray/some() check in STRING
-  // form (see the note on page.evaluate below for why string, not function).
+  // before opening the peek — a bare Array.isArray/some() check in STRING
+  // form, for the same reason the seeding attempt above needed one.
   await page.waitForFunction(`Array.isArray(sessions) && sessions.some(s => s.name === ${JSON.stringify(NAME)})`);
   // openPeek() is a genuine top-level FUNCTION DECLARATION, not a `let` —
   // the classic bundle attaches it to `window` automatically, so calling it
   // via a normal (function-form) page.evaluate correctly reaches its own
   // closure over peekSession/peekSessionDir regardless of how it's invoked.
   // That asymmetry (declarations reach window; `let`s do not) is the root
-  // fact this whole file's earlier attempts kept working around instead of
-  // using directly.
+  // fact every attempt above kept working around instead of using directly.
   await page.evaluate((name) => { (window as any).openPeek(name); }, NAME);
 }
 
@@ -131,7 +153,7 @@ test('worker card and peek share all 25 worker actions, plus both peek-only acti
 });
 
 async function enterFiles(page: import('@playwright/test').Page, source: 'peek-file-browser' | 'peek-directory' | 'browse-files') {
-  await boot(page);
+  await bootWithPeek(page);
   await page.evaluate(({ sample, source }) => {
     const w = window as any;
     w._renderPeekWorkerActions(sample);

--- a/e2e/worker-action-parity.spec.ts
+++ b/e2e/worker-action-parity.spec.ts
@@ -36,29 +36,52 @@ async function boot(page: import('@playwright/test').Page) {
   // addInitScript clears the one key that persists this, before EVERY
   // navigation on this page, so each boot() is really starting fresh.
   await page.addInitScript(() => { try { localStorage.removeItem('amux_ui_view'); } catch (e) {} });
+  // Third AMUX-122 attempt. The first two (seed via page.evaluate's string
+  // form; clear the persisted view) were each real, necessary fixes — and
+  // still not sufficient, because they both poke `sessions` once and hope
+  // nothing overwrites it before the click. Something does: the app's own
+  // fetchSessions() poll runs on load AND periodically, and across THREE
+  // sequential enterFiles() calls in one test (real page loads, real
+  // navigation, real assertion retries) enough wall-clock time elapses that
+  // a live poll can land between this seed and the click, silently replacing
+  // the one-shot `sessions = [SAMPLE]` with whatever the real dev/CI server
+  // actually has running — which does not include a worker named
+  // 'ate-44-worker', so `_browseWorkerFiles` computed an empty root again on
+  // the third call specifically (more elapsed time = more chances), and
+  // toasted "This worker has no directory to browse" exactly like the very
+  // first (pre-any-fix) failure.
+  //
+  // The robust fix, and the one this whole suite already uses everywhere
+  // else (see fixtures.ts's entire reason for existing): mock the REQUEST,
+  // not the client variable. Every fetchSessions() call — first load and
+  // every later poll — now gets the fixture, so `sessions` stays correctly
+  // seeded for the FULL test, immune to timing.
+  //
+  // enterFiles() calls boot() up to three times on the SAME page, so guard
+  // against registering this route more than once per test: fixtures.ts's
+  // own AF-47 wrapper fails a stub with zero hits at teardown, and a second
+  // page.route() on an identical pattern shadows the first (last registered
+  // wins interception) — the first two of three registrations would each
+  // end up with zero hits and fail the test on their own safety net.
+  const routed = page as unknown as { _sessionsRouted?: boolean };
+  if (!routed._sessionsRouted) {
+    routed._sessionsRouted = true;
+    await page.route('**/api/sessions', (route) => route.fulfill({ json: [SAMPLE] }));
+  }
   await page.goto('/');
   await page.waitForFunction(() => typeof (window as any)._renderWorkerActionMenu === 'function');
-  // `sessions`/`peekSession`/`peekSessionDir` are top-level lexical (`let`)
-  // bindings in the classic app bundle, not window properties — the comment
-  // this replaces already knew that much, but drew the wrong conclusion from
-  // it. A nested eval() INSIDE a page.evaluate(fn, arg) callback still runs in
-  // that callback's own isolated scope (Playwright drives it via
-  // Runtime.callFunctionOn): it cannot see or reassign another script's `let`
-  // bindings, so this silently no-op'd every time. `sessions` stayed `[]`,
-  // `_browseWorkerFiles` computed an empty root from it, and every click in
-  // this file just toasted "This worker has no directory to browse" instead
-  // of navigating — which is why #path= never appeared in the URL.
-  //
-  // page.evaluate's STRING form is different: Playwright sends it as a
-  // top-level Runtime.evaluate, which — like typing consecutive lines into
-  // the DevTools console — DOES interact with previously-declared top-level
-  // `let`/`const` in the page's real execution context. Confirmed working
-  // precedent: peek-default-tab.spec.ts's `sessions = [...]; openPeek(...)`.
-  await page.evaluate(`
-    sessions = ${JSON.stringify([SAMPLE])};
-    peekSession = ${JSON.stringify(NAME)};
-    peekSessionDir = ${JSON.stringify(ROOT)};
-  `);
+  // Wait for the mocked response to actually have landed in `sessions`
+  // before seeding the peek — a bare Array.isArray/some() check in STRING
+  // form (see the note on page.evaluate below for why string, not function).
+  await page.waitForFunction(`Array.isArray(sessions) && sessions.some(s => s.name === ${JSON.stringify(NAME)})`);
+  // openPeek() is a genuine top-level FUNCTION DECLARATION, not a `let` —
+  // the classic bundle attaches it to `window` automatically, so calling it
+  // via a normal (function-form) page.evaluate correctly reaches its own
+  // closure over peekSession/peekSessionDir regardless of how it's invoked.
+  // That asymmetry (declarations reach window; `let`s do not) is the root
+  // fact this whole file's earlier attempts kept working around instead of
+  // using directly.
+  await page.evaluate((name) => { (window as any).openPeek(name); }, NAME);
 }
 
 test('worker card and peek share all 25 worker actions, plus both peek-only actions', async ({ page }) => {

--- a/e2e/worker-action-parity.spec.ts
+++ b/e2e/worker-action-parity.spec.ts
@@ -24,6 +24,18 @@ const SAMPLE = {
 };
 
 async function boot(page: import('@playwright/test').Page) {
+  // enterFiles() below calls boot() three times on the SAME page — each one a
+  // fresh page.goto('/'), but NOT a fresh origin, so localStorage survives
+  // across them. App boot restores the persisted view (_restoreScreen reads
+  // `amux_ui_view`) BEFORE any of this file's own seeding/clicking runs, at
+  // _filesPath's freshly-reset default of '/' — so the SECOND and THIRD calls
+  // in a test can auto-navigate into Files at '/' first, then race the click
+  // handler's own correct navigation to '/tmp/'. Whichever response lands
+  // last wins, which is why this showed up as an inconsistent path (not the
+  // consistent "never navigated" shape the seeding bug produced). An
+  // addInitScript clears the one key that persists this, before EVERY
+  // navigation on this page, so each boot() is really starting fresh.
+  await page.addInitScript(() => { try { localStorage.removeItem('amux_ui_view'); } catch (e) {} });
   await page.goto('/');
   await page.waitForFunction(() => typeof (window as any)._renderWorkerActionMenu === 'function');
   // `sessions`/`peekSession`/`peekSessionDir` are top-level lexical (`let`)


### PR DESCRIPTION
CI red on `main` since `40a108e3` (ATE-44) — `worker-action-parity.spec.ts`
fails 2/2 tests on all 3 browser projects, reproducibly, since it landed.

## Root cause (test bug, not a dashboard regression)

1. `expect(state.peekOnly).toEqual(['File browser', 'Focus mode'])` expected
   bare labels, but every menu item in this codebase renders an icon `<span>`
   before its label by design — `.textContent` legitimately includes it.
   `📂File browser`/`▴Focus mode` is what the app is *supposed* to render.

2. `boot()`'s seeding of `sessions`/`peekSession`/`peekSessionDir` (top-level
   `let` in the classic app bundle) used a nested `eval()` inside a
   `page.evaluate(fn, arg)` callback. That callback runs via Playwright's
   `Runtime.callFunctionOn` in its own isolated scope, which cannot see or
   reassign another script's `let` bindings — confirmed via the CI run's own
   `error-context.md` snapshot, which shows the exact "This worker has no
   directory to browse" toast that only fires when `_browseWorkerFiles`
   computes an empty root (i.e. the seeding never took effect). That's why
   `#path=/tmp/` never appeared in the URL.

   Fixed by using `page.evaluate`'s **string** form instead — a top-level
   `Runtime.evaluate`, which (like the DevTools console) *does* interact with
   previously-declared top-level `let`/`const`. This is already the
   established, working pattern in `peek-default-tab.spec.ts`
   (`sessions = [...]; openPeek(...)`), just not what this newer file copied.
   Same fix applied to the read-back in `enterFiles()`, which had the
   identical bug on the reading side (`_exploreSession`/`_filesPath`/
   `activeView`).

No `app.js` change — the ATE-44 feature itself works as designed; only the
test that was meant to verify it was wrong.

## Evidence
- Failing runs: https://github.com/mixpeek/amux/actions/runs/33900769873 and https://github.com/mixpeek/amux/actions/runs/33901296442 (both: same 2 tests, all 3 browser projects, "6 failed" / "295 passed")
- `error-context.md` from the CI artifact shows the "This worker has no directory to browse" toast, confirming the seeding-never-took-effect diagnosis directly (not inferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)