### PR TITLE
fix(cli): board request --help now names what its --depends-on does NOT do (AMUX-140)

### DIFF
--- a/amux
+++ b/amux
@@ -2388,6 +2388,8 @@ Usage: amux board request <worker> <title>
 Creates a backlog card on the verified requester's own board and links the named
 worker as its reviewer. Workers cannot place new cards directly on another
 worker's board; use reviewer/shepherd and depends_on links for peer coordination.
+The requester is notified back on THIS card's own resolution — that path is
+separate from anything a --depends-on link does (see below).
 
 Optional:
   --desc <text> | --desc-stdin | --desc-file <path>
@@ -2395,7 +2397,10 @@ Optional:
   --depends-on <ISSUE-ID>                  repeatable cross-board task link. It
                                           blocks the claim until resolved and
                                           does not push by itself when cleared
-                                          (AF-621).
+                                          (AF-621) — not this card's own
+                                          requester notification above, which
+                                          fires on ITS resolution regardless
+                                          of whether any dependency exists.
   --due <YYYY-MM-DD>
   --help
 


### PR DESCRIPTION
Fixes the CI red on `main` (`checks`, 5 consecutive failures starting 2026-09-09 20:33 UTC, step 'CLI dispatch tests').

`scripts/test-depends-on-help.sh`'s `req-separates` check failed with a plain, deterministic content mismatch (not flaky): it asserts `board request --help` contains the literal substring "not this", and it didn't appear anywhere in `_board_request_usage()`'s text — confirmed the word "callback"/"notification" wasn't in that help block at all, so there was nothing for a "not this" to distinguish itself from.

The test's own header names the intent: `board request` arms a notification back to the requester on that card's own resolution, and a reader seeing `--depends-on`'s "does not push" note nearby could reasonably wonder whether that suppresses the SAME notification. It doesn't — two unrelated mechanisms — but the help text never said so, unlike `board add`'s already-fixed side of this exact symmetry (AF-621: add-blocks/add-nopush/add-remedy, still passing).

**Fix:** two lines, text-only, no behavior change — a sentence in the main body naming the requester notification, and a clause on `--depends-on` pointing back at it by name.

**Verified:** the full CLI-dispatch step sequence (`test-board-add-flags`, `test-amux-url`, `test-discard-folded-into-help`, `test-send-fallback-atomic`, `test-depends-on-help`) all green — 9/9 on the one this fixes (was 8/9). `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)