### PR TITLE
feat(board): derived display status and Smart Board view

### DIFF
--- a/crates/amux-dashboard/static/app.js
+++ b/crates/amux-dashboard/static/app.js
@@ -9298,7 +9298,7 @@ async function saveGlobalMemory() {
   }
 }
 
-const APP_VER = '0.9.850';   // bump together with the sw.js CACHE version
+const APP_VER = '0.9.851';   // bump together with the sw.js CACHE version
 // Warm the shared catalog so model-type filters are exact on first use. A
 // failure is non-fatal (custom ids and the open-string fallback still work)
 // and is already reported by _loadModelCatalog.
@@ -22247,6 +22247,9 @@ let _boardDragId = null;
 let boardViewMode = localStorage.getItem('amux_board_view') || 'status';
 if (boardViewMode === 'session') boardViewMode = 'worker';
 let boardOwnerFilter = localStorage.getItem('amux_board_owner') || 'human';
+// Smart Board: derived display-status data, fetched from /api/board/derived.
+let _smartBoardData = null;
+let _smartBoardFetching = false;
 let _sessionGroupCollapsed = JSON.parse(localStorage.getItem('amux_board_collapsed') || '{}');
 let _boardWorkerDensityBeaconSent = false;
 let _tagGroupCollapsed = JSON.parse(localStorage.getItem('amux_status_collapsed') || '{}');
@@ -22304,6 +22307,38 @@ const _CUSTOM_STATUS_PALETTE_LIGHT = [
   {bg:'rgba(5,80,174,0.1)',color:'#0550ae',border:'rgba(5,80,174,0.3)',dot:'#0550ae'},
   {bg:'rgba(180,30,120,0.1)',color:'#99286e',border:'rgba(180,30,120,0.3)',dot:'#99286e'},
 ];
+// Derived display-status styles (Smart Board view). These augment the
+// built-in statuses for the computed categories the /api/board/derived
+// endpoint produces.
+const _DERIVED_STATUS_STYLE = {
+  'aged-needsyou':      {bg:'rgba(248,81,73,0.18)',color:'var(--red)',border:'rgba(248,81,73,0.5)',dot:'var(--red)'},
+  'stalled':            {bg:'rgba(210,153,34,0.22)',color:'var(--yellow)',border:'rgba(210,153,34,0.55)',dot:'var(--yellow)'},
+  'stale':              {bg:'rgba(139,148,158,0.15)',color:'rgba(139,148,158,0.7)',border:'rgba(139,148,158,0.35)',dot:'rgba(139,148,158,0.5)'},
+  'verified-candidate': {bg:'rgba(45,212,191,0.12)',color:'#2dd4bf',border:'rgba(45,212,191,0.35)',dot:'#2dd4bf'},
+  'unblocked':          {bg:'rgba(88,166,255,0.18)',color:'var(--accent)',border:'rgba(88,166,255,0.45)',dot:'var(--accent)'},
+};
+const _DERIVED_STATUS_STYLE_LIGHT = {
+  'aged-needsyou':      {bg:'rgba(207,34,46,0.12)',color:'#cf222e',border:'rgba(207,34,46,0.4)',dot:'#cf222e'},
+  'stalled':            {bg:'rgba(154,103,0,0.15)',color:'#7d4e00',border:'rgba(154,103,0,0.4)',dot:'#7d4e00'},
+  'stale':              {bg:'rgba(101,109,118,0.12)',color:'#57606a',border:'rgba(101,109,118,0.3)',dot:'#57606a'},
+  'verified-candidate': {bg:'rgba(13,148,136,0.12)',color:'#0d9488',border:'rgba(13,148,136,0.35)',dot:'#0d9488'},
+  'unblocked':          {bg:'rgba(9,105,218,0.12)',color:'#0550ae',border:'rgba(9,105,218,0.35)',dot:'#0550ae'},
+};
+const _DERIVED_STATUS_LABELS = {
+  'aged-needsyou': 'Aged Needs-You (>14d)',
+  'stalled': 'Stalled (session idle)',
+  'stale': 'Stale (auto, no activity >72h)',
+  'verified-candidate': 'Verified Candidate (has evidence)',
+  'unblocked': 'Unblocked (deps resolved)',
+};
+
+function derivedStatusStyle(id) {
+  const light = document.body.classList.contains('light');
+  const derived = light ? _DERIVED_STATUS_STYLE_LIGHT[id] : _DERIVED_STATUS_STYLE[id];
+  if (derived) return derived;
+  return statusStyle(id);
+}
+
 function statusStyle(id) {
   const light = document.body.classList.contains('light');
   const builtIn = light ? _BUILT_IN_STATUS_STYLE_LIGHT[id] : _BUILT_IN_STATUS_STYLE[id];
@@ -26420,7 +26455,85 @@ let _prevCardRects = {};
 function setBoardView(mode) {
   boardViewMode = mode;
   localStorage.setItem('amux_board_view', mode);
+  if (mode === 'smart') _smartBoardData = null;
   renderBoard();
+}
+
+async function _fetchSmartBoard() {
+  try {
+    const resp = await fetch('/api/board/derived');
+    if (!resp.ok) throw new Error('derived endpoint returned ' + resp.status);
+    const data = await resp.json();
+    _smartBoardData = data;
+  } catch (e) {
+    console.error('Smart board fetch failed:', e);
+    _smartBoardData = null;
+  }
+}
+
+function _renderSmartBoard(container, visibleStored) {
+  if (!_smartBoardData || !_smartBoardData.items) {
+    container.innerHTML = '<div style="color:var(--dim);font-size:0.85rem;padding:24px;text-align:center;">No derived data available.</div>';
+    return;
+  }
+  const visibleIds = new Set(visibleStored.map(i => i.id));
+  const items = _smartBoardData.items.filter(i => visibleIds.has(i.id));
+
+  // Derived status groups in priority display order: attention-needing first
+  const derivedOrder = [
+    'aged-needsyou', 'stalled', 'stale', 'unblocked', 'verified-candidate',
+    'doing', 'review', 'needsyou', 'todo', 'backlog', 'done', 'verified', 'discarded'
+  ];
+  const groups = {};
+  items.forEach(i => {
+    const ds = i.display_status || i.status || 'todo';
+    (groups[ds] = groups[ds] || []).push(i);
+  });
+
+  let html = '';
+  // Show derived-only statuses with a highlight header
+  const derivedSpecial = new Set(['aged-needsyou', 'stalled', 'stale', 'verified-candidate', 'unblocked']);
+  derivedOrder.concat(Object.keys(groups).filter(k => !derivedOrder.includes(k))).forEach(ds => {
+    const g = groups[ds];
+    if (!g || !g.length) return;
+    const isSpecial = derivedSpecial.has(ds);
+    const sty = derivedStatusStyle(ds);
+    const label = _DERIVED_STATUS_LABELS[ds] || ds;
+    const headStyle = isSpecial
+      ? 'display:flex;align-items:center;gap:8px;padding:10px 6px 4px;font-size:0.76rem;font-weight:700;color:' + sty.color + ';text-transform:uppercase;letter-spacing:0.05em;border-left:3px solid ' + sty.dot + ';padding-left:10px;margin-top:6px;'
+      : 'display:flex;align-items:center;gap:8px;padding:10px 6px 4px;font-size:0.74rem;font-weight:600;color:' + sty.color + ';text-transform:uppercase;letter-spacing:0.05em;';
+    html += '<div class="board-list-group-head" style="' + headStyle + '">'
+      + '<span class="board-status-dot" style="background:' + sty.dot + '"></span>' + esc(label)
+      + '<span style="color:var(--dim);font-weight:400;">' + g.length + '</span></div>';
+    html += g.map(i => {
+      let row = _issueRowHTML(i, { showOwner: true });
+      if (isSpecial && i.display_status !== i.status) {
+        const badge = '<span style="font-size:0.65rem;padding:1px 5px;border-radius:3px;background:' + sty.bg + ';color:' + sty.color + ';border:1px solid ' + sty.border + ';margin-left:6px;vertical-align:middle;font-weight:600;">' + esc(i.display_status) + '</span>';
+        row = row.replace('</div>', badge + '</div>');
+      }
+      return row;
+    }).join('');
+  });
+  container.dataset.component = 'board-smart';
+  container.innerHTML = html || '<div style="color:var(--dim);font-size:0.85rem;padding:24px;text-align:center;">Nothing to show.</div>';
+}
+
+function _smartBoardStatsHTML() {
+  if (!_smartBoardData || !_smartBoardData.counts) return '';
+  const c = _smartBoardData.counts;
+  const special = ['aged-needsyou', 'stalled', 'stale', 'verified-candidate', 'unblocked'];
+  let pills = '';
+  for (const key of special) {
+    const n = c[key] || 0;
+    if (n === 0) continue;
+    const sty = derivedStatusStyle(key);
+    const label = _DERIVED_STATUS_LABELS[key] || key;
+    pills += '<span style="display:inline-flex;align-items:center;gap:4px;padding:3px 8px;border-radius:4px;background:' + sty.bg + ';color:' + sty.color + ';border:1px solid ' + sty.border + ';font-size:0.72rem;font-weight:600;">'
+      + '<span class="board-status-dot" style="background:' + sty.dot + ';width:6px;height:6px;"></span>'
+      + esc(label) + ' <b>' + n + '</b></span>';
+  }
+  if (!pills) return '<div style="padding:6px 8px;font-size:0.75rem;color:var(--dim);">All cards are in their expected status.</div>';
+  return '<div style="display:flex;flex-wrap:wrap;gap:6px;padding:8px 8px 4px;">' + pills + '</div>';
 }
 
 function setBoardOwner(type) {
@@ -27100,9 +27213,11 @@ function renderBoard() {
   var bvS = document.getElementById('bv-session');
   var bvC = document.getElementById('bv-status');
   var bvL = document.getElementById('bv-list');
+  var bvSm = document.getElementById('bv-smart');
   if (bvS) bvS.classList.toggle('active', boardViewMode === 'worker');
   if (bvC) bvC.classList.toggle('active', boardViewMode === 'status');
   if (bvL) bvL.classList.toggle('active', boardViewMode === 'list');
+  if (bvSm) bvSm.classList.toggle('active', boardViewMode === 'smart');
   var boH = document.getElementById('bo-human');
   var boA = document.getElementById('bo-agent');
   if (boH) boH.classList.toggle('active', boardOwnerFilter === 'human');
@@ -27156,6 +27271,26 @@ function renderBoard() {
     container.innerHTML = html || '<div style="color:var(--dim);font-size:0.85rem;padding:24px;text-align:center;">Nothing matches.</div>';
     return;
   }
+
+  if (boardViewMode === 'smart') {
+    container.classList.remove('board-columns');
+    container.classList.add('board-list-mode');
+    if (!_smartBoardData && !_smartBoardFetching) {
+      _smartBoardFetching = true;
+      container.innerHTML = '<div style="color:var(--dim);font-size:0.85rem;padding:24px;text-align:center;">Loading derived statuses...</div>';
+      _fetchSmartBoard().then(() => { _smartBoardFetching = false; renderBoard(); }).catch(() => { _smartBoardFetching = false; });
+      return;
+    }
+    if (!_smartBoardData) {
+      container.innerHTML = '<div style="color:var(--dim);font-size:0.85rem;padding:24px;text-align:center;">Loading derived statuses...</div>';
+      return;
+    }
+    _renderSmartBoard(container, visible);
+    const _sElSm = document.getElementById('board-stats-mount');
+    if (_sElSm) _sElSm.innerHTML = _smartBoardStatsHTML();
+    return;
+  }
+
   // Mount the progress strip above the columns, over the SAME `visible` set the
   // columns are about to render (AMUX-2506). Fed from `visible` and not from
   // boardItems so it can never describe a different population than the board.

--- a/crates/amux-dashboard/static/index.html
+++ b/crates/amux-dashboard/static/index.html
@@ -620,6 +620,7 @@ setTimeout(function(){var f=document.getElementById('js-fallback');if(f&&f.style
       <button id="bv-list" class="bv-btn" onclick="setBoardView('list')" title="Dense list grouped by status">&#x2630;</button>
         <button id="bv-session" class="bv-btn" onclick="setBoardView('worker')" title="Group by worker">&#x25A4;</button>
       <button id="bv-status" class="bv-btn" onclick="setBoardView('status')" title="Group by status">&#x2630;</button>
+      <button id="bv-smart" class="bv-btn" onclick="setBoardView('smart')" title="Smart board: derived status from durable facts">&#x2728;</button>
     </div>
     <!-- Export the CURRENT view. Reuses .board-view-toggle so it inherits the
          group styling and the 44px mobile touch targets already tuned for it,

--- a/crates/amux-dashboard/static/sw.js
+++ b/crates/amux-dashboard/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'amux-v0.9.850';
+const CACHE = 'amux-v0.9.851';
 const SHELL_URLS = ['/', '/manifest.json', '/icon.svg', '/icon.png', '/icon-192.png', '/icon-512.png'];
 
 // Install: pre-cache entire app shell

--- a/crates/amux-server/src/api/board.rs
+++ b/crates/amux-server/src/api/board.rs
@@ -54,6 +54,10 @@ pub fn routes() -> Router<AppState> {
             get(list_session_gates).patch(patch_session_gates),
         )
         .route("/contract", get(get_contract))
+        // Static /derived outranks /{id}. Computed display status from durable
+        // facts, never stored (AO architecture: display status is derived at
+        // read time).
+        .route("/derived", get(derived_board))
         // Static /ready outranks /{id}. The read side of the dependency graph
         // (AMUX-3948) — READY is a query, never a stored status.
         .route("/ready", get(ready_frontier))
@@ -329,6 +333,143 @@ pub const QUEUE_DISPOSITION_CREATOR: &str = "queue-disposition";
 
 /// How many needsyou cards the owner view shows before hiding the rest.
 const NEEDSYOU_VIEW_CAP: usize = 10;
+
+// ---- GET /api/board/derived -----------------------------------------------
+
+/// Derived display status from durable facts.
+///
+/// The stored `status` is the lifecycle position a worker set. The `display_status`
+/// is what a human triaging the board should see, computed from timestamps, session
+/// liveness, evidence, and dependency state. This endpoint returns the board with
+/// both, so the dashboard can group by either.
+///
+/// Rules (in priority order; first match wins):
+///   1. status=needsyou AND entered_state_at older than 14 days: "aged-needsyou"
+///   2. status=doing AND assigned session is not active for >1h: "stalled"
+///   3. source=capture AND status=todo AND age > 72h AND no log activity: "stale"
+///   4. status=done AND evidence IS NOT NULL: "verified-candidate"
+///   5. depends_on non-empty AND all resolved: "unblocked"
+///   6. otherwise: the stored status itself
+async fn derived_board(State(state): State<AppState>) -> Response {
+    let store = state.store.clone();
+    let joined = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+        let conn = store.read()?;
+        let rows =
+            bs::list_issues(&conn, &[], &[], ArchivedFilter::ActiveOnly)?;
+        let working =
+            crate::api::sessions_legacy::active_python_sessions(&conn);
+        let now = now_secs();
+
+        let mut items: Vec<Value> = Vec::with_capacity(rows.len());
+        let mut counts: std::collections::BTreeMap<String, usize> =
+            std::collections::BTreeMap::new();
+
+        for r in &rows {
+            let display = derive_display_status(r, now, &working, &conn);
+            *counts.entry(display.clone()).or_default() += 1;
+            let mut v = list_body(r, true, is_stale(r, now, &working));
+            if let Some(obj) = v.as_object_mut() {
+                obj.insert("display_status".into(), json!(display));
+            }
+            items.push(v);
+        }
+
+        Ok((items, counts))
+    })
+    .await;
+    let (items, counts) = match joined {
+        Ok(Ok(v)) => v,
+        Ok(Err(e)) => return internal(e),
+        Err(e) => return internal(e),
+    };
+    Json(crate::api::measured::measured(
+        json!({
+            "items": items,
+            "counts": counts,
+            "total": items.len(),
+            "note": "display_status is computed from durable facts, never stored. \
+                     Rules: aged-needsyou (>14d), stalled (doing + session idle >1h), \
+                     stale (auto-captured todo >72h, no log), verified-candidate \
+                     (done + evidence), unblocked (all deps resolved). Otherwise \
+                     the stored status.",
+        }),
+        items.len(),
+    ))
+    .into_response()
+}
+
+fn derive_display_status(
+    row: &IssueRow,
+    now: i64,
+    working: &std::collections::BTreeSet<String>,
+    conn: &Connection,
+) -> String {
+    let status = row.status.as_str();
+    let age_secs = now - row.created;
+
+    // 1. Aged needsyou: status=needsyou and sitting longer than 14 days.
+    if status == "needsyou" {
+        let in_state_secs = row
+            .entered_state_at
+            .map(|t| now - t)
+            .unwrap_or(age_secs);
+        if in_state_secs > 14 * 86_400 {
+            return "aged-needsyou".into();
+        }
+    }
+
+    // 2. Stalled: status=doing but the assigned session is not active.
+    if status == "doing" {
+        if let Some(sess) = row.session.as_deref().filter(|s| !s.is_empty()) {
+            let idle_secs = now - row.updated;
+            if idle_secs > 3600 && !working.contains(sess) {
+                return "stalled".into();
+            }
+        }
+    }
+
+    // 3. Stale autofix/capture: auto-captured todo older than 72h with no log.
+    if status == "todo" {
+        let is_auto = row
+            .source
+            .as_deref()
+            .is_some_and(|s| s == "capture" || s == "autofix");
+        let no_activity = row
+            .log
+            .as_deref()
+            .map(|l| l.trim().is_empty())
+            .unwrap_or(true);
+        if is_auto && age_secs > 72 * 3600 && no_activity {
+            return "stale".into();
+        }
+    }
+
+    // 4. Verified candidate: done with evidence recorded.
+    if status == "done" && row.evidence.is_some() {
+        return "verified-candidate".into();
+    }
+
+    // 5. Unblocked: has dependencies and all are resolved (done/verified/discarded).
+    if !row.depends_on.is_empty() && matches!(status, "todo" | "backlog" | "doing") {
+        let all_resolved = row.depends_on.iter().all(|dep_id| {
+            bs::get_issue(conn, dep_id)
+                .ok()
+                .flatten()
+                .is_some_and(|dep| {
+                    matches!(
+                        dep.status.as_str(),
+                        "done" | "verified" | "discarded"
+                    )
+                })
+        });
+        if all_resolved {
+            return "unblocked".into();
+        }
+    }
+
+    // 6. Passthrough: the stored status.
+    status.to_string()
+}
 
 /// Why a candidate is NOT on the ready frontier, or `None` if it is ready.
 ///


### PR DESCRIPTION
## Summary

- Adds `GET /api/board/derived` endpoint that computes `display_status` from durable card facts (timestamps, session liveness, evidence, dependencies), never storing the result
- Derivation rules: `aged-needsyou` (>14d in needsyou), `stalled` (doing + session idle >1h), `stale` (auto-captured todo >72h with no log activity), `verified-candidate` (done + evidence present), `unblocked` (all deps resolved)
- Adds "Smart Board" view toggle in the dashboard (sparkle icon) that groups cards by derived status with highlighted attention-needing sections
- Additive only: does not modify existing `/api/board` endpoint or existing view modes

## Test plan

- [ ] Cargo check + clippy pass with zero warnings (verified)
- [ ] JS syntax check passes (verified)
- [ ] Deploy and verify `/api/board/derived` returns cards with `display_status` field and `counts` summary
- [ ] Open dashboard, click Smart Board toggle, verify cards group by derived status
- [ ] Verify derived-only categories (aged-needsyou, stalled, stale) show highlighted headers with left border
- [ ] Verify passthrough statuses (doing, todo, etc.) still render normally
- [ ] Verify toggling back to Status/List/Worker views works without regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)