### PR TITLE
Fix local Tailscale multiplayer auth lifecycle

### DIFF
--- a/crates/amux-dashboard/static/app.js
+++ b/crates/amux-dashboard/static/app.js
@@ -9018,7 +9018,7 @@ async function saveGlobalMemory() {
   }
 }
 
-const APP_VER = '0.9.823';   // bump together with the sw.js CACHE version
+const APP_VER = '0.9.824';   // bump together with the sw.js CACHE version
 // Warm the shared catalog so model-type filters are exact on first use. A
 // failure is non-fatal (custom ids and the open-string fallback still work)
 // and is already reported by _loadModelCatalog.

--- a/crates/amux-dashboard/static/sw.js
+++ b/crates/amux-dashboard/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'amux-v0.9.823';
+const CACHE = 'amux-v0.9.824';
 const SHELL_URLS = ['/', '/manifest.json', '/icon.svg', '/icon.png', '/icon-192.png', '/icon-512.png'];
 
 // Install: pre-cache entire app shell
@@ -73,6 +73,17 @@ self.addEventListener('fetch', e => {
   // Main HTML (SPA): network-first, always cache as canonical '/' key
   // Hash fragments (#path=...) are client-side only — SW sees bare '/' regardless
   if (url.pathname === '/') {
+    // A remote owner reaches the public shell with `?_token=...`, which the
+    // server exchanges for an HttpOnly owner-session cookie and redirects to
+    // a clean URL. Never answer that one-time exchange from the canonical `/`
+    // cache: doing so drops the query before the server sees it and leaves the
+    // correct owner credential looking exactly like an unauthenticated peer.
+    // `fetch(e.request)` follows the server redirect on the network, applying
+    // Set-Cookie before the clean owner shell is returned.
+    if (url.searchParams.has('_token')) {
+      e.respondWith(fetch(e.request));
+      return;
+    }
     const canonical = new Request('/', { headers: { 'Accept': 'text/html' } });
     // STALE-WHILE-REVALIDATE, not network-first. The shell is ~1.6MB of inline
     // HTML/CSS/JS; network-first meant every single load blocked on that full

--- a/crates/amux-server/src/api/auth.rs
+++ b/crates/amux-server/src/api/auth.rs
@@ -31,7 +31,7 @@
 
 use super::AppState;
 use axum::extract::{ConnectInfo, Request, State};
-use axum::http::{Method, StatusCode};
+use axum::http::{HeaderMap, Method, StatusCode, Uri};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use std::net::SocketAddr;
@@ -95,17 +95,7 @@ pub async fn require_bearer(
     if req.method() == Method::GET && !path.starts_with("/api/") && !path.starts_with("/proxy/") {
         return next.run(req).await;
     }
-    let provided = req
-        .headers()
-        .get(axum::http::header::AUTHORIZATION)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.strip_prefix("Bearer "))
-        .or_else(|| {
-            req.uri()
-                .query()
-                .and_then(|q| q.split('&').find_map(|kv| kv.strip_prefix("_token=")))
-        });
-    match provided {
+    match provided_owner_token(req.headers(), req.uri()) {
         Some(t) if constant_time_eq(t.as_bytes(), expected.as_bytes()) => next.run(req).await,
         // Python's exact 401: JSON body, not bare text (the SPA and CLI both
         // parse the body; a text/plain 401 reads as a broken server).
@@ -118,9 +108,48 @@ pub async fn require_bearer(
     }
 }
 
+/// Whether this request explicitly presented the configured owner bearer.
+///
+/// Static shell serving is intentionally outside [`require_bearer`] so an
+/// invited member can load it using only their HttpOnly member cookie. It must
+/// still be able to distinguish an explicitly-authenticated remote owner from
+/// an anonymous tailnet peer without duplicating the credential parser.
+pub(crate) fn has_owner_token(state: &AppState, headers: &HeaderMap, uri: &Uri) -> bool {
+    state.auth_token.as_deref().is_some_and(|expected| {
+        provided_owner_token(headers, uri)
+            .is_some_and(|provided| constant_time_eq(provided.as_bytes(), expected.as_bytes()))
+    })
+}
+
+/// Query-only variant used by the public shell to exchange a one-time URL
+/// credential for an HttpOnly owner session before a service worker can cache
+/// the credential-bearing URL or reload it without the query string.
+pub(crate) fn has_owner_query_token(state: &AppState, uri: &Uri) -> bool {
+    let provided = uri
+        .query()
+        .and_then(|q| q.split('&').find_map(|kv| kv.strip_prefix("_token=")));
+    match (state.auth_token.as_deref(), provided) {
+        (Some(expected), Some(provided)) => {
+            constant_time_eq(provided.as_bytes(), expected.as_bytes())
+        }
+        _ => false,
+    }
+}
+
+fn provided_owner_token<'a>(headers: &'a HeaderMap, uri: &'a Uri) -> Option<&'a str> {
+    headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .or_else(|| {
+            uri.query()
+                .and_then(|q| q.split('&').find_map(|kv| kv.strip_prefix("_token=")))
+        })
+}
+
 /// Constant-time comparison — a token check that leaks length-prefix timing
 /// is a token check that can be brute-forced from the LAN.
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+pub(crate) fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
     if a.len() != b.len() {
         return false;
     }

--- a/crates/amux-server/src/api/fs.rs
+++ b/crates/amux-server/src/api/fs.rs
@@ -565,7 +565,10 @@ async fn mkdir(req: Request) -> Response {
 ///
 /// Resolution failure returns false: refusing to open is recoverable (the path
 /// is in the response), opening a Finder window on someone else's desktop is not.
-fn browser_is_on_this_machine(peer: Option<std::net::IpAddr>, host_header: Option<&str>) -> bool {
+pub(crate) fn browser_is_on_this_machine(
+    peer: Option<std::net::IpAddr>,
+    host_header: Option<&str>,
+) -> bool {
     browser_is_on_this_machine_with(peer, host_header, |h| {
         std::net::ToSocketAddrs::to_socket_addrs(&(h, 0u16))
             .map(|it| it.map(|a| a.ip()).collect())

--- a/crates/amux-server/src/api/org.rs
+++ b/crates/amux-server/src/api/org.rs
@@ -27,7 +27,7 @@ use crate::db::{PendingEvent, WriteOutcome};
 use crate::integrations::email::base64url_nopad;
 use amux_core::revision::{EntityType, MutationKind};
 use axum::extract::{Form, Path, Request, State};
-use axum::http::{header, HeaderMap, HeaderValue, StatusCode};
+use axum::http::{header, HeaderMap, HeaderValue, StatusCode, Uri};
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
@@ -75,6 +75,14 @@ fn member_cookie(headers: &HeaderMap) -> Option<&str> {
             (name == MEMBER_COOKIE && !value.is_empty()).then_some(value)
         })
     })
+}
+
+/// A cookie with this name remains significant even after its backing member
+/// is deleted. Static shell serving uses the distinction between "no member
+/// session" and "a revoked member session" so a reload cannot silently turn
+/// a revoked invitee into the owner.
+pub(crate) fn has_local_member_cookie(headers: &HeaderMap) -> bool {
+    member_cookie(headers).is_some()
 }
 
 /// Resolve a local invitee before auth and before the request logger.
@@ -159,25 +167,41 @@ fn token_urlsafe(nbytes: usize) -> String {
     base64url_nopad(&bytes)
 }
 
-/// Python: `scheme = "https" if X-Forwarded-Proto == "https" else "http"`,
-/// host from the Host header. The fallback host is this server's OWN port
-/// (`config::canonical_port()`), not Python's 8822 literal — an invite link is
-/// mailed to a person and outlives the process, so minting it against the
-/// retired address hands out a URL with an expiry date on it.
-fn base_url(headers: &HeaderMap) -> String {
+/// Public origin for a link another browser must be able to open.
+///
+/// HTTP/2 carries the authority and scheme as pseudo-headers; axum exposes
+/// them on the URI, not in `HeaderMap`. Browsers negotiate h2 on the Tailscale
+/// TLS listener, so reading only `Host` used to mint
+/// `http://localhost:8824/invite/...` from the real tailnet dashboard.
+/// HTTP/1.1 still supplies `Host`, while a reverse proxy remains authoritative
+/// through `X-Forwarded-Proto`. With no protocol signal, HTTPS is the honest
+/// default because the production Rust listener is TLS-only.
+fn base_url(headers: &HeaderMap, uri: &Uri) -> String {
     let fallback = format!("localhost:{}", crate::config::canonical_port());
-    let host = headers
+    let authority = headers
         .get("host")
         .and_then(|v| v.to_str().ok())
-        .unwrap_or(&fallback);
-    let scheme = if headers
+        .map(str::to_string)
+        .or_else(|| uri.authority().map(|a| a.to_string()));
+    let host = match authority {
+        Some(authority) => authority,
+        None => {
+            tracing::warn!(
+                target: "amux::local_invite",
+                verdict = "origin_fallback",
+                fallback = %fallback,
+                "invite request carried no HTTP authority; using the canonical localhost origin"
+            );
+            fallback
+        }
+    };
+    let forwarded = headers
         .get("x-forwarded-proto")
         .and_then(|v| v.to_str().ok())
-        == Some("https")
-    {
-        "https"
-    } else {
-        "http"
+        .map(str::to_ascii_lowercase);
+    let scheme = match forwarded.as_deref().or_else(|| uri.scheme_str()) {
+        Some("http") => "http",
+        _ => "https",
     };
     format!("{scheme}://{host}")
 }
@@ -511,8 +535,12 @@ pub async fn delete_member(State(state): State<AppState>, Path(id): Path<String>
 
 // ---- GET /api/org/invites -------------------------------------------------
 
-pub async fn list_invites(State(state): State<AppState>, headers: HeaderMap) -> Response {
-    let base = base_url(&headers);
+pub async fn list_invites(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    uri: Uri,
+) -> Response {
+    let base = base_url(&headers, &uri);
     let store = state.store.clone();
     let joined = tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<Value>> {
         let conn = store.read()?;
@@ -543,6 +571,7 @@ pub async fn list_invites(State(state): State<AppState>, headers: HeaderMap) -> 
 pub async fn create_invite(
     State(state): State<AppState>,
     headers: HeaderMap,
+    uri: Uri,
     Json(body): Json<Value>,
 ) -> Response {
     // Python: `body.get("email", "").strip().lower() or None`.
@@ -578,7 +607,7 @@ pub async fn create_invite(
             tracing::info!(target: "amux::local_invite", verdict = "created",
                 bound_email = email.as_deref().unwrap_or("open"), expires_at = expires,
                 "local invite created");
-            let url = format!("{}/invite/{token}", base_url(&headers));
+            let url = format!("{}/invite/{token}", base_url(&headers, &uri));
             (
                 StatusCode::CREATED,
                 Json(json!({ "token": token, "url": url, "expires_at": expires })),
@@ -805,12 +834,31 @@ mod tests {
             json!("https://cloud.amux.io/invite/livetokenlivetokenlivetoken00001")
         );
 
+        // A real browser reaches the TLS listener over HTTP/2. In that
+        // protocol there is no Host header: :authority and :scheme are
+        // surfaced on the request URI. This is the actual Tailscale shape,
+        // and the invite must remain usable from another node instead of
+        // silently falling back to http://localhost.
+        let (st, h2) = send(
+            &app,
+            "GET",
+            "https://desktop.tail5ce8f5.ts.net:8824/api/org/invites",
+            None,
+            &[],
+        )
+        .await;
+        assert_eq!(st, StatusCode::OK, "{h2}");
+        assert_eq!(
+            h2[0]["url"],
+            json!("https://desktop.tail5ce8f5.ts.net:8824/invite/livetokenlivetokenlivetoken00001")
+        );
+
         // Default host/scheme when the headers are absent.
         let (_, inv2) = send(&app, "GET", "/api/org/invites", None, &[]).await;
         let url = inv2[0]["url"].as_str().unwrap();
         // Derived, not literal: the fallback follows this server's own port,
         // so hardcoding one here would pin the test to a deployment.
-        let want = format!("http://localhost:{}/invite/", crate::config::canonical_port());
+        let want = format!("https://localhost:{}/invite/", crate::config::canonical_port());
         assert!(url.starts_with(&want), "{url} should start with {want}");
     }
 
@@ -948,6 +996,18 @@ mod tests {
         assert_eq!(deleted, StatusCode::OK, "{body}");
         let (revoked, _, _) = raw_send(&app, "GET", "/api/org/members", "", &[("cookie", cookie)]).await;
         assert_eq!(revoked, StatusCode::UNAUTHORIZED);
+        // Revocation must survive a page reload. The stale HttpOnly cookie is
+        // still stored by the browser after its member row is deleted; the
+        // public shell must not treat the now-unverified request as an owner
+        // and bootstrap the owner's bearer into JavaScript.
+        let (shell_status, _, revoked_shell) =
+            raw_send(&app, "GET", "/", "", &[("cookie", cookie)]).await;
+        assert_eq!(shell_status, StatusCode::OK);
+        assert!(revoked_shell.contains("window._AMUX_AUTH_TOKEN=\"\""), "{revoked_shell}");
+        assert!(
+            !revoked_shell.contains("window._AMUX_AUTH_TOKEN=\"owner-token\""),
+            "{revoked_shell}"
+        );
         let (replay, _, _) = raw_send(&app, "GET", &format!("/invite/{token}"), "", &[]).await;
         assert_eq!(replay, StatusCode::GONE);
     }

--- a/crates/amux-server/src/api/static_files.rs
+++ b/crates/amux-server/src/api/static_files.rs
@@ -2,21 +2,21 @@
 //!
 //! Files come from amux-dashboard's `static/` at compile time. index.html
 //! gets its AMUX-BOOTSTRAP block substituted at serve time — the same
-//! values the Python server injects (amux-server.py:65679), same trust
-//! model: the owner's dashboard shell + auth token are served unauthenticated
-//! on the LAN, exactly as the Python server does today. A browser carrying a
-//! verified local-member cookie gets the shell WITHOUT the owner bearer and
-//! continues through that revocable cookie. Cloud deployments put a gateway
-//! in front of both.
+//! values the Python server injects (amux-server.py:65679). The owner's bearer
+//! is injected only for a browser on this machine or a request that explicitly
+//! presents it. A remote browser carrying a verified local-member cookie gets
+//! the shell WITHOUT that bearer and continues through its revocable cookie.
 
 use super::AppState;
 use amux_dashboard::DashboardAssets;
-use axum::extract::State;
-use axum::http::{header, HeaderMap, StatusCode, Uri};
-use axum::response::{IntoResponse, Response};
-use axum::Router;
+use axum::extract::{ConnectInfo, State};
+use axum::http::{header, HeaderMap, HeaderValue, StatusCode, Uri};
+use axum::response::{IntoResponse, Redirect, Response};
+use axum::{Extension, Router};
 use sha2::Digest;
+use std::net::{IpAddr, SocketAddr};
 
+const OWNER_COOKIE: &str = "__Host-amux_owner";
 
 /// The public iCal URL the dashboard's Subscribe button shows.
 ///
@@ -87,13 +87,24 @@ pub fn routes() -> Router<AppState> {
 /// came in on that socket — never from a client-supplied `Host` header, which
 /// would let any client trigger the migration prompt against the real origin.
 type Legacy = Option<axum::Extension<crate::legacy_port::OnLegacyListener>>;
+type Peer = Option<Extension<ConnectInfo<SocketAddr>>>;
 
 fn legacy_port_of(l: Legacy) -> Option<u16> {
     l.map(|axum::Extension(crate::legacy_port::OnLegacyListener(p))| p)
 }
 
-async fn index(State(state): State<AppState>, headers: HeaderMap, legacy: Legacy) -> Response {
-    serve_index(&state, legacy_port_of(legacy), super::org::is_verified_local_member(&headers))
+fn peer_ip(peer: Peer) -> Option<IpAddr> {
+    peer.map(|Extension(ConnectInfo(addr))| addr.ip())
+}
+
+async fn index(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    uri: Uri,
+    peer: Peer,
+    legacy: Legacy,
+) -> Response {
+    serve_shell(&state, legacy_port_of(legacy), &headers, &uri, peer_ip(peer))
 }
 
 async fn serve_path(
@@ -101,6 +112,7 @@ async fn serve_path(
     headers: HeaderMap,
     method: axum::http::Method,
     uri: Uri,
+    peer: Peer,
     legacy: Legacy,
 ) -> Response {
     let path = uri.path().trim_start_matches('/');
@@ -132,16 +144,124 @@ async fn serve_path(
         }
         // SPA fallback: unknown NON-API paths get the shell so client routing
         // works offline-first.
-        None => serve_index(&state, legacy_port_of(legacy), super::org::is_verified_local_member(&headers)),
+        None => serve_shell(&state, legacy_port_of(legacy), &headers, &uri, peer_ip(peer)),
     }
 }
 
-fn serve_index(state: &AppState, legacy: Option<u16>, local_member: bool) -> Response {
+fn cookie_value<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {
+    headers.get(header::COOKIE).and_then(|v| v.to_str().ok()).and_then(|cookies| {
+        cookies.split(';').find_map(|part| {
+            let (cookie_name, value) = part.trim().split_once('=')?;
+            (cookie_name == name && !value.is_empty()).then_some(value)
+        })
+    })
+}
+
+fn owner_session_value(state: &AppState) -> Option<String> {
+    let owner_auth = state.auth_token.as_deref()?;
+    let mut hash = sha2::Sha256::new();
+    hash.update(format!("amux-owner-session:{owner_auth}"));
+    Some(hex::encode(hash.finalize()))
+}
+
+fn has_owner_session(state: &AppState, headers: &HeaderMap) -> bool {
+    match (owner_session_value(state), cookie_value(headers, OWNER_COOKIE)) {
+        (Some(expected), Some(provided)) => {
+            super::auth::constant_time_eq(provided.as_bytes(), expected.as_bytes())
+        }
+        _ => false,
+    }
+}
+
+fn establish_owner_session(state: &AppState) -> Response {
+    let Some(value) = owner_session_value(state) else {
+        return Redirect::to("/").into_response();
+    };
+    let cookie = format!(
+        "{OWNER_COOKIE}={value}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=2592000"
+    );
+    let mut response = Redirect::to("/").into_response();
+    response.headers_mut().insert(
+        header::SET_COOKIE,
+        HeaderValue::from_str(&cookie).expect("hex owner-session cookie is a valid header"),
+    );
+    tracing::info!(
+        target: "amux::local_invite",
+        verdict = "owner_session_established",
+        "an explicit owner URL credential was exchanged for an HttpOnly session"
+    );
+    response
+}
+
+fn serve_shell(
+    state: &AppState,
+    legacy: Option<u16>,
+    headers: &HeaderMap,
+    uri: &Uri,
+    peer: Option<IpAddr>,
+) -> Response {
+    // Remove the bearer from the address bar before app.js or the service
+    // worker starts. The resulting HttpOnly cookie survives the SW's canonical
+    // `/` fetch and reload without leaving the bearer in history or caches.
+    if super::auth::has_owner_query_token(state, uri) {
+        return establish_owner_session(state);
+    }
+    serve_index(state, legacy, headers, uri, peer)
+}
+
+fn request_authority(headers: &HeaderMap, uri: &Uri) -> Option<String> {
+    headers
+        .get(header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string)
+        .or_else(|| uri.authority().map(|authority| authority.to_string()))
+}
+
+fn owner_bootstrap_allowed(
+    state: &AppState,
+    headers: &HeaderMap,
+    uri: &Uri,
+    peer: Option<IpAddr>,
+) -> bool {
+    // An explicit owner credential always wins, including when the owner is
+    // recovering a browser that still carries an old member cookie.
+    if super::auth::has_owner_token(state, headers, uri) || has_owner_session(state, headers) {
+        return true;
+    }
+
+    let verified_member = super::org::is_verified_local_member(headers);
+    let has_member_cookie = super::org::has_local_member_cookie(headers);
+    if verified_member || has_member_cookie {
+        if has_member_cookie && !verified_member && state.auth_token.is_some() {
+            tracing::warn!(
+                target: "amux::local_invite",
+                verdict = "revoked_member_bootstrap_withheld",
+                "a dashboard reload carried an unverified member cookie; owner credentials were withheld"
+            );
+        }
+        return false;
+    }
+
+    super::fs::browser_is_on_this_machine(peer, request_authority(headers, uri).as_deref())
+}
+
+fn serve_index(
+    state: &AppState,
+    legacy: Option<u16>,
+    headers: &HeaderMap,
+    uri: &Uri,
+    peer: Option<IpAddr>,
+) -> Response {
     let Some(index) = DashboardAssets::get("index.html") else {
         return (StatusCode::NOT_FOUND, "dashboard not embedded").into_response();
     };
     let html = String::from_utf8_lossy(&index.data).into_owned();
-    let injected = inject_bootstrap(&html, state, legacy, local_member);
+    let injected = inject_bootstrap(
+        &html,
+        state,
+        legacy,
+        owner_bootstrap_allowed(state, headers, uri, peer),
+    );
     (
         [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
         injected,
@@ -172,16 +292,17 @@ fn serve_index(state: &AppState, legacy: Option<u16>, local_member: bool) -> Res
 /// `_AMUX_LEGACY_PORT` is 0 on the canonical listener, so the SPA's check is
 /// "did the server say I am on the retired port", not "does my URL look odd" —
 /// the client never has to know either number.
-fn inject_bootstrap(html: &str, state: &AppState, legacy: Option<u16>, local_member: bool) -> String {
+fn inject_bootstrap(html: &str, state: &AppState, legacy: Option<u16>, owner_access: bool) -> String {
     const BEGIN: &str = "<!-- AMUX-BOOTSTRAP-BEGIN";
     const END: &str = "<!-- AMUX-BOOTSTRAP-END -->";
     let (Some(b), Some(e)) = (html.find(BEGIN), html.find(END)) else {
         return html.to_string(); // no markers: serve untouched, never corrupt
     };
     let owner_auth = state.auth_token.clone().unwrap_or_default();
-    // Invited browsers authenticate with their member cookie, never by
-    // inheriting the owner's bearer from the public SPA bootstrap.
-    let auth = if local_member { String::new() } else { owner_auth.clone() };
+    // Invited and anonymous remote browsers never inherit the owner's bearer
+    // from the public SPA bootstrap. Locality or an explicitly supplied owner
+    // credential is required.
+    let auth = if owner_access { owner_auth.clone() } else { String::new() };
     let ui_token = if owner_auth.is_empty() {
         String::new()
     } else {
@@ -274,7 +395,7 @@ mod tests {
     #[test]
     fn bootstrap_injects_auth_and_derived_ui_token() {
         let html = "<head><!-- AMUX-BOOTSTRAP-BEGIN x -->old<!-- AMUX-BOOTSTRAP-END --></head>";
-        let out = inject_bootstrap(html, &state(Some("tok123")), None, false);
+        let out = inject_bootstrap(html, &state(Some("tok123")), None, true);
         assert!(out.contains("window._AMUX_AUTH_TOKEN=\"tok123\""));
         // Python-parity UI token: sha256("amux-ui-guard:tok123")[..40]
         let mut h = sha2::Sha256::new();
@@ -287,8 +408,8 @@ mod tests {
     #[test]
     fn invited_member_bootstrap_withholds_owner_bearer_but_keeps_ui_guard() {
         let html = "<head><!-- AMUX-BOOTSTRAP-BEGIN x -->old<!-- AMUX-BOOTSTRAP-END --></head>";
-        let owner = inject_bootstrap(html, &state(Some("tok123")), None, false);
-        let member = inject_bootstrap(html, &state(Some("tok123")), None, true);
+        let owner = inject_bootstrap(html, &state(Some("tok123")), None, true);
+        let member = inject_bootstrap(html, &state(Some("tok123")), None, false);
         assert!(member.contains("window._AMUX_AUTH_TOKEN=\"\""), "{member}");
         assert!(!member.contains("window._AMUX_AUTH_TOKEN=\"tok123\""), "{member}");
         let owner_guard = owner.split("window._AMUX_UI_TOKEN=").nth(1)
@@ -303,7 +424,7 @@ mod tests {
         // or a backend-only deploy shows UI Python never showed.
         let html = "<head><!-- AMUX-BOOTSTRAP-BEGIN x -->old<!-- AMUX-BOOTSTRAP-END --></head><body></body>";
         let s = state(Some("tok"));
-        let out = inject_bootstrap(html, &s, None, false);
+        let out = inject_bootstrap(html, &s, None, true);
         assert!(!out.contains("AMUX-UPDATE-WATCH"));
         assert!(!out.contains("amux-update-bar"));
         // The CRM feature-flag layer still injects.
@@ -326,14 +447,14 @@ mod tests {
         let html = "<head><!-- AMUX-BOOTSTRAP-BEGIN x -->old<!-- AMUX-BOOTSTRAP-END --></head><body></body>";
         let s = state(Some("tok"));
 
-        let canonical = inject_bootstrap(html, &s, None, false);
+        let canonical = inject_bootstrap(html, &s, None, true);
         assert!(
             canonical.contains("window._AMUX_LEGACY_PORT=0"),
             "a document served on the canonical port must report legacy 0, or every \
              already-migrated client is told to migrate: {canonical}"
         );
 
-        let from_legacy = inject_bootstrap(html, &s, Some(8822), false);
+        let from_legacy = inject_bootstrap(html, &s, Some(8822), true);
         assert!(
             from_legacy.contains("window._AMUX_LEGACY_PORT=8822"),
             "a document served on the retired port must say so — this is the ONLY \
@@ -355,6 +476,82 @@ mod tests {
     fn missing_markers_serve_untouched() {
         let html = "<head>no markers</head>";
         assert_eq!(inject_bootstrap(html, &state(None), None, false), html);
+    }
+
+    async fn shell(
+        app: &Router,
+        uri: &str,
+        cookie: Option<&str>,
+        peer: Option<&str>,
+    ) -> String {
+        use tower::ServiceExt;
+        let mut builder = axum::http::Request::builder().uri(uri);
+        if let Some(cookie) = cookie {
+            builder = builder.header(header::COOKIE, cookie);
+        }
+        let mut request = builder.body(axum::body::Body::empty()).unwrap();
+        if let Some(peer) = peer {
+            let addr: SocketAddr = format!("{peer}:50000").parse().unwrap();
+            request.extensions_mut().insert(ConnectInfo(addr));
+        }
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+
+    #[tokio::test]
+    async fn owner_bearer_is_not_bootstrapped_to_remote_or_revoked_member_shells() {
+        let app = routes().with_state(state(Some("tok123")));
+
+        let remote = shell(&app, "https://remote-node.example/", None, None).await;
+        assert!(remote.contains("window._AMUX_AUTH_TOKEN=\"\""), "{remote}");
+
+        let local = shell(
+            &app,
+            "https://desktop.tailnet.example/",
+            None,
+            Some("127.0.0.1"),
+        )
+        .await;
+        assert!(local.contains("window._AMUX_AUTH_TOKEN=\"tok123\""), "{local}");
+
+        // Deleting a member removes the DB row but their HttpOnly cookie stays
+        // in the browser. Even on the owner's machine that stale cookie must
+        // not change roles on reload and inherit the owner credential.
+        let revoked = shell(
+            &app,
+            "https://desktop.tailnet.example/",
+            Some("amux_member=revoked-invite-token"),
+            Some("127.0.0.1"),
+        )
+        .await;
+        assert!(revoked.contains("window._AMUX_AUTH_TOKEN=\"\""), "{revoked}");
+        assert!(!revoked.contains("window._AMUX_AUTH_TOKEN=\"tok123\""), "{revoked}");
+
+        // A remote owner can still authenticate explicitly. Exchange the URL
+        // token for an HttpOnly cookie before serving any credential-bearing
+        // HTML, so the service worker's canonical `/` cache and reload retain
+        // the owner session without retaining the URL token.
+        use tower::ServiceExt;
+        let response = app
+            .clone()
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("https://remote-node.example/?_token=tok123")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        assert_eq!(response.headers()[header::LOCATION], "/");
+        let set_cookie = response.headers()[header::SET_COOKIE].to_str().unwrap();
+        assert!(set_cookie.contains("HttpOnly") && set_cookie.contains("Secure"), "{set_cookie}");
+        assert!(!set_cookie.contains("tok123"), "the raw bearer must not be copied into the cookie");
+        let owner_cookie = set_cookie.split(';').next().unwrap();
+        let explicit = shell(&app, "https://remote-node.example/", Some(owner_cookie), None).await;
+        assert!(explicit.contains("window._AMUX_AUTH_TOKEN=\"tok123\""), "{explicit}");
     }
 
     /// AF-61: the GET-only version of this test passed for months while every

--- a/e2e/local-multiplayer.spec.ts
+++ b/e2e/local-multiplayer.spec.ts
@@ -28,7 +28,7 @@ async function openTeam(page: Page): Promise<void> {
   await expect(page.locator('#settings-team-section')).toBeVisible();
 }
 
-test('local invitee joins, shares work, appears in logs, and can be revoked', async ({
+test('local invitee joins, shares work, uses worker APIs, appears in logs, and can be revoked', async ({
   page: owner,
   browser,
   request,
@@ -36,7 +36,9 @@ test('local invitee joins, shares work, appears in logs, and can be revoked', as
   await owner.goto('/');
   await settle(owner);
   const ownerToken = await owner.evaluate(() => (window as any)._AMUX_AUTH_TOKEN as string);
+  const ownerUiToken = await owner.evaluate(() => (window as any)._AMUX_UI_TOKEN as string);
   expect(ownerToken).toBeTruthy();
+  expect(ownerUiToken).toBeTruthy();
   const ownerHeaders = {
     Authorization: `Bearer ${ownerToken}`,
     'Content-Type': 'application/json',
@@ -65,6 +67,7 @@ test('local invitee joins, shares work, appears in logs, and can be revoked', as
     serviceWorkers: 'block',
   });
   const guest = await guestContext.newPage();
+  let memberWorker: string | undefined;
   try {
     await guest.goto(inviteUrl);
     await expect(guest.getByRole('heading', { name: /^Join / })).toBeVisible();
@@ -98,6 +101,43 @@ test('local invitee joins, shares work, appears in logs, and can be revoked', as
     await openTeam(owner);
     await owner.evaluate(() => (window as any).loadTeamSection());
     await expect(owner.locator('#settings-members-list')).toContainText('Guest User');
+
+    // Multiplayer includes the fleet, not just the board. Exercise the real
+    // worker registry and per-worker read surface with only the invitee's
+    // HttpOnly cookie. The live Tailnet acceptance run starts and sends to this
+    // same shape against a disposable Codex worker; this hermetic case pins the
+    // member-auth contract without auto-waking a model in CI.
+    memberWorker = `e2e-member-worker-${Date.now()}`;
+    const workerAccess = await guest.evaluate(async (workerName) => {
+      const create = await fetch('/api/sessions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: workerName,
+          dir: '/tmp',
+          provider: 'codex',
+          creator: 'guest@example.com',
+          tags: ['e2e-multiplayer'],
+        }),
+      });
+      const fleet = await fetch('/api/sessions');
+      const rows = await fleet.json();
+      const info = await fetch(`/api/sessions/${encodeURIComponent(workerName)}/info`);
+      return {
+        createStatus: create.status,
+        fleetStatus: fleet.status,
+        listed: rows.some((row: any) => row.name === workerName),
+        infoStatus: info.status,
+        infoBody: await info.json(),
+      };
+    }, memberWorker);
+    expect(workerAccess).toMatchObject({
+      createStatus: 201,
+      fleetStatus: 200,
+      listed: true,
+      infoStatus: 200,
+      infoBody: { name: memberWorker },
+    });
 
     // The invitee performs real work with cookie auth. The owner's browser
     // observes the same card after the normal board refresh.
@@ -180,6 +220,19 @@ test('local invitee joins, shares work, appears in logs, and can be revoked', as
     expect(revoked.status()).toBe(200);
     const afterRevoke = await guest.evaluate(async () => (await fetch('/api/org/members')).status);
     expect(afterRevoke).toBe(401);
+    expect(
+      await guest.evaluate(
+        async (workerName) =>
+          (
+            await fetch(`/api/sessions/${encodeURIComponent(workerName)}/send`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ text: 'must remain revoked' }),
+            })
+          ).status,
+        memberWorker,
+      ),
+    ).toBe(401);
 
     // The cookie is HttpOnly and survives member deletion. A full reload must
     // remain revoked; it must never fall through to the public owner shell and
@@ -190,6 +243,11 @@ test('local invitee joins, shares work, appears in logs, and can be revoked', as
     const afterReload = await guest.evaluate(async () => (await fetch('/api/org/members')).status);
     expect(afterReload).toBe(401);
   } finally {
+    if (memberWorker) {
+      await request.delete(`/api/sessions/${encodeURIComponent(memberWorker)}`, {
+        headers: { ...ownerHeaders, 'X-Amux-UI-Token': ownerUiToken },
+      });
+    }
     await guestContext.close();
   }
 });

--- a/e2e/local-multiplayer.spec.ts
+++ b/e2e/local-multiplayer.spec.ts
@@ -180,6 +180,15 @@ test('local invitee joins, shares work, appears in logs, and can be revoked', as
     expect(revoked.status()).toBe(200);
     const afterRevoke = await guest.evaluate(async () => (await fetch('/api/org/members')).status);
     expect(afterRevoke).toBe(401);
+
+    // The cookie is HttpOnly and survives member deletion. A full reload must
+    // remain revoked; it must never fall through to the public owner shell and
+    // receive the owner's bearer just because the member lookup now fails.
+    await guest.reload();
+    await guest.waitForFunction(() => '_AMUX_AUTH_TOKEN' in window);
+    expect(await guest.evaluate(() => (window as any)._AMUX_AUTH_TOKEN)).toBe('');
+    const afterReload = await guest.evaluate(async () => (await fetch('/api/org/members')).status);
+    expect(afterReload).toBe(401);
   } finally {
     await guestContext.close();
   }

--- a/frustrations.md
+++ b/frustrations.md
@@ -3544,3 +3544,59 @@ CARD: ATE-75
 SYMPTOM: After an interrupted turn, the dashboard accepted `continue`, then recorded a second message.sent event with chars=0 even though the empty suggestion probe found nothing. Its fallback Enter returned no visible effect verdict, and the worker had to be stopped and resumed before the composer/control state was trustworthy again.
 COST: The live acceptance turn was interrupted, a no-op entered the durable audit trail as a confirmed send, and recovery required a worker stop/start.
 FIX: Classify a missing suggestion as submission=no_effect, omit it from send history/last_send, and emit a session.control_noop event plus composer-control WARN. Raw key responses now name effect=unverified, and the dashboard awaits the fallback and displays that verdict or an explicit failure.
+
+## Local multiplayer passed localhost while its Tailscale invite links were unusable
+AREA: tests
+SEVERITY: blocks
+STATUS: fixed
+DATE: 2026-09-07
+SESSION: Codex local Tailscale multiplayer
+CARD: ATE-79
+SYMPTOM: The checked-in local multiplayer Playwright test passed in three browser
+ projects, but it ran only on localhost. A real browser negotiated HTTP/2 on the
+ Tailscale TLS listener, where authority and scheme live on the request URI rather
+ than the HTTP/1.1 Host header, and Team generated an http://localhost invite link
+ that no second tailnet node could open.
+COST: The original green E2E result gave the wrong release verdict and about 45
+ minutes went to repeating the flow at the real Tailscale origin before the protocol
+ difference became visible.
+FIX: ATE-79 reads authority and scheme from either HTTP version, pins the HTTP/2
+ request shape in the route test, and logs `origin_fallback` when neither source is
+ present.
+
+## Local multiplayer called a member revoked before testing a reload
+AREA: tests
+SEVERITY: blocks
+STATUS: fixed
+DATE: 2026-09-07
+SESSION: Codex local Tailscale multiplayer
+CARD: ATE-79
+SYMPTOM: The revocation E2E asserted that the already-open member page received 401
+ after deletion and stopped. The HttpOnly cookie remained in the browser; reloading
+ made its DB lookup fail, classified the request as an ordinary public shell, and
+ injected the owner bearer into JavaScript. The member was therefore promoted to
+ owner by the first recovery action a user would try.
+COST: A revocable-invite feature carried a privilege-escalation path despite a green
+ browser test, and the missing lifecycle edge added about an hour of independent
+ cookie, reload, mutation, and request-log checks.
+FIX: ATE-79 distinguishes absent, verified, and revoked member cookies before owner
+ bootstrap, adds the reload assertion to all three Playwright projects, and emits
+ `revoked_member_bootstrap_withheld` when the blocked transition is attempted.
+
+## The PWA cache discarded a valid remote-owner bootstrap credential
+AREA: auth
+SEVERITY: blocks
+STATUS: fixed
+DATE: 2026-09-07
+SESSION: Codex local Tailscale multiplayer
+CARD: ATE-79
+SYMPTOM: A remote owner opened the dashboard with the correct `?_token`, but the
+ service worker canonicalized every root navigation to cached `/` before the server
+ could see the query. The UI loaded, reported Polling, and every Team mutation failed
+ unauthorized, while direct HTTP with the same credential succeeded.
+COST: Two fresh browser origins and two server rebuilds were needed to separate a
+ server-auth failure from a cached-shell failure; without the browser check the new
+ secure remote-owner boundary would have shipped with no usable recovery path.
+FIX: ATE-79 exchanges the one-time URL bearer for a derived HttpOnly owner-session
+ cookie, removes it from the address bar, bypasses the canonical shell cache for the
+ exchange request, and pins the app/service-worker version seam.

--- a/scripts/test-multiplayer-browser-contract.mjs
+++ b/scripts/test-multiplayer-browser-contract.mjs
@@ -7,6 +7,14 @@ const root = new URL('../', import.meta.url);
 const read = path => readFileSync(new URL(path, root), 'utf8');
 
 const app = read('crates/amux-dashboard/static/app.js');
+const serviceWorker = read('crates/amux-dashboard/static/sw.js');
+assert.ok(serviceWorker.includes("url.searchParams.has('_token')"),
+  'the service worker must send remote-owner token exchange navigations to the server');
+assert.ok(serviceWorker.includes('e.respondWith(fetch(e.request))'),
+  'the remote-owner token exchange must preserve the original request and redirect cookies');
+const appVersion = app.match(/const APP_VER = '([^']+)'/)?.[1];
+const cacheVersion = serviceWorker.match(/const CACHE = 'amux-v([^']+)'/)?.[1];
+assert.equal(appVersion, cacheVersion, 'app and service-worker cache versions must move together');
 const skipLine = app.split('\n').find(line => line.startsWith('const _OUTBOX_SKIP = '));
 assert.ok(skipLine, 'dashboard must define the offline-outbox exclusion list');
 const skip = Function(`return ${skipLine.slice(skipLine.indexOf('=') + 1, skipLine.lastIndexOf(';'))}`)();


### PR DESCRIPTION
## Summary

- build invite URLs correctly for real HTTP/2 Tailscale TLS requests by reading URI authority/scheme when HTTP/1.1 headers are absent
- prevent verified or revoked member cookies from ever falling through to the implicit local-owner bootstrap on reload
- let an explicit remote owner exchange the URL credential for a derived HttpOnly session, and bypass the service-worker shell cache for that exchange
- add route, browser, contract, mutation, and diagnostic-log coverage for the three failures

## End-to-end evidence

- Real Tailscale TLS origin (`desktop.tail5ce8f5.ts.net`) produced a reachable HTTPS invite URL, accepted invited users, and preserved attributed identities.
- Two browser clients created separate board cards and converged both ways; the guest observed the owner's card via the live connection without a manual refresh.
- Owner revocation returned 200; the stale member cookie then received 401 from the API, still received 401 after a full page reload, and never received the owner bearer in the shell.
- A fresh remote-owner browser exchanged `?_token` for an HttpOnly session, redirected to a clean URL, remained `Live`, and could create a Team invite through the UI.

## Verification

- `npx playwright test --config=e2e/playwright.config.ts e2e/local-multiplayer.spec.ts` — 3 passed (desktop, mobile, iOS Safari)
- `./scripts/safe-cargo.sh clippy --workspace --all-targets -- -D warnings` — passed before and after rebase
- `./scripts/test-contended.sh -p amux-server` — 2,027 unit tests passed, 0 failed; all non-ignored integration/doc suites passed
- `node scripts/test-multiplayer-browser-contract.mjs` — passed
- `scripts/test-frustration-scan.sh` — 17 passed, 0 failed
- `scripts/test-frustrations-audit.sh` — 29 passed, 0 failed
- mutation checks independently proved the revoked-cookie, service-worker bypass, and HTTP/2 authority assertions fail when their fixes are removed

## Observability

- emits `origin_fallback` if an invite request genuinely has no usable authority
- emits `revoked_member_bootstrap_withheld` when a stale member cookie is prevented from inheriting owner access
- emits `owner_session_established` after an explicit remote-owner credential exchange

Refs: ATE-79
