### PR TITLE
fix(test): a non-matching pgrep must not kill test-build-disk-clear.sh (AMUX-134)

### DIFF
--- a/scripts/test-build-disk-clear.sh
+++ b/scripts/test-build-disk-clear.sh
@@ -282,8 +282,22 @@ else bad "(l) the override must SAY it overrode a peer, not clear silently" "$ou
 # Recorded rather than deleted, because the next reader will be tempted to
 # "fix" this back to an exit-code test.)
 #
+# AMUX-134: "read the output, not the exit code" describes what the IF BELOW
+# does, not what this ASSIGNMENT does. `{ pgrep -x rustc; pgrep -x cargo; }`
+# exits 1 (from the last pgrep, per the note above) on the overwhelmingly
+# common "no real build running" host — under `pipefail` that 1 survives the
+# pipe into `tr`, and under this script's own `set -euo pipefail` a plain
+# assignment statement that ends nonzero kills the WHOLE SCRIPT right here,
+# silently (bash's own errexit trap leaves no trace beyond the EXIT trap
+# firing) — before the `if` below ever gets to read the output at all. Caught
+# 2026-09-07 (CI red, AMUX-134) because CI runners never have a stray cargo/
+# rustc process to accidentally mask it; this dev box does, most of the time,
+# which is exactly backwards from the host-dependence the comment above
+# already worried about. `|| true` makes "nothing found" the unremarkable
+# case it always was semantically, without changing what the `if` reads.
+#
 # The shipped detector consumes the output too, so it is unaffected either way.
-_real_builds="$( { pgrep -x rustc; pgrep -x cargo; } 2>/dev/null | tr -d '[:space:]')"
+_real_builds="$( { pgrep -x rustc; pgrep -x cargo; } 2>/dev/null | tr -d '[:space:]' || true )"
 if [ -n "$_real_builds" ]; then
   echo "SKIP (m): a real cargo/rustc is running on this host, so the no-peer"
   echo "         precondition cannot be established. Not counted as a pass."


### PR DESCRIPTION
Fixes the CI-red on `main` (`checks`, 2 consecutive failures starting 2026-09-07 18:44 UTC, step 'SessionStart freshness + deployment and watchdog recovery').

**Symptom:** the step failed with **zero output** — no FAIL line, no summary, just `Process completed with exit code 1` right after `test-build-provenance.sh`'s own summary line. That silence was the tell: the failing script died before reaching any of its own `echo` statements.

**Root cause**, reproduced deterministically both in isolation and repeatedly against a fresh `--depth 1` clone of the affected commit:

```bash
_real_builds="$( { pgrep -x rustc; pgrep -x cargo; } 2>/dev/null | tr -d '[:space:]')"
```

This exact line's own comment already documents *"measured on an idle host it exits 1"* and says the fix is to *"READ THE OUTPUT, NOT THE EXIT CODE"* — true of the `if` that follows it, but not of this assignment itself. Under the script's own `set -euo pipefail`, a bare assignment statement's exit status IS the pipeline's (pipefail'd) status — here, `pgrep -x cargo`'s `1` (no such process — the ordinary case on any host with no build in flight right now) survives through `tr` under `pipefail`, even though `tr` itself exits 0. An assignment ending nonzero, outside any `if`/`&&`/`||`/`while`, is exactly what `-e` kills the whole script for — silently, straight to the `EXIT` trap, before the "read the output" logic is ever reached.

A GitHub Actions runner has no stray `cargo`/`rustc` process to accidentally mask this. This dev box usually does (continuous local builds per this repo's own dogfooding setup), which is why the same test stayed green here almost every time I ran it locally — backwards from the exact host-dependence this file's own comment already worried about for a different reason.

**Fix:** `|| true` on the assignment. Preserves the existing "read the captured output, not $?" design untouched — the `if [ -n "$_real_builds" ]` below doesn't change — it only stops a normal empty result from being treated as a script-ending error.

**Verified:** `bash -n` clean; 10 consecutive runs post-fix all exit 0 (pre-fix, reliably exit 1 with zero output, reproduced against a fresh clone specifically to rule out any of my own session's local build activity as the actual variable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)