### PR TITLE
fix(dashboard): global banners must not outrank the peek overlay (AMUX-126)

### DIFF
--- a/crates/amux-dashboard/static/index.html
+++ b/crates/amux-dashboard/static/index.html
@@ -121,7 +121,7 @@
 <script>
 setTimeout(function(){var f=document.getElementById('js-fallback');if(f&&f.style.display!=='none'){document.getElementById('js-fallback-retry').style.display='';}},8000);
 </script>
-<div id="no-apikey-banner" style="display:none;background:#7c2d12;color:#fed7aa;padding:8px 16px;text-align:center;font-size:0.82rem;z-index:200;position:relative;">
+<div id="no-apikey-banner" style="display:none;background:#7c2d12;color:#fed7aa;padding:8px 16px;text-align:center;font-size:0.82rem;z-index:90;position:relative;">
   No Anthropic API key set — Claude workers won't work. <a href="#" onclick="event.preventDefault();document.getElementById('no-apikey-banner').style.display='none';toggleSettings()" style="color:#fde68a;font-weight:600;text-decoration:underline;">Add key in Settings</a>
 </div>
 <!-- API key setup modal — shown on cloud when no user key is configured (dismissible) -->
@@ -157,11 +157,11 @@ setTimeout(function(){var f=document.getElementById('js-fallback');if(f&&f.style
     <div style="text-align:center;margin-top:8px;font-size:0.78rem;color:#b0b0b0;">You can change this later in Settings</div>
   </div>
 </div>
-<div id="org-banner" style="display:none;background:#312e81;border-bottom:1px solid #6366f1;color:#e0e7ff;padding:7px 16px;text-align:center;font-size:0.82rem;z-index:200;position:relative;display:none;">
+<div id="org-banner" style="display:none;background:#312e81;border-bottom:1px solid #6366f1;color:#e0e7ff;padding:7px 16px;text-align:center;font-size:0.82rem;z-index:90;position:relative;display:none;">
   <span id="org-banner-text"></span>
   <button onclick="_switchOrg('')" style="margin-left:12px;background:#4338ca;color:#e0e7ff;border:none;border-radius:4px;padding:2px 10px;font-size:0.78rem;cursor:pointer;">← My workspace</button>
 </div>
-<div id="org-invite-banner" style="display:none;background:#166534;border-bottom:1px solid #22c55e;color:#dcfce7;padding:7px 16px;font-size:0.82rem;z-index:200;position:relative;display:none;align-items:center;justify-content:center;gap:10px;">
+<div id="org-invite-banner" style="display:none;background:#166534;border-bottom:1px solid #22c55e;color:#dcfce7;padding:7px 16px;font-size:0.82rem;z-index:90;position:relative;display:none;align-items:center;justify-content:center;gap:10px;">
   <span id="org-invite-banner-text"></span>
   <button onclick="_dismissOrgBanner()" style="background:none;border:none;color:#bbf7d0;cursor:pointer;font-size:1rem;line-height:1;opacity:0.7;padding:0 2px;" title="Dismiss">&#x2715;</button>
 </div>

--- a/crates/amux-server/tests/dashboard_assets.rs
+++ b/crates/amux-server/tests/dashboard_assets.rs
@@ -886,3 +886,59 @@ fn worker_board_opens_current_work_without_expanding_every_idle_lane() {
         "the old undefined-means-every-worker-open default returned"
     );
 }
+
+/// AF-390 fixed `#email-approvals-banner` swallowing clicks on the peek
+/// overlay's fixed-position controls (`.overlay { z-index: 100 }`): an
+/// in-flow global banner with `z-index: 200` painted over it once the banner
+/// grew tall enough (narrow viewport -> its text wraps -> its box reaches
+/// further down the screen). The fix set that ONE banner to `z-index: 90`
+/// and left a comment stating the rule for every future one: "NOTHING IN
+/// NORMAL FLOW MAY OUTRANK THESE TWO... If you add another global strip, put
+/// it under 100 too."
+///
+/// AMUX-126 (2026-09-07): three more global banners violated exactly that
+/// rule — `#no-apikey-banner`, `#org-banner`, `#org-invite-banner` all still
+/// carried `z-index: 200`, inherited from before AF-390 landed and never
+/// updated to match. CI caught the symptom (a real `locator.click` timeout on
+/// mobile/ios-safari in `terminal-message-navigation.spec.ts`, `#no-apikey-
+/// banner` named in the error as the element "intercepting pointer events")
+/// but nothing had checked the RULE itself — a comment stating an invariant
+/// is not a check that can fail (ethos rule 7). This scans every global
+/// banner div for its inline z-index and fails if a new one is ever added (or
+/// an old one edited) above the overlay's own 100.
+#[test]
+fn global_banners_never_outrank_the_peek_overlay() {
+    let html = asset("index.html");
+    // Every id in this list is a banner that renders in NORMAL DOCUMENT FLOW
+    // (not `position: fixed`) at the top of the page, in the same screen band
+    // as `.overlay` (z-index 100) and `#board-detail-overlay` (z-index 150) —
+    // exactly the AF-390 hazard. A banner added under a NEW id needs adding
+    // here too, or this test cannot see it.
+    let banner_ids =
+        ["no-apikey-banner", "org-banner", "org-invite-banner", "email-approvals-banner"];
+    for id in banner_ids {
+        let needle = format!("id=\"{id}\" style=\"");
+        let start = html.find(&needle).unwrap_or_else(|| panic!("banner #{id} not found in index.html — did it move or get renamed?"));
+        let tail = &html[start..];
+        let tag_end = tail.find('>').expect("unterminated div tag");
+        let style_attr = &tail[..tag_end];
+        let zi_key = "z-index:";
+        let zi_start = style_attr
+            .find(zi_key)
+            .unwrap_or_else(|| panic!("banner #{id} has no inline z-index at all — add one under 100, don't rely on the cascade default"))
+            + zi_key.len();
+        let zi_rest = &style_attr[zi_start..];
+        let zi_end = zi_rest.find(';').unwrap_or(zi_rest.len());
+        let z: i32 = zi_rest[..zi_end]
+            .trim()
+            .parse()
+            .unwrap_or_else(|e| panic!("banner #{id}'s z-index isn't a plain integer: {e}"));
+        assert!(
+            z < 100,
+            "banner #{id} has z-index:{z} -- AF-390's rule is nothing in normal flow may outrank \
+             the peek overlay (z-index:100); a tall-wrapped banner at {z} will paint over and \
+             swallow clicks on the overlay's own controls exactly like AF-390 did. Use 90, matching \
+             #email-approvals-banner."
+        );
+    }
+}


### PR DESCRIPTION
Fixes the CI-red on `main` (rust/e2e, 2 consecutive failures starting 2026-09-07 13:31 UTC).

**Root cause:** AF-390 already fixed this exact bug class once for `#email-approvals-banner` — an in-flow global banner with `z-index:200` painting over `.overlay`'s own `z-index:100` once the banner wraps tall enough on a narrow viewport to reach down over the peek overlay's own top controls. The fix set that one banner to `z-index:90` and left a comment stating the rule for every future banner: *"NOTHING IN NORMAL FLOW MAY OUTRANK THESE TWO ... If you add another global strip, put it under 100 too."*

Three more banners never got the memo: `#no-apikey-banner`, `#org-banner`, `#org-invite-banner` all still carried `z-index:200`. `#no-apikey-banner` is the one CI caught — it renders in every CI run (no API key configured there) — and Playwright's own diagnostics named it directly: `<div id="no-apikey-banner"> intercepts pointer events`, timing out a click on `terminal-message-navigation.spec.ts`'s message-nav buttons on mobile/ios-safari. The other two carry the identical latent bug, just gated behind org-membership states CI doesn't currently exercise.

**Fix:** all three to `z-index:90`, matching `#email-approvals-banner`.

**Two-fix rule:** added `global_banners_never_outrank_the_peek_overlay` (`tests/dashboard_assets.rs`) — reads every listed banner's inline z-index and fails if any is ever `>= 100` again. Verified it actually fails via `scripts/mutate.sh` (reintroduced `z-index:200` on one banner, confirmed a clear failure naming the rule, confirmed a clean revert). A comment stating an invariant isn't a check that can fail — three banners already slipped past this one.

**Not in scope, confirmed pre-existing/unrelated:** the other 2 CI failures (`settings-default-model` on desktop + ios-safari, `Element is not a <select> element`) are the e2e suite not yet updated for 322f76c8's deliberate change of that control from a `<select>` to a free-typeable `<input list=...datalist>`. Real product change, not a defect — a separate test-authoring follow-up, not touched here.

Verified: `cargo check`/`clippy --all-targets -D warnings` clean, the new test passes with the fix and fails without it, `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)