### PR TITLE
fix(board): dedup autofix cards, expire stale alerts, filter conversational acks

### DIFF
--- a/crates/amux-core/src/board.rs
+++ b/crates/amux-core/src/board.rs
@@ -1530,6 +1530,54 @@ fn is_non_mutating_answer_tail(tail: &str) -> bool {
     saw_clause
 }
 
+/// Short conversational acks that should not become board cards. These are
+/// inter-session coordination messages (acknowledgements, status phrases,
+/// corrections) that are not work items. The prompt still lands in
+/// `cmd_history`, so the Messages ledger keeps every prompt; it just does not
+/// mint a board card.
+///
+/// Deliberately conservative: only short messages (<50 chars) whose opening
+/// matches a known ack pattern are suppressed. Unknown shapes fail open to a
+/// card so the filter cannot silently lose work.
+pub fn is_conversational_ack(text: &str) -> bool {
+    let mut t = text.trim();
+    while t.starts_with('[') {
+        match t.find(']') {
+            Some(i) => t = t[i + 1..].trim_start(),
+            None => break,
+        }
+    }
+    let collapsed: String = t.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() >= 50 {
+        return false;
+    }
+    let lower = collapsed.to_lowercase();
+    const ACK_PREFIXES: &[&str] = &[
+        "continue",
+        "standing by",
+        "read,",
+        "read.",
+        "read ",
+        "all clear",
+        "correction to",
+        "thanks",
+        "thank you",
+        "acknowledged",
+        "ack,",
+        "ack.",
+        "ack ",
+        "noted",
+        "got it",
+        "roger",
+        "copy that",
+        "understood",
+        "will do",
+        "on it",
+        "sounds good",
+    ];
+    ACK_PREFIXES.iter().any(|p| lower.starts_with(p))
+}
+
 /// Bare demonstratives/pronouns: words whose referent lives OUTSIDE the title.
 const DEICTIC: [&str; 9] = ["this", "that", "these", "those", "it", "they", "them", "here", "there"];
 
@@ -2620,5 +2668,27 @@ mod self_description_tests {
 
         let t2 = title_from_prompt("please add a route for /api/board/clear-done").unwrap();
         assert_eq!(title_needs_self_description(&t2), None, "{t2:?}");
+    }
+
+    #[test]
+    fn conversational_acks_are_detected() {
+        assert!(is_conversational_ack("continue"));
+        assert!(is_conversational_ack("Continue working"));
+        assert!(is_conversational_ack("standing by"));
+        assert!(is_conversational_ack("read, will review"));
+        assert!(is_conversational_ack("all clear"));
+        assert!(is_conversational_ack("correction to the above"));
+        assert!(is_conversational_ack("thanks for the update"));
+        assert!(is_conversational_ack("acknowledged"));
+        assert!(is_conversational_ack("got it"));
+        assert!(is_conversational_ack("noted"));
+        assert!(is_conversational_ack("[15:42 PM] standing by"));
+    }
+
+    #[test]
+    fn real_work_is_not_an_ack() {
+        assert!(!is_conversational_ack("fix the auth middleware to handle expired tokens correctly and add a test"));
+        assert!(!is_conversational_ack("add a new endpoint for /api/board/clear-done"));
+        assert!(!is_conversational_ack("continue refactoring the entire session management layer to use the new connection pool and update all tests"));
     }
 }

--- a/crates/amux-server/src/api/session_verbs.rs
+++ b/crates/amux-server/src/api/session_verbs.rs
@@ -4144,6 +4144,13 @@ fn mint_capture_card(
     if session_name.trim().is_empty() {
         return Ok(None);
     }
+    if amux_core::board::is_conversational_ack(body) {
+        tracing::info!(
+            session = %session_name,
+            "ledger: conversational ack not carded (recorded in cmd_history only)"
+        );
+        return Ok(None);
+    }
     // A pure status / info query ("status on MSG-29602?", "any update on X?") is
     // answered inline and produces no deliverable, so it is NOT a board work card:
     // the old capture minted it type=code/doing, which a question can never take

--- a/crates/amux-server/src/runtime_jobs/autofix.rs
+++ b/crates/amux-server/src/runtime_jobs/autofix.rs
@@ -6066,6 +6066,19 @@ fn already_filed(conn: &Connection, signature: &str) -> bool {
 /// stops being a set of tasks and becomes a log, and a queue that cannot be read
 /// is one nobody reads, including for the cards that DO discriminate.
 fn fault_identity(signature: &str) -> Option<&str> {
+    // INVARIANT DEDUP: an invariant's identity is `invariant|<name>`, not the
+    // per-entity or per-episode variant. Measured 2026-09-09: 15,222 board
+    // cards, with invariant violations filing one card per entity per episode
+    // because this function returned None for them, so `open_card_for_fault`
+    // never suppressed. An invariant failing on three entities is one fault
+    // ("the invariant is broken"), not three cards.
+    if signature.starts_with("invariant|") {
+        // `invariant|<name>|<entity>|<epoch>` -- identity is `invariant|<name>`.
+        return signature
+            .get("invariant|".len()..)
+            .and_then(|rest| rest.find('|'))
+            .map(|i| &signature[..("invariant|".len() + i)]);
+    }
     if !(signature.starts_with("5xx|") || signature.starts_with("latency|outlier|")) {
         return None;
     }
@@ -7394,6 +7407,83 @@ async fn note_quiet_signatures(
 }
 
 // ---------------------------------------------------------------------------
+// Auto-expire stale autofix cards (transient operational alerts).
+// ---------------------------------------------------------------------------
+
+fn autofix_expire_hours() -> i64 {
+    std::env::var("AMUX_AUTOFIX_EXPIRE_HOURS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(72)
+}
+
+/// Discard autofix-created cards in todo/backlog that are older than the TTL.
+/// These are transient operational alerts; if the condition persists, the next
+/// autofix tick will re-file. Returns the number of cards expired.
+async fn expire_stale_autofix_cards(state: &AppState) -> anyhow::Result<usize> {
+    let ttl_h = autofix_expire_hours();
+    if ttl_h <= 0 {
+        return Ok(0);
+    }
+    let cutoff = crate::api::reclaim::now_secs() - (ttl_h * 3600);
+    let expired: Vec<(String, String)> = {
+        let conn = state.store.read()?;
+        let mut stmt = conn.prepare(
+            "SELECT id, title FROM issues \
+             WHERE creator = 'autofix' \
+               AND status IN ('todo', 'backlog') \
+               AND COALESCE(archived, 0) = 0 \
+               AND deleted IS NULL \
+               AND COALESCE(updated_at, created_at) < ?1",
+        )?;
+        let rows = stmt.query_map(rusqlite::params![cutoff], |r| {
+            Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+        })?;
+        rows.flatten().collect()
+    };
+    if expired.is_empty() {
+        return Ok(0);
+    }
+    let now = crate::api::reclaim::now_secs();
+    let count = expired.len();
+    let ids = expired.iter().map(|(id, _)| id.clone()).collect::<Vec<_>>();
+    state
+        .store
+        .write_async(move |conn| {
+            for id in &ids {
+                conn.execute(
+                    "UPDATE issues SET status = 'discarded', \
+                        updated_at = ?2, \
+                        log = COALESCE(log, '') || ?3 \
+                     WHERE id = ?1",
+                    rusqlite::params![
+                        id,
+                        now,
+                        format!(
+                            "\n[autofix-expire] discarded after {}h with no action",
+                            ttl_h
+                        )
+                    ],
+                )?;
+            }
+            Ok(crate::db::WriteOutcome {
+                applied: true,
+                events: vec![],
+            })
+        })
+        .await?;
+    for (id, title) in &expired {
+        tracing::info!(
+            card = %id,
+            title = %title,
+            ttl_hours = ttl_h,
+            "autofix_expire: discarded stale autofix card (no action within TTL)"
+        );
+    }
+    Ok(count)
+}
+
+// ---------------------------------------------------------------------------
 // Spawn + debug surface.
 // ---------------------------------------------------------------------------
 
@@ -7436,6 +7526,11 @@ pub fn spawn(state: AppState) -> Option<super::PeriodicTask> {
                     errors = ?r.errors,
                     "autofix tick"
                 );
+            }
+            match expire_stale_autofix_cards(&state).await {
+                Ok(n) if n > 0 => tracing::info!(expired = n, "autofix tick: expired stale cards"),
+                Err(e) => tracing::warn!(err = %e, "autofix tick: expire sweep failed"),
+                _ => {}
             }
         }
     }))
@@ -8728,12 +8823,21 @@ mod tests {
             "a rollup and a single-endpoint outlier are different faults"
         );
 
-        // CONTROL 3: only the two timestamped families have a fault identity at
-        // all. Stripping a trailing field from an arbitrary signature would
-        // merge unrelated faults.
+        // Invariant signatures dedup by invariant name: all violations of the
+        // same invariant (different entities, different episodes) are one fault.
         assert_eq!(
             fault_identity("invariant|hooks.guard|fleet|1787223065"),
-            None
+            Some("invariant|hooks.guard")
+        );
+        assert_eq!(
+            fault_identity("invariant|hooks.guard|fleet"),
+            Some("invariant|hooks.guard"),
+            "an invariant signature without an epoch still has a fault identity"
+        );
+        assert_eq!(
+            fault_identity("invariant|hooks.guard|fleet|1787223065"),
+            fault_identity("invariant|hooks.guard|other-entity|1787224000"),
+            "same invariant, different entity = same fault"
         );
         assert_eq!(
             fault_identity("5xx|502|POST|/api/x|/api/x|nota-number"),


### PR DESCRIPTION
## Summary

- **Invariant dedup**: Extend `fault_identity()` to handle `invariant|` signatures. Previously only `5xx|` and `latency|outlier|` had dedup via `open_card_for_fault`; invariant violations filed one card per entity per episode. Measured on the live board: `route.callers_have_routes` alone had 78 duplicate cards, `queue.has_live_consumer` had 33. Now all violations of the same invariant name collapse to a single open card.

- **72h TTL stale expiry**: Add `expire_stale_autofix_cards()`, a periodic sweep that runs each autofix tick and discards `creator=autofix` cards in `todo`/`backlog` older than 72 hours (`AMUX_AUTOFIX_EXPIRE_HOURS`). If the condition persists, the next tick re-files. Each expiry is logged with card ID, title, and TTL for auditability.

- **Conversational ack filtering**: Add `is_conversational_ack()` in `amux_core::board`. Short messages (<50 chars) starting with known ack patterns (continue, standing by, read, all clear, thanks, etc.) skip card creation in `mint_capture_card`. The prompt still lands in `cmd_history`.

## Test plan

- [x] `cargo check --workspace` passes (clean build with fresh target dir)
- [x] `fault_identity` tests updated and passing (invariant sigs now return identity)
- [x] `is_conversational_ack` unit tests passing (positive and negative cases)
- [x] `open_card_for_fault` integration test still passes
- [ ] After deploy, verify board growth rate slows (grep `autofix_expire:` and `autofix_mute:` in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)