### PR TITLE
fix(email-themes): call registry::tick() so the loop can report its own health (AMUX-123)

### DIFF
--- a/crates/amux-server/src/api/email_intel.rs
+++ b/crates/amux-server/src/api/email_intel.rs
@@ -689,6 +689,18 @@ pub async fn theme_refresh_loop() {
     // and the mechanism disagree.
     loop {
         one_theme_pass().await;
+        // AMUX-123: this loop never called the registry's tick() — every
+        // sibling loop of this exact "do the work, then sleep for the
+        // interval" shape does (see pipe_reconcile_loop). Without it, `ticks`
+        // stays 0 and `last_tick_at` stays null FOREVER, regardless of
+        // whether the loop is actually healthy: classify()'s own "never
+        // ticked past the stall budget" rule then reports this job as
+        // `stalled` on every single run, permanently, whether or not a real
+        // recompute (or a legitimate skip-because-fresh) happened. Recorded
+        // here rather than inside one_theme_pass() itself, so a skip counts
+        // as a real, healthy pass — the loop's job is deciding whether to
+        // recompute, not only the recompute itself.
+        crate::runtime_jobs::registry::tick(crate::runtime_jobs::registry::ids::EMAIL_THEMES);
         tokio::time::sleep(std::time::Duration::from_secs(THEME_REFRESH_SECS)).await;
     }
 }


### PR DESCRIPTION
`email-themes` was showing `stalled` (`ticks:0`, `last_tick_at: null`) for
its entire ~17h uptime — not evidence the loop is dead, evidence it never
called anything the registry's `classify()` reads.

## Root cause

`theme_refresh_loop()` is the "do the work, then sleep for the interval"
shape every sibling loop uses (`pipe_reconcile_loop`, etc.), and every one
of those calls `registry::tick(id)` once per iteration. This one never
did — a pure instrumentation gap, not a real stall: `classify()`'s own
"never ticked past the stall budget" rule reports `stalled` for a loop
like this permanently, on every run, whether or not real work happened.

## Fix

Call `registry::tick(ids::EMAIL_THEMES)` once per loop iteration, after
`one_theme_pass()` — including its "skip, themes still fresh" branch,
since the loop's job is deciding whether to recompute, not only the
recompute itself, so a skip is a real healthy pass.

Two-fix rule: the fix itself is the log signal — `classify()` already
surfaces ticks/`last_tick_at` at `GET /api/system-jobs`, so once this loop
actually reports, a real future stall becomes visible the same way every
other job's does.

Verified locally: `cargo check --workspace --all-targets` and `cargo
clippy --workspace --all-targets -- -D warnings` both pass (via the
repo's own commit hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)