### PR TITLE
feat(sessions): add blocked activity state for permission dialogs

### DIFF
--- a/crates/amux-dashboard/static/app.css
+++ b/crates/amux-dashboard/static/app.css
@@ -2522,6 +2522,7 @@
     letter-spacing: 0.3px;
   }
   .status-badge.active { background: rgba(63,185,80,0.2); color: var(--green); }
+  .status-badge.blocked { background: rgba(227,134,37,0.22); color: #e38625; }
   .status-badge.waiting { background: rgba(210,153,34,0.2); color: var(--yellow); }
   .status-badge.idle { background: rgba(139,148,158,0.15); color: var(--dim); }
   .status-badge.steering { background: rgba(137,87,229,0.2); color: var(--purple,#8957e5); }

--- a/crates/amux-dashboard/static/app.js
+++ b/crates/amux-dashboard/static/app.js
@@ -9304,7 +9304,7 @@ async function saveGlobalMemory() {
   }
 }
 
-const APP_VER = '0.9.851';   // bump together with the sw.js CACHE version
+const APP_VER = '0.9.852';   // bump together with the sw.js CACHE version
 // Warm the shared catalog so model-type filters are exact on first use. A
 // failure is non-fatal (custom ids and the open-string fallback still work)
 // and is already reported by _loadModelCatalog.

--- a/crates/amux-dashboard/static/app.js
+++ b/crates/amux-dashboard/static/app.js
@@ -612,13 +612,14 @@ let _logSearchTimer = null;
 let _logSearchAbort = null;
 // Filters modal facets (session list). Multi-select within a facet.
 let filterProviders = new Set();   // 'claude' | 'codex' | 'gemini' | 'iterm2'
-let filterStatuses = new Set();    // 'working' | 'waiting' | 'idle' | 'stopped'
+let filterStatuses = new Set();    // 'working' | 'blocked' | 'waiting' | 'idle' | 'stopped'
 // Stable status key for filtering: card WORKING = 'active' internally.
 function _sessStatusKey(s) {
   if (!s.running) return 'stopped';
   if (s.status === 'rate_limited') return 'rate_limited';
   if (s.status === 'api_error') return 'api_error';
   if (s.status === 'unattributed') return 'waiting';
+  if (s.status === 'blocked') return 'blocked';
   if (s.status === 'active') return 'working';
   if (s.status === 'waiting') return 'waiting';
   return 'idle';
@@ -2939,7 +2940,10 @@ function _checkSessionTransitions(newData) {
     const statusChanged = s.status !== prev.status;
     const stoppedNow = prev.running && !s.running;
     if (statusChanged) {
-      if (s.status === 'waiting') {
+      if (s.status === 'blocked') {
+        _fireSessionNotif(s.name, s.name + ' blocked on permission', s.task_name || 'Waiting on a permission dialog');
+        amuxTrack('session_blocked', { session: s.name, task: s.task_name || '' });
+      } else if (s.status === 'waiting') {
         _fireSessionNotif(s.name, s.name + ' needs input', s.task_name || 'Waiting for a response');
         amuxTrack('session_waiting', { session: s.name, task: s.task_name || '', auto_continue: !!s.auto_continue });
       } else if (s.status === 'active' && prev.status !== 'active') {
@@ -3275,6 +3279,7 @@ function updatePeekStatus() {
     : '<span class="status-badge active">working</span>' + _agentsChip(s)
       + (runtimeBoard.cardless ? _runtimeBoardCardlessBadge() : '');
   else if (s.status === 'unattributed') badge = _runtimeBoardSplitBadge(s);
+  else if (s.status === 'blocked') badge = '<span class="status-badge blocked" title="Agent is waiting on a permission decision. Do not send automated messages.">blocked</span>';
   else if (s.status === 'waiting') badge = '<span class="status-badge waiting"' + _waitingTitle(s) + '>' + _waitingLabel(s) + '</span>';
   else if (s.status === 'rate_limited') badge = '<span class="status-badge rate-limited">rate limited</span>';
   else if (s.status === 'api_error') badge = `<span class="status-badge rate-limited" title="API Error ${esc(s.api_error_code || '5xx')} — server-side and retryable. Send &quot;continue&quot;.">API ${esc(s.api_error_code || '5xx')}</span>`;
@@ -3921,6 +3926,7 @@ ${/* A lane at a limit banner is not WORKING, and a working lane is not
               rate_limited_until is set it is the true state and it supersedes
               the status badge outright (AMUX-2566). */ ''}          ${s.rate_limited_until ? '' : `${s.status === 'rate_limited' ? '<span class="status-badge rate-limited" title="Hit a usage limit (on credits or waiting for reset)">rate limited</span>' : ''}${s.status === 'active' ? (runtimeBoard.syncing ? _runtimeBoardSyncBadge() : '<span class="status-badge active">working</span>' + _agentsChip(s) + (runtimeBoard.cardless ? _runtimeBoardCardlessBadge() : '')) : ''}
           ${s.status === 'unattributed' ? _runtimeBoardSplitBadge(s) : ''}
+          ${s.status === 'blocked' ? '<span class="status-badge blocked" title="Agent is waiting on a permission decision. Do not send automated messages.">blocked</span>' : ''}
           ${s.status === 'waiting' ? `<span class="status-badge waiting"${_waitingTitle(s)}>${_waitingLabel(s)}</span>${_stalledFor(s)}` : ''}
           ${s.status === 'idle' ? '<span class="status-badge idle">idle</span>' : ''}`}
           ${s.rate_limited_until ? `<span class="status-badge rate-limited" title="${s.rate_limit_weekly ? 'Weekly limit' : 'Rate-limited'} — auto-resume at ${_fmtResetTime(s.rate_limited_until)}">${s.rate_limit_weekly ? 'Weekly limit until' : 'Rate-limited until'} ${_fmtResetTime(s.rate_limited_until)}</span>` : ''}
@@ -16184,13 +16190,13 @@ function closeFiltersModal() {
 const _PROVIDER_LABELS = { claude: 'Claude', codex: 'Codex', gemini: 'Gemini', iterm2: 'iTerm2' };
 const _MODEL_LABELS = { opus: 'Opus', sonnet: 'Sonnet', haiku: 'Haiku', fable: 'Fable', gpt: 'GPT', gemini: 'Gemini', 'o-series': 'o-series' };
 function _mLabel(x){ return _MODEL_LABELS[x] || (x.charAt(0).toUpperCase()+x.slice(1)); }
-const _STATUS_LABELS = { working: 'Working', waiting: 'Needs input', rate_limited: 'Rate limited', api_error: 'API error', idle: 'Idle', stopped: 'Stopped' };
+const _STATUS_LABELS = { working: 'Working', blocked: 'Blocked', waiting: 'Needs input', rate_limited: 'Rate limited', api_error: 'API error', idle: 'Idle', stopped: 'Stopped' };
 function renderFilterOptions() {
   const live = sessions.filter(s => !s.archived);
   // Status chips — fixed order, only states that exist (or are selected)
   const sEl = document.getElementById('filter-statuses');
   if (sEl) {
-    const opts = ['working', 'waiting', 'rate_limited', 'api_error', 'idle', 'stopped']
+    const opts = ['working', 'blocked', 'waiting', 'rate_limited', 'api_error', 'idle', 'stopped']
       .filter(k => filterStatuses.has(k) || live.some(x => _sessStatusKey(x) === k));
     sEl.innerHTML = opts.length ? opts.map(k => {
       const on = filterStatuses.has(k);

--- a/crates/amux-dashboard/static/sw.js
+++ b/crates/amux-dashboard/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'amux-v0.9.851';
+const CACHE = 'amux-v0.9.852';
 const SHELL_URLS = ['/', '/manifest.json', '/icon.svg', '/icon.png', '/icon-192.png', '/icon-512.png'];
 
 // Install: pre-cache entire app shell

--- a/crates/amux-server/src/api/request_log.rs
+++ b/crates/amux-server/src/api/request_log.rs
@@ -1472,7 +1472,9 @@ pub const ROUTE_TABLE: &[RouteEntry] = &[
     // completeness test learned to follow .nest() (AMUX-2917); it previously
     // scanned only api/mod.rs's own .route() calls.
     RouteEntry { path: "/api/board/contract", methods: &["GET"] },
+    RouteEntry { path: "/api/board/derived", methods: &["GET"] },
     RouteEntry { path: "/api/board/ready", methods: &["GET"] },
+    RouteEntry { path: "/api/board/changes", methods: &["GET"] },
     RouteEntry { path: "/api/board/bulk-migrate", methods: &["POST"] },
     RouteEntry { path: "/api/board/{id}/decompose", methods: &["POST"] },
     RouteEntry { path: "/api/board/needsyou", methods: &["GET"] },

--- a/crates/amux-server/src/api/session_verbs.rs
+++ b/crates/amux-server/src/api/session_verbs.rs
@@ -6796,6 +6796,15 @@ pub(crate) async fn deliver_automated(
     if parse_env(name).get("CC_ARCHIVED") == Some("1") {
         return refuse(format!("target '{name}' is archived — not delivered, not woken"));
     }
+    // A blocked session is on a permission/approval dialog. Delivering input
+    // could accidentally answer that dialog. The message stays queued (via the
+    // steering hold below) and delivers when the block clears.
+    if lane_is_blocked(state, name) {
+        return refuse(format!(
+            "target '{name}' is blocked on a permission dialog — not delivered. \
+             Answer the dialog in the terminal; queued messages deliver when it clears."
+        ));
+    }
     // A stopped (but not archived) lane is `send_text`'s auto-wake path, exactly
     // as under Python. It must NOT be queued: `steer_deliver_loop` skips lanes
     // that are not running and leaves the row pending, so a queued command for a
@@ -11065,6 +11074,13 @@ pub(crate) fn reason_is_reapable(reason: &str) -> bool {
 /// minutes ago that has never been seen is strictly worse than one that arrives
 /// a turn early.
 pub(crate) fn steer_decide(reported: Option<&str>, pane_idle: Option<bool>, age_s: f64, max_age_s: f64) -> SteerDelivery {
+    // A blocked session is on a permission/approval dialog. Sending input
+    // could accidentally answer the dialog, so delivery is held unconditionally
+    // with no overdue escape. The agent must clear the block (by reporting idle
+    // or active) before any queued message is delivered.
+    if reported == Some("blocked") {
+        return SteerDelivery::Hold;
+    }
     let idle = match reported {
         // The lane's own report wins (D1): the harness knows its boundaries.
         Some(st) => st == "idle",
@@ -11159,6 +11175,14 @@ pub(crate) fn lane_report(state: &AppState, name: &str) -> Option<LaneReport> {
         applies,
         subagents_live,
     })
+}
+
+/// Whether a lane's trusted self-report says it is blocked on a permission or
+/// approval dialog. Sending input to a blocked session could accidentally
+/// answer the dialog, so all automated delivery paths refuse.
+pub(crate) fn lane_is_blocked(state: &AppState, name: &str) -> bool {
+    lane_report(state, name)
+        .is_some_and(|r| r.applies && r.state == "blocked")
 }
 
 /// Exact provider-owned evidence that work continues behind an idle-looking
@@ -12544,6 +12568,10 @@ pub async fn steer_deliver_for_session(state: &AppState, session: &str) -> bool 
     }
     if !is_running(session).await {
         skip(session, "", "not-running");
+        return false;
+    }
+    if lane_is_blocked(state, session) {
+        skip(session, "", "blocked-on-permission-dialog");
         return false;
     }
     let mut id = String::new();
@@ -15494,6 +15522,22 @@ async fn send_post(state: &AppState, name: &str, headers: &HeaderMap, body: &Val
     // mediation, which is what "raw LLM pass through" excludes.
     let send_origin =
         if origin.is_empty() { SendOrigin::Owner } else { SendOrigin::Automation };
+    // A blocked session is on a permission/approval dialog. Automated sends
+    // could accidentally answer it, so peer/automation sends are refused.
+    // Owner sends (dashboard, human) pass through so the human can answer the
+    // dialog directly.
+    if matches!(send_origin, SendOrigin::Automation) && lane_is_blocked(state, name) {
+        return jresp(
+            StatusCode::CONFLICT,
+            json!({
+                "ok": false,
+                "error": format!("Session '{name}' is blocked on a permission dialog. \
+                    Use the terminal to answer it directly."),
+                "blocked": "permission_dialog",
+                "code": "session_blocked",
+            }),
+        );
+    }
     let (ok, msg) = send_text(state, name, &text, defer_busy, send_origin).await;
     let no_effect = ok && msg == "no suggestion found";
     if no_effect {
@@ -17610,14 +17654,13 @@ pub(crate) async fn report_post(state: &AppState, name: &str, headers: &HeaderMa
     let st = match st_raw.as_str() {
         "working" | "busy" => "active",
         "done" => "idle",
-        "blocked" => "waiting",
         other => other,
     }
     .to_string();
-    if !matches!(st.as_str(), "active" | "idle" | "waiting" | "error") {
+    if !matches!(st.as_str(), "active" | "idle" | "waiting" | "blocked" | "error") {
         return jresp(
             StatusCode::BAD_REQUEST,
-            json!({"error": format!("state must be one of active|idle|waiting|error (got '{st_raw}')")}),
+            json!({"error": format!("state must be one of active|idle|waiting|blocked|error (got '{st_raw}')")}),
         );
     }
     // A normal Stop report is the prompt terminal edge. Reconcile a provider
@@ -26870,6 +26913,22 @@ mod steer_max_age_tests {
         // path refuses a selector even when overdue — answering a pending tool
         // is the user's, not amux's.)
         assert_eq!(steer_decide(Some("waiting"), None, 10.0, MAX), SteerDelivery::Hold);
+    }
+
+    #[test]
+    fn a_blocked_session_is_never_delivered_to() {
+        // A blocked session is on a permission/approval dialog. Delivering
+        // input could accidentally answer it. The hold must survive past the
+        // max-age deadline: the overdue escape is for busy-but-safe lanes, and
+        // a dialog is neither.
+        assert_eq!(steer_decide(Some("blocked"), None, 0.0, MAX), SteerDelivery::Hold);
+        assert_eq!(steer_decide(Some("blocked"), None, MAX + 1.0, MAX), SteerDelivery::Hold);
+        assert_eq!(steer_decide(Some("blocked"), None, 86_400.0, MAX), SteerDelivery::Hold);
+        assert_eq!(
+            steer_decide(Some("blocked"), Some(true), MAX + 1.0, MAX),
+            SteerDelivery::Hold,
+            "pane saying idle must not override a blocked report"
+        );
     }
 
     #[test]

--- a/crates/amux-server/src/api/sessions_legacy.rs
+++ b/crates/amux-server/src/api/sessions_legacy.rs
@@ -137,9 +137,10 @@ pub fn report_applies(state: &str, ts: f64, started: f64, now: f64) -> bool {
     // flight paints. Silence past the heartbeat means the claim outlived its
     // evidence — a Stop hook that never fired, a crashed turn, an interrupt.
     let stale_active = state == "active" && age > env_secs("AMUX_ACTIVE_HEARTBEAT_S", 120.0);
-    // `idle` survives silence (an idle lane has nothing to report until its
-    // next prompt); every other state has a much shorter trust window.
-    let trust_window = if state == "idle" {
+    // `idle` and `blocked` survive silence (an idle lane has nothing to report
+    // until its next prompt; a blocked lane is parked on a dialog until a human
+    // answers it); every other state has a much shorter trust window.
+    let trust_window = if state == "idle" || state == "blocked" {
         env_secs("AMUX_HOOKS_LIVE_IDLE_S", 86400.0)
     } else {
         env_secs("AMUX_HOOKS_LIVE_S", 1800.0)
@@ -147,7 +148,7 @@ pub fn report_applies(state: &str, ts: f64, started: f64, now: f64) -> bool {
     from_this_life
         && !stale_active
         && age < trust_window
-        && matches!(state, "active" | "idle" | "waiting")
+        && matches!(state, "active" | "idle" | "waiting" | "blocked")
 }
 
 /// Pane captures abandoned on a deadline, and the lanes they were for.
@@ -1240,7 +1241,7 @@ impl FleetSignals {
                 let ts = rep["ts"].as_f64().unwrap_or(0.0);
                 let from_this_life = self.started.get(name).copied().unwrap_or(0.0) <= ts;
                 let live = self.now - ts < env_secs("AMUX_HOOKS_LIVE_S", 1800.0);
-                if from_this_life && live && (st == "active" || st == "waiting") {
+                if from_this_life && live && (st == "active" || st == "waiting" || st == "blocked") {
                     return true;
                 }
             }
@@ -4152,7 +4153,7 @@ pub(crate) fn build_array(conn: &rusqlite::Connection) -> rusqlite::Result<Vec<s
     // active/waiting before idle/blank, then most-recent human activity.
     let status_rank = |s: &str| -> i64 {
         match s {
-            "active" | "waiting" => 0,
+            "active" | "waiting" | "blocked" => 0,
             _ => 1,
         }
     };
@@ -5709,6 +5710,9 @@ CLAUDE-POSTFIX-COMPLETE
             ("idle", 40_000.0, true, "idle survives silence inside its 24h window"),
             ("idle", 90_000.0, false, "past the 24h idle window"),
             ("waiting", 60.0, true, "a fresh selector report"),
+            ("blocked", 50.0, true, "a fresh blocked report — permission dialog"),
+            ("blocked", 40_000.0, true, "blocked survives silence inside its 24h window"),
+            ("blocked", 90_000.0, false, "past the 24h blocked window"),
             ("compacting", 5.0, false, "a state no rule knows is not evidence"),
         ];
         for (st, age, want, why) in cells {

--- a/crates/amux-server/src/invariants/checks.rs
+++ b/crates/amux-server/src/invariants/checks.rs
@@ -673,6 +673,8 @@ pub const TIMESTAMP_COLUMNS: &[(&str, &str, bool)] = &[
     ("board_overlap_members", "created_at", false),
     ("board_overlap_members", "last_seen_at", false),
     ("board_overlap_refs", "created_at", false),
+    // SECONDS: DEFAULT (unixepoch('subsec')) in migration 0061.
+    ("board_change_log", "changed_at", false),
     ("cmd_history", "delivered_at", true),
     ("cmd_history", "queued_at", true),
     ("cmd_history", "ts", true),

--- a/e2e/tunnel-blackhole.spec.ts
+++ b/e2e/tunnel-blackhole.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 
 // A DEAD TUNNEL HANGS; IT DOES NOT REFUSE.
 //


### PR DESCRIPTION
## Summary

- Adds `blocked` as a first-class session activity state, distinguishing "agent stuck on a permission dialog" from "agent waiting for user input at an empty prompt"
- All automated delivery paths (steering queue, scheduler, peer sends) refuse to deliver to a blocked session, preventing accidental dialog answers
- Dashboard shows an amber "blocked" badge (distinct from the yellow "needs input"), with tooltip and filter support

## Changes

**Server (session_verbs.rs)**
- `report_post`: accepts `"blocked"` without mapping it to `"waiting"`
- `steer_decide`: returns `Hold` unconditionally for blocked sessions (no overdue escape)
- `lane_is_blocked()`: new helper reading the trusted self-report
- `deliver_automated`: refuses delivery to blocked sessions
- `send_post`: returns 409 for automated sends to blocked sessions
- `steer_deliver_for_session`: skips blocked sessions in reactive delivery
- New test: `a_blocked_session_is_never_delivered_to`

**Server (sessions_legacy.rs)**
- `report_applies`: trusts `"blocked"` with a 24h window (sticky, like idle)
- `agent_running`: recognizes blocked as evidence of a live agent
- Status rank sorts blocked alongside active/waiting
- New test cells for blocked in `report_applies` test

**Dashboard (app.js, app.css, sw.js)**
- Amber badge: `rgba(227,134,37,0.22)` bg, `#e38625` text
- Status filter with "Blocked" label
- Session notification: "blocked on permission"
- List and peek view badge rendering
- APP_VER + CACHE bump to 0.9.851

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes (pre-commit hook)
- [x] `node --check app.js` passes
- [x] New `steer_decide` test verifies Hold at all ages including past max-age
- [x] New `report_applies` test cells verify 24h trust window and expiry
- [ ] Manual: simulate a blocked session via `POST /api/sessions/{name}/report` with `state=blocked`, verify dashboard badge
- [ ] Manual: `curl -X POST` a send to a blocked session, verify 409 refusal

🤖 Generated with [Claude Code](https://claude.com/claude-code)