### PR TITLE
Add knos to .mcp.json so agents share one decision record

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "knos": {
+      "command": "python",
+      "args": [
+        "-m",
+        "knos.mcp"
+      ]
+    }
+  }
+}

--- a/examples/knos-decisions.example.md
+++ b/examples/knos-decisions.example.md
@@ -5,8 +5,8 @@
 
 ## Decisions
 
-- **rule 1** - Whenever you fix a bug: 1) fix it at the root cause, 2) make it surface in amux logs so a sweep would catch it. _(source: CLAUDE.md)_
-- **rule 2** - `crates/amux-server` -- axum server: `src/api/`, `src/db/`, `migrations/`, `src/runtime_jobs/` _(source: CLAUDE.md)_
+- Whenever you fix a bug: 1) fix it at the root cause, 2) make it surface in amux logs so a sweep would catch it. _(source: CLAUDE.md)_
+- `crates/amux-server` -- axum server: `src/api/`, `src/db/`, `migrations/`, `src/runtime_jobs/` _(source: CLAUDE.md)_
 
 ## Being worked on right now
 

--- a/examples/knos-decisions.example.md
+++ b/examples/knos-decisions.example.md
@@ -1,0 +1,17 @@
+# Decisions and current work
+
+<!-- Example record. `knos export` writes this file in an adopting repo; it is
+     plain markdown, so a fresh clone reads it with nothing installed. -->
+
+## Decisions
+
+- **rule 1** - Whenever you fix a bug: 1) fix it at the root cause, 2) make it surface in amux logs so a sweep would catch it. _(source: CLAUDE.md)_
+- **rule 2** - `crates/amux-server` -- axum server: `src/api/`, `src/db/`, `migrations/`, `src/runtime_jobs/` _(source: CLAUDE.md)_
+
+## Being worked on right now
+
+_Nothing claimed._
+
+---
+<sub>One record every agent working in this repo reads. Claims lapse after 30
+minutes or on `knos done`.</sub>


### PR DESCRIPTION
mixpeek/amux runs more than one coding agent over the same tree. Agents do not
see each other's decisions, so two of them can reach opposite conclusions about
the same file in the same hour, and neither one knows.

**What this adds**

- `knos` in a new `.mcp.json`, the standard MCP config location - a local MCP server (`pip install knos`, Python 3.10+).
  No network, no account, no model download; one SQLite file.
- `examples/knos-decisions.example.md` - the shape of the record it writes,
  seeded with two rules taken from this repo's own CLAUDE.md, so the format is
  visible without installing anything.

**What it does**

When one agent claims a piece of work, another agent asking about that topic is
told who holds it instead of being handed the answer. Claims lapse after 30
minutes, so a crashed agent cannot hold work forever.

**Runtime note:** the server needs Python 3.10+ and `pip install knos`. Nothing
else in the repo depends on it - if it is absent, the example file still reads
normally and no other tooling changes.

Disclosure: I wrote knos. Happy to drop either half, or close this, if it is not
a fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
